### PR TITLE
[ci:component:github.com/gardener/etcd-backup-restore:0.8.0->v0.9.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,4 +6,4 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.8.0"
+  tag: "v0.9.0"


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/etcd-backup-restore #222 @swapnilgm
Skip the first full snapshot on start,  if initial delta snapshot is taken and last full snapshot is recent enough than 24hr.
```

``` improvement operator github.com/gardener/etcd-backup-restore #217 @shreyas-s-rao
Add documentation to force restore etcd data.
```

``` improvement developer github.com/gardener/etcd-backup-restore #215 @shreyas-s-rao
Fix integration test setup script.
```

``` noteworthy user github.com/gardener/etcd-backup-restore #214 @shreyas-s-rao
HTTP API for triggering out-of-schedule full and delta snapshots now returns snapshot metadata in response body in JSON format.
```

``` improvement user github.com/gardener/etcd-backup-restore #214 @shreyas-s-rao
Added new HTTP API for fetching details of latest full and delta snapshots, in JSON format.
```

``` improvement user github.com/gardener/etcd-backup-restore #211 @shreyas-s-rao
Add metrics `etcdbr_snapstore_latest_deltas_total` and `etcdbr_snapstore_latest_deltas_revisions_total` to provide information about the delta snapshots since the latest full snapshot in the snapstore.
```

``` improvement operator github.com/gardener/etcd-backup-restore #210 @ialidzhikov
The release tags from now are prefixed with `v`.
```

``` improvement operator github.com/gardener/etcd-backup-restore #208 @swapnilgm
Configuring backup-restore server using config file is now supported.
```