### PR TITLE
Update pipeline images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -8,6 +8,7 @@ etcd-druid:
           'inject-commit-hash'
         inject_effective_version: true
       publish:
+        oci-builder: 'kaniko'
         dockerimages:
           etcd-druid:
             registry: 'gcr-readwrite'
@@ -20,11 +21,11 @@ etcd-druid:
                 build: ~
     steps:
       check:
-        image: 'golang:1.13'
+        image: 'golang:1.15.8'
       test:
-        image: 'golang:1.13'
+        image: 'golang:1.15.8'
       build:
-        image: 'golang:1.13'
+        image: 'golang:1.15.8'
         output_dir: 'binary'
 
   jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the used pipeline images to Go 1.15.8. This is required for further dependency updates.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
