### PR TITLE
Add .ci/component_descriptor

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+repo_root_dir="$(dirname $0)"/..
+repo_name="${2:-github.com/gardener/etcd-druid}"
+descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
+
+echo "enriching creating component descriptor from ${BASE_DEFINITION_PATH}"
+
+if [[ -f "$repo_root_dir/charts/images.yaml" ]]; then
+  images="$(yaml2json < "$repo_root_dir/charts/images.yaml")"
+  eval "$(jq -r ".images |
+    map(select(.sourceRepository != \"$repo_name\") |
+      \"--container-image-dependencies '{\\\"name\\\": \\\"\" + .name + \"\\\", \\\"image_reference\\\": \\\"\" + .repository + \":\" + .tag + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
+    ) |
+    \"${ADD_DEPENDENCIES_CMD} \\\\\n\" +
+    join(\" \\\\\n\")" <<< "$images")"
+fi
+
+cp "${BASE_DEFINITION_PATH}" "${descriptor_out_file}"

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -35,6 +35,7 @@ etcd-druid:
     pull-request:
       traits:
         pull-request: ~
+        component_descriptor: ~
     release:
       traits:
         version:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add .ci/component_descriptor.
As now the `etcd-backup-restore` image is part of etcd-druid `charts/images.yaml`, it should be added also to component_descriptor.yaml.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
