### PR TITLE
Add support for OCS S3 storage

### DIFF
--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -259,6 +259,39 @@ spec:
             secretKeyRef:
               name: {{ .Values.store.storeSecret }}
               key: "secretAccessKey"
+{{- else if eq .Values.store.storageProvider "OCS" }}
+        - name: "OCS_ENDPOINT"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.store.storeSecret }}
+              key: "endpoint"
+        - name: "OCS_ACCESS_KEY_ID"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.store.storeSecret }}
+              key: "accessKeyID"
+        - name: "OCS_SECRET_ACCESS_KEY"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.store.storeSecret }}
+              key: "secretAccessKey"
+        - name: "OCS_REGION"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.store.storeSecret }}
+              key: "region"
+        - name: "OCS_DISABLE_SSL"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.store.storeSecret }}
+              key: "disableSSL"
+              optional: true
+        - name: "OCS_INSECURE_SKIP_VERIFY"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.store.storeSecret }}
+              key: "insecureSkipVerify"
+              optional: true
 {{- end }}
         volumeMounts:
         - name: {{ .Values.volumeClaimTemplateName }}

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -35,6 +35,7 @@ const (
 	alicloud  = "alicloud"
 	openstack = "openstack"
 	dell      = "dell"
+	openshift = "openshift"
 )
 
 const (
@@ -45,6 +46,7 @@ const (
 	swift = "Swift"
 	local = "Local"
 	ecs   = "ECS"
+	ocs   = "OCS"
 )
 
 // ValueExists returns true or false, depending on whether the given string <value>
@@ -170,6 +172,8 @@ func StorageProviderFromInfraProvider(infra *druidv1alpha1.StorageProvider) (str
 		return gcs, nil
 	case dell, ecs:
 		return ecs, nil
+	case openshift, ocs:
+		return ocs, nil
 	case local:
 		return local, nil
 	default:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for OpenShift Container Storage (OCS) S3 storage type.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See also https://github.com/gardener/etcd-backup-restore/pull/261

**Release note**:
```improvement operator
Added support for OpenShift Container Storage (OCS) S3 storage type.
```
