### PR TITLE
Accept 'openstack' for storage provider

### DIFF
--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -29,11 +29,11 @@ const (
 )
 
 const (
-	aws      = "aws"
-	azure    = "azure"
-	gcp      = "gcp"
-	alicloud = "alicloud"
-	os       = "os"
+	aws       = "aws"
+	azure     = "azure"
+	gcp       = "gcp"
+	alicloud  = "alicloud"
+	openstack = "openstack"
 )
 
 const (
@@ -162,7 +162,7 @@ func StorageProviderFromInfraProvider(infra *druidv1alpha1.StorageProvider) (str
 		return abs, nil
 	case alicloud, oss:
 		return oss, nil
-	case os, swift:
+	case openstack, swift:
 		return swift, nil
 	case gcp, gcs:
 		return gcs, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Accept `openstack` for storage provider, not `os`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`etcd-druid` does now accept `openstack` for spec.backup.store.provider.
```
