### PR TITLE
Fixed call to get provider when store field is nil

### DIFF
--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -878,12 +878,11 @@ func (r *EtcdReconciler) getMapFromEtcd(etcd *druidv1alpha1.Etcd) (map[string]in
 		values["tlsCASecret"] = etcd.Spec.Etcd.TLS.TLSCASecretRef.Name
 	}
 
-	storageProvider, err := utils.StorageProviderFromInfraProvider(etcd.Spec.Backup.Store.Provider)
-	if err != nil {
-		return nil, err
-	}
-
 	if etcd.Spec.Backup.Store != nil {
+		storageProvider, err := utils.StorageProviderFromInfraProvider(etcd.Spec.Backup.Store.Provider)
+		if err != nil {
+			return nil, err
+		}
 		storeValues := map[string]interface{}{
 			"storageContainer": etcd.Spec.Backup.Store.Container,
 			"storePrefix":      etcd.Spec.Backup.Store.Prefix,
@@ -952,7 +951,7 @@ func (r *EtcdReconciler) removeFinalizersToDependantSecrets(ctx context.Context,
 		secret := &corev1.Secret{}
 		if err := r.Client.Get(ctx, types.NamespacedName{
 			Name:      secretRef.Name,
-			Namespace: secretRef.Namespace,
+			Namespace: etcd.Namespace,
 		}, secret); err != nil {
 			if !errors.IsNotFound(err) {
 				return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes fetching provider when store is nil and fetches secrets in etcd resource namespace.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
