### PR TITLE
Added binaries required by kubebuilder test setup

### DIFF
--- a/.ci/test
+++ b/.ci/test
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -e
+set -ex
 
 # For the test step concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
@@ -48,6 +48,20 @@ export GO111MODULE=on
 
 # Install Ginkgo (test framework) to be able to execute the tests.
 go get -u github.com/onsi/ginkgo/ginkgo
+
+###############################################################################
+
+# Install Kubebuilder test dependencies
+OS=$(go env GOOS)
+ARCH=$(go env GOARCH)
+
+# download kubebuilder and extract it to tmp
+curl -sL https://go.kubebuilder.io/dl/2.2.0/${OS}/${ARCH} | tar -xz -C /tmp/
+
+# move to a long-term location and put it on your path
+# (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
+mv /tmp/kubebuilder_2.2.0_${OS}_${ARCH} /usr/local/kubebuilder
+export PATH=$PATH:/usr/local/kubebuilder/bin
 
 ###############################################################################
 


### PR DESCRIPTION
The tests need binaries such as etcd and apiserver to spring up an ad-hoc k8s cluster for tests. This PR amends the test script to install the required binaries installed as part of kubebuilder setup.