### PR TITLE
Integrate the etcdbr-compression feature from etcd-backup-restore with etcd-druid.

### DIFF
--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -65,6 +65,14 @@ type TLSConfig struct {
 	TLSCASecretRef corev1.SecretReference `json:"tlsCASecretRef"`
 }
 
+// CompressionSpec defines parameters related to compression of Snapshots(full as well as delta).
+type CompressionSpec struct {
+	// +optional
+	Enabled bool `json:"enabled,omitempty"`
+	// +optional
+	CompressionPolicy *string `json:"policy,omitempty"`
+}
+
 // BackupSpec defines parametes associated with the full and delta snapshots of etcd
 type BackupSpec struct {
 	// Port define the port on which etcd-backup-restore server will exposed.
@@ -97,6 +105,9 @@ type BackupSpec struct {
 	// DeltaSnapshotMemoryLimit defines the memory limit after which delta snapshots will be taken
 	// +optional
 	DeltaSnapshotMemoryLimit *resource.Quantity `json:"deltaSnapshotMemoryLimit,omitempty"`
+	// SnapshotCompression defines the specification for compression of Snapshots.
+	// +optional
+	SnapshotCompression *CompressionSpec `json:"compression,omitempty"`
 }
 
 // EtcdConfig defines parameters associated etcd deployed

--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -159,6 +159,14 @@ spec:
 {{- if .Values.backup.garbageCollectionPeriod }}
         - --garbage-collection-period={{ .Values.backup.garbageCollectionPeriod }}
 {{- end }}
+{{- if .Values.backup.compression }}
+        {{- if .Values.backup.compression.enabled }}
+        - --compress-snapshots={{ .Values.backup.compression.enabled }}
+        {{- end }}
+        {{- if .Values.backup.compression.policy }}        
+        - --compression-policy={{ .Values.backup.compression.policy }}
+        {{- end }}
+{{- end }}
         - --snapstore-temp-directory={{ .Values.backup.snapstoreTempDir }}
         image: {{ .Values.backup.image }}
         imagePullPolicy: {{ .Values.backup.pullPolicy }}

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -45,6 +45,9 @@ backup:
     requests:
       cpu: 50m
       memory: 128Mi
+  # compression:
+  #   enabled: true
+  #   policy: "gzip"
 
 volumeClaimTemplateName: test
 storageClass: ""

--- a/config/crd/bases/druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/druid.gardener.cloud_etcds.yaml
@@ -46,6 +46,14 @@ spec:
               backup:
                 description: BackupSpec defines parametes associated with the full and delta snapshots of etcd
                 properties:
+                  compression:
+                    description: SnapshotCompression defines the specification for compression of Snapshots.
+                    properties:
+                      enabled:
+                        type: boolean
+                      policy:
+                        type: string
+                    type: object
                   deltaSnapshotMemoryLimit:
                     anyOf:
                     - type: integer

--- a/config/samples/druid_v1alpha1_etcd.yaml
+++ b/config/samples/druid_v1alpha1_etcd.yaml
@@ -37,7 +37,7 @@ spec:
         clientPort: 2379
         serverPort: 2380
     backup:
-        image: eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.11.1
+        image: eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.12.0-dev-e6df91b7463cf784f651bd6cc6ac7fc4d2e5a70b
         port: 8080
         fullSnapshotSchedule: "0 */24 * * *"
         resources:
@@ -54,6 +54,9 @@ spec:
             container: shoot--dev--i308301-1--b3cab
             provider: aws
             prefix: etcd-test
+        compression:
+            enabled: false
+            policy: "gzip"
     replicas: 1
     # priorityClassName: foo
     storageClass: gardener.cloud-fast

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -904,6 +904,17 @@ func (r *EtcdReconciler) getMapFromEtcd(etcd *druidv1alpha1.Etcd) (map[string]in
 		backupValues["port"] = etcd.Spec.Backup.Port
 	}
 
+	if etcd.Spec.Backup.SnapshotCompression != nil {
+		compressionValues := make(map[string]interface{})
+		if etcd.Spec.Backup.SnapshotCompression.Enabled {
+			compressionValues["enabled"] = etcd.Spec.Backup.SnapshotCompression.Enabled
+		}
+		if etcd.Spec.Backup.SnapshotCompression.CompressionPolicy != nil {
+			compressionValues["policy"] = etcd.Spec.Backup.SnapshotCompression.CompressionPolicy
+		}
+		backupValues["compression"] = compressionValues
+	}
+
 	if etcd.Spec.Backup.Image == nil {
 		val, ok := images[common.BackupRestore]
 		if !ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
It integrates the [etcdbr-compression feature](https://github.com/gardener/etcd-backup-restore/pull/293) with etcd-druid.

**Which issue(s) this PR fixes**:
Fixes #137 

**Special notes for your reviewer**:


**Release note**:
```improvement operator
Snapshot compression specification can be configured through helm-charts as well as etcd resource spec configuration file.
```
