### PR TITLE
Enable TLS for backup-restore server

### DIFF
--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -132,6 +132,9 @@ spec:
         - --insecure-transport=false
         - --insecure-skip-tls-verify=false
         - --endpoints=https://{{ .Values.name }}-local:{{ .Values.etcd.clientPort }}
+        # enable TLS on backup-restore server reusing etcd cert bundle
+        - --server-cert=/var/etcd/ssl/server/tls.crt
+        - --server-key=/var/etcd/ssl/server/tls.key
 {{ else }}
         - --insecure-transport=true
         - --insecure-skip-tls-verify=true
@@ -238,6 +241,8 @@ spec:
 {{- if .Values.etcd.enableTLS }}
         - name: ca-etcd
           mountPath: /var/etcd/ssl/ca
+        - name: etcd-server-tls
+          mountPath: /var/etcd/ssl/server
         - name: etcd-client-tls
           mountPath: /var/etcd/ssl/client
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR enables TLS on backup-restore server, reusing etcd cert bundle.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Enable TLS on backup-restore server.
```
