### PR TITLE
Add additional printer columns for kubectl

### DIFF
--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -289,6 +289,8 @@ type EtcdStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
 
 // Etcd is the Schema for the etcds API

--- a/config/crd/bases/druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/druid.gardener.cloud_etcds.yaml
@@ -8,6 +8,13 @@ metadata:
   creationTimestamp: null
   name: etcds.druid.gardener.cloud
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.ready
+    name: Ready
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: druid.gardener.cloud
   names:
     kind: Etcd


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds additional columns for etcd information such as creation date and readiness status.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add additional printer columns for kubectl.
```
