### PR TITLE
Remove the cluster autooscaler safe-to-evict  annotation from etcd sts.

### DIFF
--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -27,7 +27,6 @@ spec:
   template:
     metadata:
       annotations:
-        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         checksum/etcd-bootstrap-configmap: {{ include (print $.Template.BasePath "/etcd-bootstrap-configmap.yaml") . | sha256sum }}
 {{- if .Values.annotations }}
 {{ toYaml .Values.annotations | indent 8 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Please check https://github.com/gardener/etcd-druid/issues/54 for description
**Which issue(s) this PR fixes**:
Fixes #54

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```user operator
:warning: Etcd-druid NO MORE adds the annotation `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` to etcd pods. Please make use of `.spec.annotations` to configure such annotation.
```
