### PR TITLE
:sparkle: Populate system default root-ca-certificate with ca-bundle

### DIFF
--- a/charts/etcd/templates/etcd-bootstrap-configmap.yaml
+++ b/charts/etcd/templates/etcd-bootstrap-configmap.yaml
@@ -23,25 +23,11 @@ data:
     VALIDATION_MARKER=/var/etcd/data/validation_marker
 
 {{- if .Values.etcd.enableTLS }}
-    # install wget from apk in order to pass --ca-certificate flag because
-    # busybox wget only has bare minimum features, without --ca-certificate option
-    apk update
+    # Add self-signed CA to list of root CA-certificates
+    cat /var/etcd/ssl/ca/ca.crt >> /etc/ssl/cert.pem
     if [ $? -ne 0 ]
     then
-      echo "apk update failed"
-      exit 1
-    fi
-    apk add wget
-    if [ $? -ne 0 ]
-    then
-      echo "failed to update wget"
-      exit 1
-    fi
-    # ensure that newly updated wget comes with --ca-certificate flag
-    wget --help | grep -- --ca-certificate
-    if [ $? -ne 0 ]
-    then
-      echo "updated wget is missing --ca-certificate flag"
+      echo "failed to update root certificate list"
       exit 1
     fi
 {{- end }}
@@ -68,11 +54,11 @@ data:
     check_and_start_etcd(){
           while true;
           do
-            wget {{ if .Values.etcd.enableTLS }}--ca-certificate=/var/etcd/ssl/ca/ca.crt "https{{ else }}"http{{ end }}://{{ .Values.name }}-local:{{ .Values.backup.port }}/initialization/status" -S -O status;
+            wget "http{{ if .Values.etcd.enableTLS }}s{{ end }}://{{ .Values.name }}-local:{{ .Values.backup.port }}/initialization/status" -S -O status;
             STATUS=`cat status`;
             case $STATUS in
             "New")
-                  wget {{ if .Values.etcd.enableTLS }}--ca-certificate=/var/etcd/ssl/ca/ca.crt "https{{ else }}"http{{ end }}://{{ .Values.name }}-local:{{ .Values.backup.port }}/initialization/start?mode=$1{{- if .Values.backup.failBelowRevision }}&failbelowrevision={{ int $.Values.backup.failBelowRevision }}{{- end }}" -S -O - ;;
+                  wget "http{{ if .Values.etcd.enableTLS }}s{{ end }}://{{ .Values.name }}-local:{{ .Values.backup.port }}/initialization/start?mode=$1{{- if .Values.backup.failBelowRevision }}&failbelowrevision={{ int $.Values.backup.failBelowRevision }}{{- end }}" -S -O - ;;
             "Progress")
                   sleep 1;
                   continue;;

--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
     metadata:
       annotations:
         "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
-        checksum/configmap-etcd-bootstrap: {{ include (print $.Template.BasePath "/etcd-bootstrap-configmap.yaml") . | sha256sum }}
+        checksum/etcd-bootstrap-configmap: {{ include (print $.Template.BasePath "/etcd-bootstrap-configmap.yaml") . | sha256sum }}
 {{- if .Values.annotations }}
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}

--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
     metadata:
       annotations:
         "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
-        checksum/configmap-etcd-bootstrap: {{ include (print $.Template.BasePath "/configmap-etcd-bootstrap.yaml") . | sha256sum }}
+        checksum/configmap-etcd-bootstrap: {{ include (print $.Template.BasePath "/etcd-bootstrap-configmap.yaml") . | sha256sum }}
 {{- if .Values.annotations }}
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -126,7 +126,7 @@ func getChartPathForStatefulSet() string {
 }
 
 func getChartPathForConfigMap() string {
-	return filepath.Join("etcd", "templates", "configmap-etcd-bootstrap.yaml")
+	return filepath.Join("etcd", "templates", "etcd-bootstrap-configmap.yaml")
 }
 
 func getChartPathForService() string {


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
- This PR removes the bootstrap script dependency over `apk` to download appropriate  wget version, which makes it self-contained.

**Which issue(s) this PR fixes**:
Fixes #39

**Special notes for your reviewer**:
Please test whether certificate based operation are performed properly on etcd container.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
:sparkle: Populate etcd container root-ca-certificates list with the provided self-signed ca-bundle for communication with backup-restore sidecar
```
