### PR TITLE
Added ci changes and updated etcdbrctl version

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -49,3 +49,14 @@ etcd-druid:
               channel_name: 'k8s-etcd'
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
+    create_update_pull_requests:
+      repo:
+        trigger: false
+        disable_ci_skip: true
+      steps: ~
+      traits:
+        component_descriptor: ~
+        update_component_deps: ~
+        cronjob:
+          interval: '5m'
+        version: ~

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,4 +6,4 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.9.0"
+  tag: "v0.9.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the `.ci` directory files to create release PRs on druid when etcdbrctl release happens.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Bump default etcd-backup-restore image version to v0.9.1.
```
