### PR TITLE
Stop reconciliation of etcd resources on sts changes

### DIFF
--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -276,7 +276,7 @@ type EtcdStatus struct {
 	// +optional
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
 	// +optional
-	Ready bool `json:"ready,omitempty"`
+	Ready *bool `json:"ready,omitempty"`
 	// +optional
 	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
 	// selector is a label query over pods that should match the replica count.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -312,6 +312,11 @@ func (in *EtcdStatus) DeepCopyInto(out *EtcdStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Ready != nil {
+		in, out := &in.Ready, &out.Ready
+		*out = new(bool)
+		**out = **in
+	}
 	if in.LabelSelector != nil {
 		in, out := &in.LabelSelector, &out.LabelSelector
 		*out = new(metav1.LabelSelector)

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const timeout = time.Second * 5
+const timeout = time.Minute * 2
 
 var _ = Describe("Druid", func() {
 

--- a/vendor/github.com/gardener/gardener/pkg/utils/context/context.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/context/context.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"context"
+	"time"
+)
+
+type ops struct{}
+
+// WithTimeout returns the context with the given timeout and a CancelFunc to cleanup its resources.
+func (ops) WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, timeout)
+}
+
+// DefaultOps returns the default Ops implementation.
+func DefaultOps() Ops {
+	return ops{}
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/context/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/context/types.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"context"
+	"time"
+)
+
+// Ops are operations to do with a context. They mimic the functions from the context package.
+type Ops interface {
+	// WithTimeout returns a new context with the given timeout that can be canceled with the returned function.
+	WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/retry/alias.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/retry/alias.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+var (
+	// Until is an alias for `DefaultOps().Until`.
+	Until = DefaultOps().Until
+
+	// UntilTimeout is an alias for `DefaultOps().New`.
+	UntilTimeout = DefaultOps().UntilTimeout
+
+	// Interval is an alias for `DefaultIntervalFactory().New`.
+	Interval = DefaultIntervalFactory().New
+)

--- a/vendor/github.com/gardener/gardener/pkg/utils/retry/retry.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/retry/retry.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	utilcontext "github.com/gardener/gardener/pkg/utils/context"
+)
+
+type lastErrorAggregator struct {
+	lastError error
+}
+
+// Minor implements ErrorAggregator.
+func (l *lastErrorAggregator) Minor(err error) {
+	l.lastError = err
+}
+
+// Severe implements ErrorAggregator.
+func (l *lastErrorAggregator) Severe(err error) {
+	l.lastError = err
+}
+
+// Error implements ErrorAggregator.
+func (l *lastErrorAggregator) Error() error {
+	return l.lastError
+}
+
+// NewLastErrorAggregator returns an ErrorAggregator that only keeps the last error it recorded.
+func NewLastErrorAggregator() ErrorAggregator {
+	return &lastErrorAggregator{}
+}
+
+// New implements ErrorAggregatorFactory.
+func (f ErrorAggregatorFactoryFunc) New() ErrorAggregator {
+	return f()
+}
+
+// DefaultErrorAggregatorFactory returns the default ErrorAggregatorFactory.
+func DefaultErrorAggregatorFactory() ErrorAggregatorFactory {
+	return ErrorAggregatorFactoryFunc(NewLastErrorAggregator)
+}
+
+// New implements IntervalFactory.
+func (f IntervalFactoryFunc) New(interval time.Duration) WaitFunc {
+	return f(interval)
+}
+
+// NewIntervalFactory returns a new IntervalFactory using the given utilcontext.Ops.
+func NewIntervalFactory(contextOps utilcontext.Ops) IntervalFactory {
+	return IntervalFactoryFunc(func(interval time.Duration) WaitFunc {
+		return func(ctx context.Context) (context.Context, context.CancelFunc) {
+			return contextOps.WithTimeout(ctx, interval)
+		}
+	})
+}
+
+var defaultIntervalFactory = NewIntervalFactory(utilcontext.DefaultOps())
+
+// DefaultIntervalFactory returns the default IntervalFactory.
+func DefaultIntervalFactory() IntervalFactory {
+	return defaultIntervalFactory
+}
+
+// SevereError indicates an operation was not successful due to the given error and cannot be retried.
+func SevereError(severeErr error) (done bool, err error) {
+	return true, severeErr
+}
+
+// MinorError indicates an operation was not successful due to the given error but can be retried.
+func MinorError(minorErr error) (done bool, err error) {
+	return false, minorErr
+}
+
+// Ok indicates that an operation was successful and does not need to be retried.
+func Ok() (done bool, err error) {
+	return true, nil
+}
+
+// NotOk indicates that an operation was not successful but can be retried.
+// It does not indicate an error. For better error reporting, consider MinorError.
+func NotOk() (done bool, err error) {
+	return false, nil
+}
+
+type retryError struct {
+	ctxError error
+	err      error
+}
+
+// Cause implements Causer.
+func (r *retryError) Cause() error {
+	if r.err != nil {
+		return r.err
+	}
+	return r.ctxError
+}
+
+// Error implements error.
+func (r *retryError) Error() string {
+	if r.err != nil {
+		return fmt.Sprintf("retry failed with %v, last error: %v", r.ctxError, r.err)
+	}
+	return fmt.Sprintf("retry failed with %v", r.ctxError)
+}
+
+// NewRetryError returns a new error with the given context error and error. The non-context error is optional.
+func NewRetryError(ctxError, err error) error {
+	return &retryError{ctxError, err}
+}
+
+// UntilFor keeps retrying the given Func until it either errors severely or the context expires.
+// Between each try, it waits using the context of the given WaitFunc.
+func UntilFor(ctx context.Context, waitFunc WaitFunc, agg ErrorAggregator, f Func) error {
+	for {
+		done, err := f(ctx)
+		if err != nil {
+			if done {
+				agg.Severe(err)
+				return agg.Error()
+			}
+
+			agg.Minor(err)
+		} else if done {
+			return nil
+		}
+
+		if err := func() error {
+			wait, cancel := waitFunc(ctx)
+			defer cancel()
+
+			waitDone := wait.Done()
+			ctxDone := ctx.Done()
+
+			select {
+			case <-waitDone:
+				select {
+				case <-ctxDone:
+					return NewRetryError(ctx.Err(), agg.Error())
+				default:
+					return nil
+				}
+			case <-ctxDone:
+				return NewRetryError(ctx.Err(), agg.Error())
+			}
+		}(); err != nil {
+			return err
+		}
+	}
+}
+
+type ops struct {
+	intervalFactory        IntervalFactory
+	errorAggregatorFactory ErrorAggregatorFactory
+	contextOps             utilcontext.Ops
+}
+
+// Until implements Ops.
+func (o *ops) Until(ctx context.Context, interval time.Duration, f Func) error {
+	return UntilFor(ctx, o.intervalFactory.New(interval), o.errorAggregatorFactory.New(), f)
+}
+
+// UntilTimeout implements Ops.
+func (o *ops) UntilTimeout(ctx context.Context, interval, timeout time.Duration, f Func) error {
+	ctx, cancel := o.contextOps.WithTimeout(ctx, timeout)
+	defer cancel()
+	return o.Until(ctx, interval, f)
+}
+
+// NewOps returns the new ops with the given IntervalFactory, ErrorAggregatorFactory and utilcontext.Ops.
+func NewOps(intervalFactory IntervalFactory, errorAggregatorFactory ErrorAggregatorFactory, contextOps utilcontext.Ops) Ops {
+	return &ops{intervalFactory, errorAggregatorFactory, contextOps}
+}
+
+var defaultOps = NewOps(DefaultIntervalFactory(), DefaultErrorAggregatorFactory(), utilcontext.DefaultOps())
+
+// DefaultOps returns the default Ops with the DefaultIntervalFactory, DefaultErrorAggregatorFactory and utilcontext.DefaultOps.
+func DefaultOps() Ops {
+	return defaultOps
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/retry/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/retry/types.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+import (
+	"context"
+	"time"
+)
+
+// WaitFunc is a function that given context of a retry execution, returns a context that is closed
+// after a predefined wait amount.
+type WaitFunc func(context.Context) (context.Context, context.CancelFunc)
+
+// Func is a function that can be retried.
+//
+// There four possible return combinations. For each of these, there's also a utility function:
+// * Ok (true, nil): Execution succeeded without error.
+// * NotOk (false, nil): Execution failed without error, can be retried.
+// * MinorError (false, err): Execution failed with error, can be retried.
+// * SevereError (true, err): Execution failed with error, cannot be retried.
+type Func func(ctx context.Context) (done bool, err error)
+
+// IntervalFactory is a factory that can produce WaitFuncs that wait for the given interval.
+type IntervalFactory interface {
+	New(interval time.Duration) WaitFunc
+}
+
+// IntervalFactoryFunc is a function that implements IntervalFactory.
+type IntervalFactoryFunc func(interval time.Duration) WaitFunc
+
+// Ops are additional operations that can be done based on the UntilFor method.
+type Ops interface {
+	// Until keeps retrying the given Func until it either errors severely or the context expires.
+	// Between each try, it waits for the given interval.
+	Until(ctx context.Context, interval time.Duration, f Func) error
+	// Until keeps retrying the given Func until it either errors severely or the context expires.
+	// Between each try, it waits for the given interval.
+	// It also passes down a modified context to the execution that times out after the given timeout.
+	UntilTimeout(ctx context.Context, interval, timeout time.Duration, f Func) error
+}
+
+// An ErrorAggregator aggregates minor and severe errors.
+//
+// It's completely up to the ErrorAggregator how to aggregate the errors. Some may choose to only
+// keep the most recent error they received.
+// If no error was being recorded and the Error function is being called, the ErrorAggregator
+// should return a proper zero value (in most cases, this will be nil).
+type ErrorAggregator interface {
+	// Minor records the given minor error.
+	Minor(err error)
+	// Severe records the given severe error.
+	Severe(err error)
+	// Error returns the aggregated error.
+	Error() error
+}
+
+// ErrorAggregatorFactory is a factory that produces ErrorAggregators.
+type ErrorAggregatorFactory interface {
+	New() ErrorAggregator
+}
+
+// ErrorAggregatorFactoryFunc is a function that implements ErrorAggregatorFactory.
+type ErrorAggregatorFactoryFunc func() ErrorAggregator

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,9 +27,11 @@ github.com/gardener/gardener/pkg/apis/extensions
 github.com/gardener/gardener/pkg/apis/extensions/v1alpha1
 github.com/gardener/gardener/pkg/logger
 github.com/gardener/gardener/pkg/utils
+github.com/gardener/gardener/pkg/utils/context
 github.com/gardener/gardener/pkg/utils/errors
 github.com/gardener/gardener/pkg/utils/imagevector
 github.com/gardener/gardener/pkg/utils/kubernetes/health
+github.com/gardener/gardener/pkg/utils/retry
 github.com/gardener/gardener/pkg/utils/version
 # github.com/ghodss/yaml v1.0.0
 github.com/ghodss/yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is required to stop reconciliation of etcd resources on sts changes. It results in multiple reconciliations. Instead, etcd druid queries for sts readiness and updates the etcd status accordingly. If sts, not ready for a pre-determined time, the reconcile operation errors out.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Changed logic in etcd druid to query for statefulset readiness and update the etcd status accordingly
```
