### PR TITLE
Read PVC warning events

### DIFF
--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -1166,7 +1166,7 @@ func (r *EtcdReconciler) fetchPVCEventsFor(ctx context.Context, ss *appsv1.State
 	)
 	for _, volumeClaim := range volumeClaims {
 		for _, pvc := range pvcs.Items {
-			if pvc.Status.Phase != corev1.ClaimBound && !strings.HasPrefix(pvc.GetName(), fmt.Sprintf("%s-%s", volumeClaim.Name, ss.Name)) {
+			if !strings.HasPrefix(pvc.GetName(), fmt.Sprintf("%s-%s", volumeClaim.Name, ss.Name)) || pvc.Status.Phase == corev1.ClaimBound {
 				continue
 			}
 			messages, err := kutil.FetchEventMessages(ctx, r.Client, &pvc, corev1.EventTypeWarning, 2)

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		ClientDisableCacheFor:      controllers.UncachedObjectList,
 		Scheme:                     scheme,
 		MetricsBindAddress:         metricsAddr,
 		LeaderElection:             enableLeaderElection,

--- a/vendor/github.com/gardener/gardener/extensions/pkg/util/test/options.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/util/test/options.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Flag interface {
+	Slice() []string
+}
+
+func keyToFlag(key string) string {
+	return fmt.Sprintf("--%s", key)
+}
+
+type intFlag struct {
+	key   string
+	value int
+}
+
+func (f *intFlag) Slice() []string {
+	return []string{keyToFlag(f.key), fmt.Sprintf("%d", f.value)}
+}
+
+type stringFlag struct {
+	key   string
+	value string
+}
+
+func (f *stringFlag) Slice() []string {
+	return []string{keyToFlag(f.key), f.value}
+}
+
+type boolFlag struct {
+	key   string
+	value bool
+}
+
+func (f *boolFlag) Slice() []string {
+	var value string
+	if f.value {
+		value = "true"
+	} else {
+		value = "false"
+	}
+
+	return []string{keyToFlag(f.key), value}
+}
+
+type stringSliceFlag struct {
+	key   string
+	value []string
+}
+
+func (f *stringSliceFlag) Slice() []string {
+	return []string{keyToFlag(f.key), strings.Join(f.value, ",")}
+}
+
+func IntFlag(key string, value int) Flag {
+	return &intFlag{key, value}
+}
+
+func StringFlag(key, value string) Flag {
+	return &stringFlag{key, value}
+}
+
+func BoolFlag(key string, value bool) Flag {
+	return &boolFlag{key, value}
+}
+
+func StringSliceFlag(key string, value ...string) Flag {
+	return &stringSliceFlag{key, value}
+}
+
+// Command is a command that has a name, a list of flags, and a list of arguments.
+type Command struct {
+	Name  string
+	Flags []Flag
+	Args  []string
+}
+
+// CommandBuilder is a builder for Command objects.
+type CommandBuilder struct {
+	command Command
+}
+
+// NewCommandBuilder creates and returns a new CommandBuilder with the given name.
+func NewCommandBuilder(name string) *CommandBuilder {
+	return &CommandBuilder{Command{Name: name}}
+}
+
+// Flags appends the given flags to this CommandBuilder.
+func (c *CommandBuilder) Flags(flags ...Flag) *CommandBuilder {
+	c.command.Flags = append(c.command.Flags, flags...)
+	return c
+}
+
+// Args appends the given arguments to this CommandBuilder.
+func (c *CommandBuilder) Args(args ...string) *CommandBuilder {
+	c.command.Args = append(c.command.Args, args...)
+	return c
+}
+
+// Command returns the Command that has been built by this CommandBuilder.
+func (c *CommandBuilder) Command() *Command {
+	return &c.command
+}
+
+// Slice returns a representation of this Command as a slice of strings.
+func (c *Command) Slice() []string {
+	out := []string{c.Name}
+	for _, flag := range c.Flags {
+		out = append(out, flag.Slice()...)
+	}
+	out = append(out, c.Args...)
+	return out
+}
+
+// String returns a representation of this Command as a string.
+func (c *Command) String() string {
+	return strings.Join(c.Slice(), " ")
+}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/util/test/test.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/util/test/test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+// WithVar sets the given var to the src value and returns a function to revert to the original state.
+// The type of `dst` has to be a settable pointer.
+// The value of `src` has to be assignable to the type of `dst`.
+//
+// Example usage:
+// ```
+// v := "foo"
+// defer WithVar(&v, "bar")()
+// ```
+func WithVar(dst interface{}, src interface{}) func() {
+	dstValue := reflect.ValueOf(dst)
+	if dstValue.Type().Kind() != reflect.Ptr {
+		ginkgo.Fail(fmt.Sprintf("destination value %T is not a pointer", dst))
+	}
+
+	if dstValue.CanSet() {
+		ginkgo.Fail(fmt.Sprintf("value %T cannot be set", dst))
+	}
+
+	srcValue := reflect.ValueOf(src)
+	if srcValue.Type().AssignableTo(dstValue.Type()) {
+		ginkgo.Fail(fmt.Sprintf("cannot write %T into %T", src, dst))
+	}
+
+	tmp := dstValue.Elem().Interface()
+	dstValue.Elem().Set(srcValue)
+	return func() {
+		dstValue.Elem().Set(reflect.ValueOf(tmp))
+	}
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/flow.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/flow.go
@@ -1,0 +1,387 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package flow provides utilities to construct a directed acyclic computational graph
+// that is then executed and monitored with maximum parallelism.
+package flow
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener/pkg/logger"
+	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	logKeyFlow = "flow"
+	logKeyTask = "task"
+)
+
+// ErrorCleaner is called when a task which errored during the previous reconciliation phase completes with success
+type ErrorCleaner func(context.Context, string)
+
+type nodes map[TaskID]*node
+
+func (ns nodes) rootIDs() TaskIDs {
+	roots := NewTaskIDs()
+	for taskID, node := range ns {
+		if node.required == 0 {
+			roots.Insert(taskID)
+		}
+	}
+	return roots
+}
+
+func (ns nodes) getOrCreate(id TaskID) *node {
+	n, ok := ns[id]
+	if !ok {
+		n = &node{}
+		ns[id] = n
+	}
+	return n
+}
+
+// Flow is a validated executable Graph.
+type Flow struct {
+	name  string
+	nodes nodes
+}
+
+// Name retrieves the name of a flow.
+func (f *Flow) Name() string {
+	return f.name
+}
+
+// Len retrieves the amount of tasks in a Flow.
+func (f *Flow) Len() int {
+	return len(f.nodes)
+}
+
+// node is a compiled Task that contains the triggered Tasks, the
+// number of triggers the node itself requires and its payload function.
+type node struct {
+	targetIDs TaskIDs
+	required  int
+	fn        TaskFn
+}
+
+func (n *node) String() string {
+	return fmt.Sprintf("node{targets=%s, required=%d}", n.targetIDs.List(), n.required)
+}
+
+// addTargets adds the given TaskIDs as targets to the node.
+func (n *node) addTargets(taskIDs ...TaskID) {
+	if n.targetIDs == nil {
+		n.targetIDs = NewTaskIDs(TaskIDSlice(taskIDs))
+		return
+	}
+	n.targetIDs.Insert(TaskIDSlice(taskIDs))
+}
+
+// Opts are options for a Flow execution. If they are not set, they
+// are left blank and don't affect the Flow.
+type Opts struct {
+	Logger           logrus.FieldLogger
+	ProgressReporter ProgressReporter
+	ErrorCleaner     func(ctx context.Context, taskID string)
+	ErrorContext     *utilerrors.ErrorContext
+	Context          context.Context
+}
+
+// Run starts an execution of a Flow.
+// It blocks until the Flow has finished and returns the error, if any.
+func (f *Flow) Run(opts Opts) error {
+	ctx := opts.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return newExecution(f, opts.Logger, opts.ProgressReporter, opts.ErrorCleaner, opts.ErrorContext).run(ctx)
+}
+
+type nodeResult struct {
+	TaskID TaskID
+	Error  error
+}
+
+// Stats are the statistics of a Flow execution.
+type Stats struct {
+	FlowName  string
+	All       TaskIDs
+	Succeeded TaskIDs
+	Failed    TaskIDs
+	Running   TaskIDs
+	Pending   TaskIDs
+}
+
+// ProgressPercent retrieves the progress of a Flow execution in percent.
+func (s *Stats) ProgressPercent() int32 {
+	progress := (100 * s.Succeeded.Len()) / s.All.Len()
+	return int32(progress)
+}
+
+// Copy deeply copies a Stats object.
+func (s *Stats) Copy() *Stats {
+	return &Stats{
+		s.FlowName,
+		s.All.Copy(),
+		s.Succeeded.Copy(),
+		s.Failed.Copy(),
+		s.Running.Copy(),
+		s.Pending.Copy(),
+	}
+}
+
+// InitialStats creates a new Stats object with the given set of initial TaskIDs.
+// The initial TaskIDs are added to all TaskIDs as well as to the pending ones.
+func InitialStats(flowName string, all TaskIDs) *Stats {
+	return &Stats{
+		flowName,
+		all,
+		NewTaskIDs(),
+		NewTaskIDs(),
+		NewTaskIDs(),
+		all.Copy(),
+	}
+}
+
+func newExecution(flow *Flow, log logrus.FieldLogger, progressReporter ProgressReporter, errorCleaner ErrorCleaner, errorContext *utilerrors.ErrorContext) *execution {
+	all := NewTaskIDs()
+
+	for name := range flow.nodes {
+		all.Insert(name)
+	}
+
+	if log == nil {
+		log = logger.NewNopLogger()
+	}
+	log = log.WithField(logKeyFlow, flow.name)
+
+	return &execution{
+		flow,
+		InitialStats(flow.name, all),
+		nil,
+		log,
+		progressReporter,
+		errorCleaner,
+		errorContext,
+		make(chan *nodeResult),
+		make(map[TaskID]int),
+	}
+}
+
+type execution struct {
+	flow *Flow
+
+	stats      *Stats
+	taskErrors []error
+
+	log              logrus.FieldLogger
+	progressReporter ProgressReporter
+	errorCleaner     ErrorCleaner
+	errorContext     *utilerrors.ErrorContext
+
+	done          chan *nodeResult
+	triggerCounts map[TaskID]int
+}
+
+func (e *execution) Log() logrus.FieldLogger {
+	return e.log
+}
+
+func (e *execution) runNode(ctx context.Context, id TaskID) {
+	if e.errorContext != nil {
+		e.errorContext.AddErrorID(string(id))
+	}
+	e.stats.Pending.Delete(id)
+	e.stats.Running.Insert(id)
+	go func() {
+		log := e.log.WithField(logKeyTask, id)
+
+		start := time.Now().UTC()
+		log.Debugf("Started")
+		err := e.flow.nodes[id].fn(ctx)
+		end := time.Now().UTC()
+		log.Debugf("Finished, took %s", end.Sub(start))
+
+		if err != nil {
+			log.WithError(err).Error("Error")
+		} else {
+			log.Info("Succeeded")
+		}
+
+		err = errors.Wrapf(err, "task %q failed", id)
+		e.done <- &nodeResult{TaskID: id, Error: err}
+	}()
+}
+
+func (e *execution) updateSuccess(id TaskID) {
+	e.stats.Running.Delete(id)
+	e.stats.Succeeded.Insert(id)
+}
+
+func (e *execution) updateFailure(id TaskID) {
+	e.stats.Running.Delete(id)
+	e.stats.Failed.Insert(id)
+}
+
+func (e *execution) processTriggers(ctx context.Context, id TaskID) {
+	node := e.flow.nodes[id]
+	for target := range node.targetIDs {
+		e.triggerCounts[target]++
+		if e.triggerCounts[target] == e.flow.nodes[target].required {
+			e.runNode(ctx, target)
+		}
+	}
+}
+
+func (e *execution) cleanErrors(ctx context.Context, taskID TaskID) {
+	if e.errorCleaner != nil {
+		e.errorCleaner(ctx, string(taskID))
+	}
+}
+
+func (e *execution) reportProgress(ctx context.Context) {
+	if e.progressReporter != nil {
+		e.progressReporter.Report(ctx, e.stats.Copy())
+	}
+}
+
+func (e *execution) run(ctx context.Context) error {
+	defer close(e.done)
+
+	if e.progressReporter != nil {
+		if err := e.progressReporter.Start(ctx); err != nil {
+			return err
+		}
+		defer e.progressReporter.Stop()
+	}
+
+	e.log.Info("Starting")
+	e.reportProgress(ctx)
+
+	var (
+		cancelErr error
+		roots     = e.flow.nodes.rootIDs()
+	)
+	for name := range roots {
+		if cancelErr = ctx.Err(); cancelErr == nil {
+			e.runNode(ctx, name)
+		}
+	}
+	e.reportProgress(ctx)
+
+	for e.stats.Running.Len() > 0 {
+		result := <-e.done
+		if result.Error != nil {
+			e.taskErrors = append(e.taskErrors, utilerrors.WithID(string(result.TaskID), result.Error))
+			e.updateFailure(result.TaskID)
+		} else {
+			e.updateSuccess(result.TaskID)
+			if e.errorContext != nil && e.errorContext.HasLastErrorWithID(string(result.TaskID)) {
+				e.cleanErrors(ctx, result.TaskID)
+			}
+			if cancelErr = ctx.Err(); cancelErr == nil {
+				e.processTriggers(ctx, result.TaskID)
+			}
+		}
+		e.reportProgress(ctx)
+	}
+
+	e.log.Info("Finished")
+	return e.result(cancelErr)
+}
+
+func (e *execution) result(cancelErr error) error {
+	if cancelErr != nil {
+		return &flowCanceled{
+			name:       e.flow.name,
+			taskErrors: e.taskErrors,
+			cause:      cancelErr,
+		}
+	}
+
+	if len(e.taskErrors) > 0 {
+		return &flowFailed{
+			name:       e.flow.name,
+			taskErrors: e.taskErrors,
+		}
+	}
+	return nil
+}
+
+type flowCanceled struct {
+	name       string
+	taskErrors []error
+	cause      error
+}
+
+type flowFailed struct {
+	name       string
+	taskErrors []error
+}
+
+func (f *flowCanceled) Error() string {
+	if len(f.taskErrors) == 0 {
+		return fmt.Sprintf("flow %q was canceled: %v", f.name, f.cause)
+	}
+	return fmt.Sprintf("flow %q was canceled: %v. Encountered task errors: %v",
+		f.name, f.cause, f.taskErrors)
+}
+
+func (f *flowCanceled) Cause() error {
+	return f.cause
+}
+
+func (f *flowFailed) Error() string {
+	return fmt.Sprintf("flow %q encountered task errors: %v", f.name, f.taskErrors)
+}
+
+func (f *flowFailed) Cause() error {
+	return &multierror.Error{Errors: f.taskErrors}
+}
+
+// Errors reports all wrapped Task errors of the given Flow error.
+func Errors(err error) *multierror.Error {
+	switch e := err.(type) {
+	case *flowCanceled:
+		return &multierror.Error{Errors: e.taskErrors}
+	case *flowFailed:
+		return &multierror.Error{Errors: e.taskErrors}
+	}
+	return nil
+}
+
+// Causes reports the causes of all Task errors of the given Flow error.
+func Causes(err error) *multierror.Error {
+	var (
+		errs   = Errors(err).Errors
+		causes = make([]error, 0, len(errs))
+	)
+	for _, err := range errs {
+		causes = append(causes, errors.Cause(err))
+	}
+	return &multierror.Error{Errors: causes}
+}
+
+// WasCanceled determines whether the given flow error was caused by cancellation.
+func WasCanceled(err error) bool {
+	_, ok := err.(*flowCanceled)
+	return ok
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/graph.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/graph.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"fmt"
+)
+
+// Task is a unit of work. It has a name, a payload function and a set of dependencies.
+// A is only started once all its dependencies have been completed successfully.
+type Task struct {
+	Name         string
+	Fn           TaskFn
+	Dependencies TaskIDs
+}
+
+// Spec returns the TaskSpec of a task.
+func (t *Task) Spec() *TaskSpec {
+	return &TaskSpec{
+		t.Fn,
+		t.Dependencies.Copy(),
+	}
+}
+
+// TaskSpec is functional body of a Task, consisting only of the payload function and
+// the dependencies of the Task.
+type TaskSpec struct {
+	Fn           TaskFn
+	Dependencies TaskIDs
+}
+
+// Tasks is a mapping from TaskID to TaskSpec.
+type Tasks map[TaskID]*TaskSpec
+
+// Graph is a builder for a Flow.
+type Graph struct {
+	name  string
+	tasks Tasks
+}
+
+// Name returns the name of a graph.
+func (g *Graph) Name() string {
+	return g.name
+}
+
+// NewGraph returns a new Graph with the given name.
+func NewGraph(name string) *Graph {
+	return &Graph{name: name, tasks: make(Tasks)}
+}
+
+// Add adds the given Task to the graph.
+// This panics if
+// - There is already a Task present with the same name
+// - One of the dependencies of the Task is not present
+func (g *Graph) Add(task Task) TaskID {
+	id := TaskID(task.Name)
+	if _, ok := g.tasks[id]; ok {
+		panic(fmt.Sprintf("Task with id %q already exists", id))
+	}
+	spec := task.Spec()
+	for dependencyID := range spec.Dependencies {
+		if _, ok := g.tasks[dependencyID]; !ok {
+			panic(fmt.Sprintf("Task %q is missing dependency %q", id, dependencyID))
+		}
+	}
+	g.tasks[id] = task.Spec()
+	return id
+}
+
+// Compile compiles the graph into an executable Flow.
+func (g *Graph) Compile() *Flow {
+	nodes := make(nodes, len(g.tasks))
+
+	for taskName, taskSpec := range g.tasks {
+		for dependencyID := range taskSpec.Dependencies {
+			dependency := nodes.getOrCreate(dependencyID)
+			dependency.addTargets(taskName)
+		}
+
+		node := nodes.getOrCreate(taskName)
+		node.fn = taskSpec.Fn
+		node.required = taskSpec.Dependencies.Len()
+	}
+
+	return &Flow{
+		g.name,
+		nodes,
+	}
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+)
+
+// ProgressReporterFn is continuously called on progress in a flow.
+type ProgressReporterFn func(context.Context, *Stats)
+
+// ProgressReporter is used to report the current progress of a flow.
+type ProgressReporter interface {
+	// Start starts the progress reporter.
+	Start(context.Context) error
+	// Stop stops the progress reporter.
+	Stop()
+	// Report reports the progress using the current statistics.
+	Report(context.Context, *Stats)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter_delaying.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter_delaying.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type progressReporterDelaying struct {
+	lock                sync.Mutex
+	ctx                 context.Context
+	ctxCancel           context.CancelFunc
+	reporterFn          ProgressReporterFn
+	period              time.Duration
+	timer               *time.Timer
+	pendingProgress     *Stats
+	delayProgressReport bool
+}
+
+// NewDelayingProgressReporter returns a new progress reporter with the given function and the configured period. A
+// period of `0` will lead to immediate reports as soon as flow tasks are completed.
+func NewDelayingProgressReporter(reporterFn ProgressReporterFn, period time.Duration) ProgressReporter {
+	return &progressReporterDelaying{
+		reporterFn: reporterFn,
+		period:     period,
+	}
+}
+
+func (p *progressReporterDelaying) Start(ctx context.Context) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.timer != nil {
+		return fmt.Errorf("progress reporter has already been started")
+	}
+
+	// We store the context on the progressReporterDelaying object so that we can call the reporterFn with the original
+	// context - otherwise, the final state cannot be reported because the cancel context will already be canceled
+	p.ctx = ctx
+
+	if p.period > 0 {
+		p.timer = time.NewTimer(p.period)
+
+		ctx, cancel := context.WithCancel(ctx)
+		p.ctxCancel = cancel
+
+		go p.run(ctx)
+	}
+
+	return nil
+}
+
+func (p *progressReporterDelaying) Stop() {
+	p.lock.Lock()
+
+	if p.ctxCancel != nil {
+		p.ctxCancel()
+	}
+
+	p.ctxCancel = nil
+	p.timer = nil
+	p.lock.Unlock()
+	p.report()
+}
+
+func (p *progressReporterDelaying) Report(_ context.Context, pendingProgress *Stats) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.timer != nil && p.delayProgressReport {
+		p.pendingProgress = pendingProgress
+		return
+	}
+
+	p.reporterFn(p.ctx, pendingProgress)
+	p.delayProgressReport = true
+}
+
+func (p *progressReporterDelaying) run(ctx context.Context) {
+	timer := p.timer
+	for timer != nil {
+		select {
+		case <-timer.C:
+			timer.Reset(p.period)
+			p.report()
+
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		}
+	}
+}
+
+func (p *progressReporterDelaying) report() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.pendingProgress != nil {
+		p.reporterFn(p.ctx, p.pendingProgress)
+		p.pendingProgress = nil
+	}
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter_immediate.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/progress_reporter_immediate.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+)
+
+type progressReporterImmediate struct {
+	reporterFn ProgressReporterFn
+}
+
+// NewImmediateProgressReporter returns a new progress reporter with the given function.
+func NewImmediateProgressReporter(reporterFn ProgressReporterFn) ProgressReporter {
+	return progressReporterImmediate{
+		reporterFn: reporterFn,
+	}
+}
+
+func (p progressReporterImmediate) Start(context.Context) error { return nil }
+func (p progressReporterImmediate) Stop()                       {}
+func (p progressReporterImmediate) Report(ctx context.Context, stats *Stats) {
+	p.reporterFn(ctx, stats)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/taskfn.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/taskfn.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gardener/gardener/pkg/utils/retry"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+var (
+	// ContextWithTimeout is context.WithTimeout. Exposed for testing.
+	ContextWithTimeout = context.WithTimeout
+)
+
+// TaskFn is a payload function of a task.
+type TaskFn func(ctx context.Context) error
+
+// RecoverFn is a function that can recover an error.
+type RecoverFn func(ctx context.Context, err error) error
+
+// EmptyTaskFn is a TaskFn that does nothing (returns nil).
+var EmptyTaskFn TaskFn = func(ctx context.Context) error { return nil }
+
+// SkipIf returns a TaskFn that does nothing if the condition is true, otherwise the function
+// will be executed once called.
+func (t TaskFn) SkipIf(condition bool) TaskFn {
+	if condition {
+		return EmptyTaskFn
+	}
+	return t
+}
+
+// DoIf returns a TaskFn that will be executed if the condition is true when it is called.
+// Otherwise, it will do nothing when called.
+func (t TaskFn) DoIf(condition bool) TaskFn {
+	return t.SkipIf(!condition)
+}
+
+// Timeout returns a TaskFn that is bound to a context which times out.
+func (t TaskFn) Timeout(timeout time.Duration) TaskFn {
+	return func(ctx context.Context) error {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		return t(ctx)
+	}
+}
+
+// RetryUntilTimeout returns a TaskFn that is retried until the timeout is reached.
+func (t TaskFn) RetryUntilTimeout(interval, timeout time.Duration) TaskFn {
+	return func(ctx context.Context) error {
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		return retry.Until(ctx, interval, func(ctx context.Context) (done bool, err error) {
+			if err := t(ctx); err != nil {
+				return retry.MinorError(err)
+			}
+			return retry.Ok()
+		})
+	}
+}
+
+// ToRecoverFn converts the TaskFn to a RecoverFn that ignores the incoming error.
+func (t TaskFn) ToRecoverFn() RecoverFn {
+	return func(ctx context.Context, _ error) error {
+		return t(ctx)
+	}
+}
+
+// Recover creates a new TaskFn that recovers an error with the given RecoverFn.
+func (t TaskFn) Recover(recoverFn RecoverFn) TaskFn {
+	return func(ctx context.Context) error {
+		if err := t(ctx); err != nil {
+			if ctx.Err() != nil {
+				return err
+			}
+			return recoverFn(ctx, err)
+		}
+		return nil
+	}
+}
+
+// Sequential runs the given TaskFns sequentially.
+func Sequential(fns ...TaskFn) TaskFn {
+	return func(ctx context.Context) error {
+		for _, fn := range fns {
+			if err := fn(ctx); err != nil {
+				return err
+			}
+
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// Parallel runs the given TaskFns in parallel, collecting their errors in a multierror.
+func Parallel(fns ...TaskFn) TaskFn {
+	return func(ctx context.Context) error {
+		var (
+			wg     sync.WaitGroup
+			errors = make(chan error)
+			result error
+		)
+
+		for _, fn := range fns {
+			t := fn
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				errors <- t(ctx)
+			}()
+		}
+
+		go func() {
+			defer close(errors)
+			wg.Wait()
+		}()
+
+		for err := range errors {
+			if err != nil {
+				result = multierror.Append(result, err)
+			}
+		}
+		return result
+	}
+}
+
+// ParallelExitOnError runs the given TaskFns in parallel and stops execution as soon as one TaskFn returns an error.
+func ParallelExitOnError(fns ...TaskFn) TaskFn {
+	return func(ctx context.Context) error {
+		var (
+			wg             sync.WaitGroup
+			errors         = make(chan error)
+			subCtx, cancel = context.WithCancel(ctx)
+		)
+		defer cancel()
+
+		for _, fn := range fns {
+			t := fn
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				errors <- t(subCtx)
+			}()
+		}
+
+		go func() {
+			defer close(errors)
+			wg.Wait()
+		}()
+
+		for err := range errors {
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/flow/taskid.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/flow/taskid.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import "sort"
+
+// TaskID is an id of a task.
+type TaskID string
+
+// TaskIDs retrieves this TaskID as a singleton slice.
+func (t TaskID) TaskIDs() []TaskID {
+	return []TaskID{t}
+}
+
+// TaskIDs is a set of TaskID.
+type TaskIDs map[TaskID]struct{}
+
+// TaskIDs retrieves all TaskIDs as an unsorted slice.
+func (t TaskIDs) TaskIDs() []TaskID {
+	return t.UnsortedList()
+}
+
+// TaskIDer can produce a slice of TaskIDs.
+// Default implementations of this are
+// TaskIDs, TaskID and TaskIDSlice
+type TaskIDer interface {
+	// TaskIDs reports all TaskIDs of this TaskIDer.
+	TaskIDs() []TaskID
+}
+
+// NewTaskIDs returns a new set of TaskIDs initialized
+// to contain all TaskIDs of the given TaskIDers.
+func NewTaskIDs(ids ...TaskIDer) TaskIDs {
+	set := make(TaskIDs)
+	set.Insert(ids...)
+	return set
+}
+
+// Insert inserts the TaskIDs of all TaskIDers into
+// this TaskIDs.
+func (t TaskIDs) Insert(iders ...TaskIDer) TaskIDs {
+	for _, ider := range iders {
+		for _, id := range ider.TaskIDs() {
+			t[id] = struct{}{}
+		}
+	}
+	return t
+}
+
+// InsertIf inserts the TaskIDs of all TaskIDers into
+// this TaskIDs if the given condition evaluates to true.
+func (t TaskIDs) InsertIf(condition bool, iders ...TaskIDer) TaskIDs {
+	if condition {
+		return t.Insert(iders...)
+	}
+	return t
+}
+
+// Delete deletes the TaskIDs of all TaskIDers from
+// this TaskIDs.
+func (t TaskIDs) Delete(iders ...TaskIDer) TaskIDs {
+	for _, ider := range iders {
+		for _, id := range ider.TaskIDs() {
+			delete(t, id)
+		}
+	}
+	return t
+}
+
+// Len returns the amount of TaskIDs this contains.
+func (t TaskIDs) Len() int {
+	return len(t)
+}
+
+// Has checks if the given TaskID is present in this set.
+func (t TaskIDs) Has(id TaskID) bool {
+	_, ok := t[id]
+	return ok
+}
+
+// Copy makes a deep copy of this TaskIDs.
+func (t TaskIDs) Copy() TaskIDs {
+	out := make(TaskIDs, len(t))
+	for k := range t {
+		out[k] = struct{}{}
+	}
+	return out
+}
+
+// UnsortedList returns the elements of this in an unordered slice.
+func (t TaskIDs) UnsortedList() TaskIDSlice {
+	out := make([]TaskID, 0, len(t))
+	for k := range t {
+		out = append(out, k)
+	}
+	return out
+}
+
+// List returns the elements of this in an ordered slice.
+func (t TaskIDs) List() TaskIDSlice {
+	out := make(TaskIDSlice, 0, len(t))
+	for k := range t {
+		out = append(out, k)
+	}
+	sort.Sort(out)
+	return out
+}
+
+// UnsortedStringList returns the elements of this in an unordered string slice.
+func (t TaskIDs) UnsortedStringList() []string {
+	out := make([]string, 0, len(t))
+	for k := range t {
+		out = append(out, string(k))
+	}
+	return out
+}
+
+// StringList returns the elements of this in an ordered string slice.
+func (t TaskIDs) StringList() []string {
+	out := t.UnsortedStringList()
+	sort.Strings(out)
+	return out
+}
+
+// TaskIDSlice is a slice of TaskIDs.
+type TaskIDSlice []TaskID
+
+// TaskIDs returns this as a slice of TaskIDs.
+func (t TaskIDSlice) TaskIDs() []TaskID {
+	return t
+}
+
+func (t TaskIDSlice) Len() int {
+	return len(t)
+}
+
+func (t TaskIDSlice) Less(i1, i2 int) bool {
+	return t[i1] < t[i2]
+}
+
+func (t TaskIDSlice) Swap(i1, i2 int) {
+	t[i1], t[i2] = t[i2], t[i1]
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/bootstrap_token.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/bootstrap_token.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	"github.com/gardener/gardener/pkg/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
+	bootstraptokenutil "k8s.io/cluster-bootstrap/token/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// ComputeBootstrapToken computes and creates a new bootstrap token, and returns it.
+func ComputeBootstrapToken(ctx context.Context, c client.Client, tokenID, description string, validity time.Duration) (secret *corev1.Secret, err error) {
+	var (
+		bootstrapTokenSecretKey string
+	)
+
+	secret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bootstraptokenutil.BootstrapTokenSecretName(tokenID),
+			Namespace: metav1.NamespaceSystem,
+		},
+	}
+
+	if err = c.Get(ctx, Key(secret.Namespace, secret.Name), secret); client.IgnoreNotFound(err) != nil {
+		return nil, err
+	}
+
+	validBootstrapTokenSecret, _ := regexp.Compile(`[a-z0-9]{16}`)
+	if existingSecretToken, ok := secret.Data[bootstraptokenapi.BootstrapTokenSecretKey]; ok && validBootstrapTokenSecret.Match(existingSecretToken) {
+		bootstrapTokenSecretKey = string(existingSecretToken)
+	} else {
+		bootstrapTokenSecretKey, err = utils.GenerateRandomStringFromCharset(16, "0123456789abcdefghijklmnopqrstuvwxyz")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	data := map[string][]byte{
+		bootstraptokenapi.BootstrapTokenDescriptionKey:      []byte(description),
+		bootstraptokenapi.BootstrapTokenIDKey:               []byte(tokenID),
+		bootstraptokenapi.BootstrapTokenSecretKey:           []byte(bootstrapTokenSecretKey),
+		bootstraptokenapi.BootstrapTokenExpirationKey:       []byte(metav1.Now().Add(validity).Format(time.RFC3339)),
+		bootstraptokenapi.BootstrapTokenUsageAuthentication: []byte("true"),
+		bootstraptokenapi.BootstrapTokenUsageSigningKey:     []byte("true"),
+	}
+
+	_, err2 := controllerutil.CreateOrUpdate(ctx, c, secret, func() error {
+		secret.Type = bootstraptokenapi.SecretTypeBootstrapToken
+		secret.Data = data
+		return nil
+	})
+
+	return secret, err2
+}
+
+// BootstrapTokenFrom returns the bootstrap token based on the secret data.
+func BootstrapTokenFrom(data map[string][]byte) string {
+	return bootstraptokenutil.TokenFromIDAndSecret(string(data[bootstraptokenapi.BootstrapTokenIDKey]), string(data[bootstraptokenapi.BootstrapTokenSecretKey]))
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/controllerinstallation.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/controllerinstallation.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencore "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+func tryUpdateControllerInstallation(
+	ctx context.Context,
+	g gardencore.Interface,
+	backoff wait.Backoff,
+	meta metav1.ObjectMeta,
+	transform func(*gardencorev1beta1.ControllerInstallation) (*gardencorev1beta1.ControllerInstallation, error),
+	updateFunc func(g gardencore.Interface, controllerInstallation *gardencorev1beta1.ControllerInstallation) (*gardencorev1beta1.ControllerInstallation, error),
+	equalFunc func(cur, updated *gardencorev1beta1.ControllerInstallation) bool,
+) (*gardencorev1beta1.ControllerInstallation, error) {
+
+	var (
+		result  *gardencorev1beta1.ControllerInstallation
+		attempt int
+	)
+	err := retry.RetryOnConflict(backoff, func() (err error) {
+		attempt++
+		cur, err := g.CoreV1beta1().ControllerInstallations().Get(ctx, meta.Name, kubernetes.DefaultGetOptions())
+		if err != nil {
+			return err
+		}
+
+		updated, err := transform(cur.DeepCopy())
+		if err != nil {
+			return err
+		}
+
+		if equalFunc(cur, updated) {
+			result = cur
+			return nil
+		}
+
+		result, err = updateFunc(g, updated)
+		if err != nil {
+			logger.Logger.Errorf("Attempt %d failed to update ControllerInstallation %s due to %v", attempt, cur.Name, err)
+		}
+		return
+	})
+	if err != nil {
+		logger.Logger.Errorf("Failed to update ControllerInstallation %s after %d attempts due to %v", meta.Name, attempt, err)
+	}
+	return result, err
+}
+
+// TryUpdateControllerInstallationWithEqualFunc tries to update the status of the controllerInstallation matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the ControllerInstallation object. If the equal
+// func concludes a semantically equal ControllerInstallation, no update is done and the operation returns normally.
+func TryUpdateControllerInstallationWithEqualFunc(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.ControllerInstallation) (*gardencorev1beta1.ControllerInstallation, error), equal func(cur, updated *gardencorev1beta1.ControllerInstallation) bool) (*gardencorev1beta1.ControllerInstallation, error) {
+	return tryUpdateControllerInstallation(ctx, g, backoff, meta, transform, func(g gardencore.Interface, controllerInstallation *gardencorev1beta1.ControllerInstallation) (*gardencorev1beta1.ControllerInstallation, error) {
+		return g.CoreV1beta1().ControllerInstallations().Update(ctx, controllerInstallation, kubernetes.DefaultUpdateOptions())
+	}, equal)
+}
+
+// TryUpdateControllerInstallation tries to update the status of the controllerInstallation matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the ControllerInstallation object. If the transformation
+// yields a semantically equal ControllerInstallation, no update is done and the operation returns normally.
+func TryUpdateControllerInstallation(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.ControllerInstallation) (*gardencorev1beta1.ControllerInstallation, error)) (*gardencorev1beta1.ControllerInstallation, error) {
+	return TryUpdateControllerInstallationWithEqualFunc(ctx, g, backoff, meta, transform, func(cur, updated *gardencorev1beta1.ControllerInstallation) bool {
+		return equality.Semantic.DeepEqual(cur, updated)
+	})
+}
+
+// TryUpdateControllerInstallationStatusWithEqualFunc tries to update the status of the controllerInstallation matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the ControllerInstallation object. If the equal
+// func concludes a semantically equal ControllerInstallation, no update is done and the operation returns normally.
+func TryUpdateControllerInstallationStatusWithEqualFunc(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.ControllerInstallation) (*gardencorev1beta1.ControllerInstallation, error), equal func(cur, updated *gardencorev1beta1.ControllerInstallation) bool) (*gardencorev1beta1.ControllerInstallation, error) {
+	return tryUpdateControllerInstallation(ctx, g, backoff, meta, transform, func(g gardencore.Interface, controllerInstallation *gardencorev1beta1.ControllerInstallation) (*gardencorev1beta1.ControllerInstallation, error) {
+		return g.CoreV1beta1().ControllerInstallations().UpdateStatus(ctx, controllerInstallation, kubernetes.DefaultUpdateOptions())
+	}, equal)
+}
+
+// TryUpdateControllerInstallationStatus tries to update the status of the controllerInstallation matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the ControllerInstallation object. If the transformation
+// yields a semantically equal ControllerInstallation, no update is done and the operation returns normally.
+func TryUpdateControllerInstallationStatus(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.ControllerInstallation) (*gardencorev1beta1.ControllerInstallation, error)) (*gardencorev1beta1.ControllerInstallation, error) {
+	return TryUpdateControllerInstallationStatusWithEqualFunc(ctx, g, backoff, meta, transform, func(cur, updated *gardencorev1beta1.ControllerInstallation) bool {
+		return equality.Semantic.DeepEqual(cur.Status, updated.Status)
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/controllerregistration.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/controllerregistration.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencore "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+func tryUpdateControllerRegistration(
+	ctx context.Context,
+	g gardencore.Interface,
+	backoff wait.Backoff,
+	meta metav1.ObjectMeta,
+	transform func(*gardencorev1beta1.ControllerRegistration) (*gardencorev1beta1.ControllerRegistration, error),
+	updateFunc func(g gardencore.Interface, controllerRegistration *gardencorev1beta1.ControllerRegistration) (*gardencorev1beta1.ControllerRegistration, error),
+	equalFunc func(cur, updated *gardencorev1beta1.ControllerRegistration) bool,
+) (*gardencorev1beta1.ControllerRegistration, error) {
+
+	var (
+		result  *gardencorev1beta1.ControllerRegistration
+		attempt int
+	)
+	err := retry.RetryOnConflict(backoff, func() (err error) {
+		attempt++
+		cur, err := g.CoreV1beta1().ControllerRegistrations().Get(ctx, meta.Name, kubernetes.DefaultGetOptions())
+		if err != nil {
+			return err
+		}
+
+		updated, err := transform(cur.DeepCopy())
+		if err != nil {
+			return err
+		}
+
+		if equalFunc(cur, updated) {
+			result = cur
+			return nil
+		}
+
+		result, err = updateFunc(g, updated)
+		if err != nil {
+			logger.Logger.Errorf("Attempt %d failed to update ControllerRegistration %s due to %v", attempt, cur.Name, err)
+		}
+		return
+	})
+	if err != nil {
+		logger.Logger.Errorf("Failed to update ControllerRegistration %s after %d attempts due to %v", meta.Name, attempt, err)
+	}
+	return result, err
+}
+
+// TryUpdateControllerRegistrationWithEqualFunc tries to update the status of the controllerRegistration matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the ControllerRegistration object. If the equal
+// func concludes a semantically equal ControllerRegistration, no update is done and the operation returns normally.
+func TryUpdateControllerRegistrationWithEqualFunc(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.ControllerRegistration) (*gardencorev1beta1.ControllerRegistration, error), equal func(cur, updated *gardencorev1beta1.ControllerRegistration) bool) (*gardencorev1beta1.ControllerRegistration, error) {
+	return tryUpdateControllerRegistration(ctx, g, backoff, meta, transform, func(g gardencore.Interface, controllerRegistration *gardencorev1beta1.ControllerRegistration) (*gardencorev1beta1.ControllerRegistration, error) {
+		return g.CoreV1beta1().ControllerRegistrations().Update(ctx, controllerRegistration, kubernetes.DefaultUpdateOptions())
+	}, equal)
+}
+
+// TryUpdateControllerRegistration tries to update the status of the controllerRegistration matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the ControllerRegistration object. If the transformation
+// yields a semantically equal ControllerRegistration, no update is done and the operation returns normally.
+func TryUpdateControllerRegistration(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.ControllerRegistration) (*gardencorev1beta1.ControllerRegistration, error)) (*gardencorev1beta1.ControllerRegistration, error) {
+	return TryUpdateControllerRegistrationWithEqualFunc(ctx, g, backoff, meta, transform, func(cur, updated *gardencorev1beta1.ControllerRegistration) bool {
+		return equality.Semantic.DeepEqual(cur, updated)
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/daemonset.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/daemonset.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// DaemonSetSource is a function that produces a slice of DaemonSets or an error.
+type DaemonSetSource func() ([]*appsv1.DaemonSet, error)
+
+// DaemonSetLister is a lister of DaemonSets.
+type DaemonSetLister interface {
+	// List lists all DaemonSets that match the given selector.
+	List(selector labels.Selector) ([]*appsv1.DaemonSet, error)
+	// DaemonSets yields a DaemonSetNamespaceLister for the given namespace.
+	DaemonSets(namespace string) DaemonSetNamespaceLister
+}
+
+// DaemonSetNamespaceLister is a lister of deployments for a specific namespace.
+type DaemonSetNamespaceLister interface {
+	// List lists all DaemonSets that match the given selector in the current namespace.
+	List(selector labels.Selector) ([]*appsv1.DaemonSet, error)
+	// Get retrieves the DaemonSet with the given name in the current namespace.
+	Get(name string) (*appsv1.DaemonSet, error)
+}
+
+type daemonSetLister struct {
+	source DaemonSetSource
+}
+
+type daemonSetNamespaceLister struct {
+	source    DaemonSetSource
+	namespace string
+}
+
+// NewDaemonSetLister creates a new DaemonSetLister from the given DaemonSetSource.
+func NewDaemonSetLister(source DaemonSetSource) DaemonSetLister {
+	return &daemonSetLister{source: source}
+}
+
+func filterDaemonSets(source DaemonSetSource, filter func(*appsv1.DaemonSet) bool) ([]*appsv1.DaemonSet, error) {
+	daemonSets, err := source()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*appsv1.DaemonSet
+	for _, daemonSet := range daemonSets {
+		if filter(daemonSet) {
+			out = append(out, daemonSet)
+		}
+	}
+	return out, nil
+}
+
+func (d *daemonSetLister) List(selector labels.Selector) ([]*appsv1.DaemonSet, error) {
+	return filterDaemonSets(d.source, func(daemonSet *appsv1.DaemonSet) bool {
+		return selector.Matches(labels.Set(daemonSet.Labels))
+	})
+}
+
+func (d *daemonSetLister) DaemonSets(namespace string) DaemonSetNamespaceLister {
+	return &daemonSetNamespaceLister{
+		source:    d.source,
+		namespace: namespace,
+	}
+}
+
+func (d *daemonSetNamespaceLister) Get(name string) (*appsv1.DaemonSet, error) {
+	daemonSets, err := filterDaemonSets(d.source, func(daemonSet *appsv1.DaemonSet) bool {
+		return daemonSet.Namespace == d.namespace && daemonSet.Name == name
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(daemonSets) == 0 {
+		return nil, apierrors.NewNotFound(appsv1.Resource("DaemonSets"), name)
+	}
+	return daemonSets[0], nil
+}
+
+func (d *daemonSetNamespaceLister) List(selector labels.Selector) ([]*appsv1.DaemonSet, error) {
+	return filterDaemonSets(d.source, func(daemonSet *appsv1.DaemonSet) bool {
+		return daemonSet.Namespace == d.namespace && selector.Matches(labels.Set(daemonSet.Labels))
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/deployment.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/deployment.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/Masterminds/semver"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ValidDeploymentContainerImageVersion validates compliance of a deployment container image to a minimum version
+func ValidDeploymentContainerImageVersion(deploymentToCheck *appsv1.Deployment, containerName, minimumVersion string) (bool, error) {
+	containers := deploymentToCheck.Spec.Template.Spec.Containers
+	getContainer := func(container string) (*corev1.Container, error) {
+		for _, container := range containers {
+			if container.Name == containerName {
+				return &container, nil
+			}
+		}
+		return nil, fmt.Errorf("container %q does not belong to this deployment", container)
+	}
+
+	containerToCheck, err := getContainer(containerName)
+	if err != nil {
+		return false, err
+	}
+	actualVersion, err := semver.NewVersion(strings.Split(containerToCheck.Image, ":")[1])
+	if err != nil {
+		return false, err
+	}
+	minVersion, err := semver.NewVersion(minimumVersion)
+	if err != nil {
+		return false, err
+	}
+	if actualVersion.LessThan(minVersion) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// DeploymentSource is a function that produces a slice of Deployments or an error.
+type DeploymentSource func() ([]*appsv1.Deployment, error)
+
+// DeploymentLister is a lister of Deployments.
+type DeploymentLister interface {
+	// List lists all Deployments that match the given selector.
+	List(selector labels.Selector) ([]*appsv1.Deployment, error)
+	// Deployments yields a DeploymentNamespaceLister for the given namespace.
+	Deployments(namespace string) DeploymentNamespaceLister
+}
+
+// DeploymentNamespaceLister is a lister of deployments for a specific namespace.
+type DeploymentNamespaceLister interface {
+	// List lists all Deployments that match the given selector in the current namespace.
+	List(selector labels.Selector) ([]*appsv1.Deployment, error)
+	// Get retrieves the Deployment with the given name in the current namespace.
+	Get(name string) (*appsv1.Deployment, error)
+}
+
+type deploymentLister struct {
+	source DeploymentSource
+}
+
+type deploymentNamespaceLister struct {
+	source    DeploymentSource
+	namespace string
+}
+
+// NewDeploymentLister creates a new DeploymentLister from the given DeploymentSource.
+func NewDeploymentLister(source DeploymentSource) DeploymentLister {
+	return &deploymentLister{source: source}
+}
+
+func filterDeployments(source DeploymentSource, filter func(*appsv1.Deployment) bool) ([]*appsv1.Deployment, error) {
+	deployments, err := source()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*appsv1.Deployment
+	for _, deployment := range deployments {
+		if filter(deployment) {
+			out = append(out, deployment)
+		}
+	}
+	return out, nil
+}
+
+func (d *deploymentLister) List(selector labels.Selector) ([]*appsv1.Deployment, error) {
+	return filterDeployments(d.source, func(deployment *appsv1.Deployment) bool {
+		return selector.Matches(labels.Set(deployment.Labels))
+	})
+}
+
+func (d *deploymentLister) Deployments(namespace string) DeploymentNamespaceLister {
+	return &deploymentNamespaceLister{
+		source:    d.source,
+		namespace: namespace,
+	}
+}
+
+func (d *deploymentNamespaceLister) Get(name string) (*appsv1.Deployment, error) {
+	deployments, err := filterDeployments(d.source, func(deployment *appsv1.Deployment) bool {
+		return deployment.Namespace == d.namespace && deployment.Name == name
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(deployments) == 0 {
+		return nil, apierrors.NewNotFound(appsv1.Resource("Deployments"), name)
+	}
+	return deployments[0], nil
+}
+
+func (d *deploymentNamespaceLister) List(selector labels.Selector) ([]*appsv1.Deployment, error) {
+	return filterDeployments(d.source, func(deployment *appsv1.Deployment) bool {
+		return deployment.Namespace == d.namespace && selector.Matches(labels.Set(deployment.Labels))
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/etcd.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/etcd.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// EtcdSource is a function that produces a slice of Etcds or an error.
+type EtcdSource func() ([]*druidv1alpha1.Etcd, error)
+
+// EtcdLister is a lister of Etcds.
+type EtcdLister interface {
+	// List lists all Etcds that match the given selector.
+	List(selector labels.Selector) ([]*druidv1alpha1.Etcd, error)
+	// Etcds yields a EtcdNamespaceLister for the given namespace.
+	Etcds(namespace string) EtcdNamespaceLister
+}
+
+// EtcdNamespaceLister is a lister of etcds for a specific namespace.
+type EtcdNamespaceLister interface {
+	// List lists all Etcds that match the given selector in the current namespace.
+	List(selector labels.Selector) ([]*druidv1alpha1.Etcd, error)
+	// Get retrieves the Etcd with the given name in the current namespace.
+	Get(name string) (*druidv1alpha1.Etcd, error)
+}
+
+type etcdLister struct {
+	source EtcdSource
+}
+
+type etcdNamespaceLister struct {
+	source    EtcdSource
+	namespace string
+}
+
+// NewEtcdLister creates a new EtcdLister from the given EtcdSource.
+func NewEtcdLister(source EtcdSource) EtcdLister {
+	return &etcdLister{source: source}
+}
+
+func filterEtcds(source EtcdSource, filter func(*druidv1alpha1.Etcd) bool) ([]*druidv1alpha1.Etcd, error) {
+	etcds, err := source()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*druidv1alpha1.Etcd
+	for _, etcd := range etcds {
+		if filter(etcd) {
+			out = append(out, etcd)
+		}
+	}
+	return out, nil
+}
+
+func (d *etcdLister) List(selector labels.Selector) ([]*druidv1alpha1.Etcd, error) {
+	return filterEtcds(d.source, func(node *druidv1alpha1.Etcd) bool {
+		return selector.Matches(labels.Set(node.Labels))
+	})
+}
+
+func (d *etcdLister) Etcds(namespace string) EtcdNamespaceLister {
+	return &etcdNamespaceLister{
+		source:    d.source,
+		namespace: namespace,
+	}
+}
+
+func (d *etcdNamespaceLister) Get(name string) (*druidv1alpha1.Etcd, error) {
+	etcds, err := filterEtcds(d.source, func(etcd *druidv1alpha1.Etcd) bool {
+		return etcd.Namespace == d.namespace && etcd.Name == name
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(etcds) == 0 {
+		return nil, apierrors.NewNotFound(appsv1.Resource("Etcds"), name)
+	}
+	return etcds[0], nil
+}
+
+func (d *etcdNamespaceLister) List(selector labels.Selector) ([]*druidv1alpha1.Etcd, error) {
+	return filterEtcds(d.source, func(etcd *druidv1alpha1.Etcd) bool {
+		return etcd.Namespace == d.namespace && selector.Matches(labels.Set(etcd.Labels))
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/kubernetes.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/kubernetes.go
@@ -1,0 +1,562 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/retry"
+
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// TruncateLabelValue truncates a string at 63 characters so it's suitable for a label value.
+func TruncateLabelValue(s string) string {
+	if len(s) > 63 {
+		return s[:63]
+	}
+	return s
+}
+
+// SetMetaDataLabel sets the key value pair in the labels section of the given Object.
+// If the given Object did not yet have labels, they are initialized.
+func SetMetaDataLabel(meta metav1.Object, key, value string) {
+	labels := meta.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[key] = value
+	meta.SetLabels(labels)
+}
+
+// SetMetaDataAnnotation sets the annotation on the given object.
+// If the given Object did not yet have annotations, they are initialized.
+func SetMetaDataAnnotation(meta metav1.Object, key, value string) {
+	annotations := meta.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[key] = value
+	meta.SetAnnotations(annotations)
+}
+
+// HasMetaDataAnnotation checks if the passed meta object has the given key, value set in the annotations section.
+func HasMetaDataAnnotation(meta metav1.Object, key, value string) bool {
+	val, ok := meta.GetAnnotations()[key]
+	return ok && val == value
+}
+
+func nameAndNamespace(namespaceOrName string, nameOpt ...string) (namespace, name string) {
+	if len(nameOpt) > 1 {
+		panic(fmt.Sprintf("more than name/namespace for key specified: %s/%v", namespaceOrName, nameOpt))
+	}
+	if len(nameOpt) == 0 {
+		name = namespaceOrName
+		return
+	}
+	namespace = namespaceOrName
+	name = nameOpt[0]
+	return
+}
+
+// Key creates a new client.ObjectKey from the given parameters.
+// There are only two ways to call this function:
+// - If only namespaceOrName is set, then a client.ObjectKey with name set to namespaceOrName is returned.
+// - If namespaceOrName and one nameOpt is given, then a client.ObjectKey with namespace set to namespaceOrName
+//   and name set to nameOpt[0] is returned.
+// For all other cases, this method panics.
+func Key(namespaceOrName string, nameOpt ...string) client.ObjectKey {
+	namespace, name := nameAndNamespace(namespaceOrName, nameOpt...)
+	return client.ObjectKey{Namespace: namespace, Name: name}
+}
+
+// ObjectMeta creates a new metav1.ObjectMeta from the given parameters.
+// There are only two ways to call this function:
+// - If only namespaceOrName is set, then a metav1.ObjectMeta with name set to namespaceOrName is returned.
+// - If namespaceOrName and one nameOpt is given, then a metav1.ObjectMeta with namespace set to namespaceOrName
+//   and name set to nameOpt[0] is returned.
+// For all other cases, this method panics.
+func ObjectMeta(namespaceOrName string, nameOpt ...string) metav1.ObjectMeta {
+	namespace, name := nameAndNamespace(namespaceOrName, nameOpt...)
+	return metav1.ObjectMeta{Namespace: namespace, Name: name}
+}
+
+// ObjectMetaFromKey returns an ObjectMeta with the namespace and name set to the values from the key.
+func ObjectMetaFromKey(key client.ObjectKey) metav1.ObjectMeta {
+	return ObjectMeta(key.Namespace, key.Name)
+}
+
+// WaitUntilResourceDeleted deletes the given resource and then waits until it has been deleted. It respects the
+// given interval and timeout.
+func WaitUntilResourceDeleted(ctx context.Context, c client.Client, obj client.Object, interval time.Duration) error {
+	key := client.ObjectKeyFromObject(obj)
+	return retry.Until(ctx, interval, func(ctx context.Context) (done bool, err error) {
+		if err := c.Get(ctx, key, obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				return retry.Ok()
+			}
+			return retry.SevereError(err)
+		}
+		return retry.MinorError(fmt.Errorf("resource %s still exists", key.String()))
+	})
+}
+
+// WaitUntilResourcesDeleted waits until the given resources are gone.
+// It respects the given interval and timeout.
+func WaitUntilResourcesDeleted(ctx context.Context, c client.Client, list client.ObjectList, interval time.Duration, opts ...client.ListOption) error {
+	return retry.Until(ctx, interval, func(ctx context.Context) (done bool, err error) {
+		if err := c.List(ctx, list, opts...); err != nil {
+			return retry.SevereError(err)
+		}
+		if meta.LenList(list) == 0 {
+			return retry.Ok()
+		}
+		var remainingItems []string
+		acc := meta.NewAccessor()
+		if err := meta.EachListItem(list, func(remainingObj runtime.Object) error {
+			name, err := acc.Name(remainingObj)
+			if err != nil {
+				return err
+			}
+			remainingItems = append(remainingItems, name)
+			return nil
+		}); err != nil {
+			return retry.SevereError(err)
+		}
+		return retry.MinorError(fmt.Errorf("resource(s) %s still exists", remainingItems))
+	})
+}
+
+// WaitUntilResourceDeletedWithDefaults deletes the given resource and then waits until it has been deleted. It
+// uses a default interval and timeout
+func WaitUntilResourceDeletedWithDefaults(ctx context.Context, c client.Client, obj client.Object) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	return WaitUntilResourceDeleted(ctx, c, obj, 5*time.Second)
+}
+
+// WaitUntilLoadBalancerIsReady waits until the given external load balancer has
+// been created (i.e., its ingress information has been updated in the service status).
+func WaitUntilLoadBalancerIsReady(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string, timeout time.Duration, logger *logrus.Entry) (string, error) {
+	var (
+		loadBalancerIngress string
+		service             = &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	)
+	if err := retry.UntilTimeout(ctx, 5*time.Second, timeout, func(ctx context.Context) (done bool, err error) {
+		loadBalancerIngress, err = GetLoadBalancerIngress(ctx, kubeClient.Client(), service)
+		if err != nil {
+			logger.Infof("Waiting until the %s service deployed is ready...", name)
+			// TODO(AC): This is a quite optimistic check / we should differentiate here
+			return retry.MinorError(fmt.Errorf("%s service deployed is not ready: %v", name, err))
+		}
+		return retry.Ok()
+	}); err != nil {
+		const eventsLimit = 2
+
+		eventsErrorMessage, err2 := FetchEventMessages(ctx, kubeClient.DirectClient(), service, corev1.EventTypeWarning, eventsLimit)
+		if err2 != nil {
+			logger.Errorf("error %q occured while fetching events for error %q", err2, err)
+			return "", fmt.Errorf("'%w' occurred but could not fetch events for more information", err)
+		}
+		if eventsErrorMessage != "" {
+			errorMessage := err.Error() + "\n\n" + eventsErrorMessage
+			return "", errors.New(errorMessage)
+		}
+		return "", err
+	}
+
+	return loadBalancerIngress, nil
+}
+
+// GetLoadBalancerIngress takes a context, a client, a service object. It gets the `service` and
+// queries for a load balancer's technical name (ip address or hostname). It returns the value of the technical name
+// whereby it always prefers the hostname (if given) over the IP address.
+// The passed `service` instance is updated with the information received from the API server.
+func GetLoadBalancerIngress(ctx context.Context, c client.Client, service *corev1.Service) (string, error) {
+	if err := c.Get(ctx, client.ObjectKeyFromObject(service), service); err != nil {
+		return "", err
+	}
+
+	var (
+		serviceStatusIngress = service.Status.LoadBalancer.Ingress
+		length               = len(serviceStatusIngress)
+	)
+
+	switch {
+	case length == 0:
+		return "", errors.New("`.status.loadBalancer.ingress[]` has no elements yet, i.e. external load balancer has not been created")
+	case serviceStatusIngress[length-1].Hostname != "":
+		return serviceStatusIngress[length-1].Hostname, nil
+	case serviceStatusIngress[length-1].IP != "":
+		return serviceStatusIngress[length-1].IP, nil
+	}
+
+	return "", errors.New("`.status.loadBalancer.ingress[]` has an element which does neither contain `.ip` nor `.hostname`")
+}
+
+// LookupObject retrieves an obj for the given object key dealing with potential stale cache that still does not contain the obj.
+// It first tries to retrieve the obj using the given cached client.
+// If the object key is not found, then it does live lookup from the API server using the given apiReader.
+func LookupObject(ctx context.Context, c client.Client, apiReader client.Reader, key client.ObjectKey, obj client.Object) error {
+	err := c.Get(ctx, key, obj)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	// Try to get the obj, now by doing a live lookup instead of relying on the cache.
+	return apiReader.Get(ctx, key, obj)
+}
+
+// FeatureGatesToCommandLineParameter transforms feature gates given as string/bool map to a command line parameter that
+// is understood by Kubernetes components.
+func FeatureGatesToCommandLineParameter(fg map[string]bool) string {
+	if len(fg) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(fg))
+	for k := range fg {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := "--feature-gates="
+	for _, key := range keys {
+		out += fmt.Sprintf("%s=%s,", key, strconv.FormatBool(fg[key]))
+	}
+	return out
+}
+
+// ReconcileServicePorts reconciles the existing service ports with the desired ports. This means that it takes the
+// existing port (identified by name), and applies the settings from the desired port to it. This way it can keep fields
+// that are defaulted by controllers, e.g. the node port. However, it does not keep ports that are not part of the
+// desired list.
+func ReconcileServicePorts(existingPorts []corev1.ServicePort, desiredPorts []corev1.ServicePort) []corev1.ServicePort {
+	var out []corev1.ServicePort
+
+	for _, desiredPort := range desiredPorts {
+		var port corev1.ServicePort
+
+		for _, existingPort := range existingPorts {
+			if existingPort.Name == desiredPort.Name {
+				port = existingPort
+				break
+			}
+		}
+
+		port.Name = desiredPort.Name
+		if len(desiredPort.Protocol) > 0 {
+			port.Protocol = desiredPort.Protocol
+		}
+		if desiredPort.Port != 0 {
+			port.Port = desiredPort.Port
+		}
+		if desiredPort.TargetPort.Type == intstr.Int || desiredPort.TargetPort.Type == intstr.String {
+			port.TargetPort = desiredPort.TargetPort
+		}
+		if desiredPort.NodePort != 0 {
+			port.NodePort = desiredPort.NodePort
+		}
+
+		out = append(out, port)
+	}
+
+	return out
+}
+
+// FetchEventMessages gets events for the given object of the given `eventType` and returns them as a formatted output.
+// The function expects that the given `obj` is specified with a proper `metav1.TypeMeta`.
+func FetchEventMessages(ctx context.Context, c client.Client, obj client.Object, eventType string, eventsLimit int) (string, error) {
+	if c.Scheme() == nil {
+		return "", errors.New("scheme is not provided")
+	}
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme())
+	if err != nil {
+		return "", fmt.Errorf("failed identify GVK for object: %w", err)
+	}
+
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	if apiVersion == "" {
+		return "", fmt.Errorf("apiVersion not specified for object %s/%s", obj.GetNamespace(), obj.GetName())
+	}
+	if kind == "" {
+		return "", fmt.Errorf("kind not specified for object %s/%s", obj.GetNamespace(), obj.GetName())
+	}
+	fieldSelector := client.MatchingFields{
+		"involvedObject.apiVersion": apiVersion,
+		"involvedObject.kind":       kind,
+		"involvedObject.name":       obj.GetName(),
+		"involvedObject.namespace":  obj.GetNamespace(),
+		"type":                      eventType,
+	}
+	eventList := &corev1.EventList{}
+	if err := c.List(ctx, eventList, fieldSelector); err != nil {
+		return "", fmt.Errorf("error '%v' occurred while fetching more details", err)
+	}
+
+	if len(eventList.Items) > 0 {
+		return buildEventsErrorMessage(eventList.Items, eventsLimit), nil
+	}
+	return "", nil
+}
+
+func buildEventsErrorMessage(events []corev1.Event, eventsLimit int) string {
+	sortByLastTimestamp := func(o1, o2 client.Object) bool {
+		obj1, ok1 := o1.(*corev1.Event)
+		obj2, ok2 := o2.(*corev1.Event)
+
+		if !ok1 || !ok2 {
+			return false
+		}
+
+		return obj1.LastTimestamp.Time.Before(obj2.LastTimestamp.Time)
+	}
+
+	list := &corev1.EventList{Items: events}
+	SortBy(sortByLastTimestamp).Sort(list)
+	events = list.Items
+
+	if len(events) > eventsLimit {
+		events = events[len(events)-eventsLimit:]
+	}
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "-> Events:")
+	for _, event := range events {
+		var interval string
+		if event.Count > 1 {
+			interval = fmt.Sprintf("%s ago (x%d over %s)", translateTimestampSince(event.LastTimestamp), event.Count, translateTimestampSince(event.FirstTimestamp))
+		} else {
+			interval = fmt.Sprintf("%s ago", translateTimestampSince(event.FirstTimestamp))
+			if event.FirstTimestamp.IsZero() {
+				interval = fmt.Sprintf("%s ago", translateMicroTimestampSince(event.EventTime))
+			}
+		}
+		source := event.Source.Component
+		if source == "" {
+			source = event.ReportingController
+		}
+
+		fmt.Fprintf(&builder, "\n* %s reported %s: %s", source, interval, event.Message)
+	}
+
+	return builder.String()
+}
+
+// translateTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateTimestampSince(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+// translateMicroTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateMicroTimestampSince(timestamp metav1.MicroTime) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+// MergeOwnerReferences merges the newReferences with the list of existing references.
+func MergeOwnerReferences(references []metav1.OwnerReference, newReferences ...metav1.OwnerReference) []metav1.OwnerReference {
+	uids := make(map[types.UID]struct{})
+	for _, reference := range references {
+		uids[reference.UID] = struct{}{}
+	}
+
+	for _, newReference := range newReferences {
+		if _, ok := uids[newReference.UID]; !ok {
+			references = append(references, newReference)
+		}
+	}
+
+	return references
+}
+
+// OwnedBy checks if the given object's owner reference contains an entry with the provided attributes.
+func OwnedBy(obj client.Object, apiVersion, kind, name string, uid types.UID) bool {
+	for _, ownerReference := range obj.GetOwnerReferences() {
+		return ownerReference.APIVersion == apiVersion &&
+			ownerReference.Kind == kind &&
+			ownerReference.Name == name &&
+			ownerReference.UID == uid
+	}
+
+	return false
+}
+
+// NewestObject returns the most recently created object based on the provided list object type. If a filter function
+// is provided then it will be applied for each object right after listing all objects. If no object remains then nil
+// is returned. The Items field in the list object will be populated with the result returned from the server after
+// applying the filter function (if provided).
+func NewestObject(ctx context.Context, c client.Client, listObj client.ObjectList, filterFn func(client.Object) bool, listOpts ...client.ListOption) (client.Object, error) {
+	if err := c.List(ctx, listObj, listOpts...); err != nil {
+		return nil, err
+	}
+
+	if filterFn != nil {
+		var items []runtime.Object
+
+		if err := meta.EachListItem(listObj, func(object runtime.Object) error {
+			obj, ok := object.(client.Object)
+			if !ok {
+				return fmt.Errorf("%T does not implement client.Object", object)
+			}
+
+			if filterFn(obj) {
+				items = append(items, obj)
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+
+		if err := meta.SetList(listObj, items); err != nil {
+			return nil, err
+		}
+	}
+
+	if meta.LenList(listObj) == 0 {
+		return nil, nil
+	}
+
+	ByCreationTimestamp().Sort(listObj)
+
+	items, err := meta.ExtractList(listObj)
+	if err != nil {
+		return nil, err
+	}
+
+	newestObject := items[meta.LenList(listObj)-1]
+	obj, ok := newestObject.(client.Object)
+	if !ok {
+		return nil, fmt.Errorf("%T does not implement client.Object", newestObject)
+	}
+
+	return obj, nil
+}
+
+// NewestPodForDeployment returns the most recently created Pod object for the given deployment.
+func NewestPodForDeployment(ctx context.Context, c client.Client, deployment *appsv1.Deployment) (*corev1.Pod, error) {
+	listOpts := []client.ListOption{client.InNamespace(deployment.Namespace)}
+	if deployment.Spec.Selector != nil {
+		listOpts = append(listOpts, client.MatchingLabels(deployment.Spec.Selector.MatchLabels))
+	}
+
+	replicaSet, err := NewestObject(
+		ctx,
+		c,
+		&appsv1.ReplicaSetList{},
+		func(obj client.Object) bool {
+			return OwnedBy(obj, appsv1.SchemeGroupVersion.String(), "Deployment", deployment.Name, deployment.UID)
+		},
+		listOpts...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if replicaSet == nil {
+		return nil, nil
+	}
+
+	newestReplicaSet, ok := replicaSet.(*appsv1.ReplicaSet)
+	if !ok {
+		return nil, fmt.Errorf("object is not of type *appsv1.ReplicaSet but %T", replicaSet)
+	}
+
+	pod, err := NewestObject(
+		ctx,
+		c,
+		&corev1.PodList{},
+		func(obj client.Object) bool {
+			return OwnedBy(obj, appsv1.SchemeGroupVersion.String(), "ReplicaSet", newestReplicaSet.Name, newestReplicaSet.UID)
+		},
+		listOpts...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if pod == nil {
+		return nil, nil
+	}
+
+	newestPod, ok := pod.(*corev1.Pod)
+	if !ok {
+		return nil, fmt.Errorf("object is not of type *corev1.Pod but %T", pod)
+	}
+
+	return newestPod, nil
+}
+
+// MostRecentCompleteLogs returns the logs of the pod/container in case it is not running. If the pod/container is
+// running then the logs of the previous pod/container are being returned.
+func MostRecentCompleteLogs(
+	ctx context.Context,
+	podInterface corev1client.PodInterface,
+	pod *corev1.Pod,
+	containerName string,
+	tailLines *int64,
+) (
+	string,
+	error,
+) {
+	previousLogs := false
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerName == "" || containerStatus.Name == containerName {
+			previousLogs = containerStatus.State.Running != nil
+			break
+		}
+	}
+
+	logs, err := kubernetes.GetPodLogs(ctx, podInterface, pod.Name, &corev1.PodLogOptions{
+		Container: containerName,
+		TailLines: tailLines,
+		Previous:  previousLogs,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return string(logs), nil
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/leaderelection.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/leaderelection.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReadLeaderElectionRecord returns the leader election record for a given lock type and a namespace/name combination.
+func ReadLeaderElectionRecord(ctx context.Context, client client.Client, lock, namespace, name string) (*resourcelock.LeaderElectionRecord, error) {
+	switch lock {
+	case resourcelock.EndpointsResourceLock:
+		endpoint := &corev1.Endpoints{}
+		if err := client.Get(ctx, Key(namespace, name), endpoint); err != nil {
+			return nil, err
+		}
+		return leaderElectionRecordFromAnnotations(endpoint.Annotations)
+
+	case resourcelock.ConfigMapsResourceLock:
+		configmap := &corev1.ConfigMap{}
+		if err := client.Get(ctx, Key(namespace, name), configmap); err != nil {
+			return nil, err
+		}
+		return leaderElectionRecordFromAnnotations(configmap.Annotations)
+
+	case resourcelock.LeasesResourceLock:
+		lease := &coordinationv1.Lease{}
+		if err := client.Get(ctx, Key(namespace, name), lease); err != nil {
+			return nil, err
+		}
+		return resourcelock.LeaseSpecToLeaderElectionRecord(&lease.Spec), nil
+	}
+
+	return nil, fmt.Errorf("unknown lock type: %s", lock)
+}
+
+func leaderElectionRecordFromAnnotations(annotations map[string]string) (*resourcelock.LeaderElectionRecord, error) {
+	var leaderElectionRecord resourcelock.LeaderElectionRecord
+
+	leaderElection, ok := annotations[resourcelock.LeaderElectionRecordAnnotationKey]
+	if !ok {
+		return nil, fmt.Errorf("could not find key %q in annotations", resourcelock.LeaderElectionRecordAnnotationKey)
+	}
+
+	if err := json.Unmarshal([]byte(leaderElection), &leaderElectionRecord); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal leader election record: %+v", err)
+	}
+
+	return &leaderElectionRecord, nil
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/managedseed.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/managedseed.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	gardenseedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+)
+
+// GetManagedSeed gets the ManagedSeed resource for the given shoot namespace and name,
+// by searching for all ManagedSeeds in the shoot namespace that have spec.shoot.name set to the shoot name.
+// If no such ManagedSeeds are found, nil is returned.
+func GetManagedSeed(ctx context.Context, seedManagementClient gardenseedmanagementclientset.Interface, shootNamespace, shootName string) (*seedmanagementv1alpha1.ManagedSeed, error) {
+	managedSeedList, err := seedManagementClient.SeedmanagementV1alpha1().ManagedSeeds(shootNamespace).List(ctx, metav1.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{seedmanagement.ManagedSeedShootName: shootName}).String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(managedSeedList.Items) == 0 {
+		return nil, nil
+	}
+	if len(managedSeedList.Items) > 1 {
+		return nil, fmt.Errorf("found more than one ManagedSeed objects for shoot %s/%s", shootNamespace, shootName)
+	}
+	return &managedSeedList.Items[0], nil
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/namespace.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/namespace.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+func tryUpdateNamespace(
+	ctx context.Context,
+	k k8s.Interface,
+	backoff wait.Backoff,
+	meta metav1.ObjectMeta,
+	transform func(*corev1.Namespace) (*corev1.Namespace, error),
+	updateFunc func(k k8s.Interface, namespace *corev1.Namespace) (*corev1.Namespace, error),
+	exitEarlyFunc func(cur, updated *corev1.Namespace) bool,
+) (*corev1.Namespace, error) {
+	var (
+		result  *corev1.Namespace
+		attempt int
+	)
+
+	err := retry.RetryOnConflict(backoff, func() (err error) {
+		attempt++
+		cur, err := k.CoreV1().Namespaces().Get(ctx, meta.Name, kubernetes.DefaultGetOptions())
+		if err != nil {
+			return err
+		}
+
+		updated, err := transform(cur.DeepCopy())
+		if err != nil {
+			return err
+		}
+
+		if exitEarlyFunc(cur, updated) {
+			result = cur
+			return nil
+		}
+
+		result, err = updateFunc(k, updated)
+		if err != nil {
+			logger.Logger.Errorf("Attempt %d failed to update Namespace %s due to %v", attempt, cur.Name, err)
+		}
+		return
+	})
+	if err != nil {
+		logger.Logger.Errorf("Failed to update Namespace %s after %d attempts due to %v", meta.Name, attempt, err)
+	}
+
+	return result, err
+}
+
+// TryUpdateNamespace tries to update a namespace and retries the operation with the given <backoff>.
+func TryUpdateNamespace(ctx context.Context, k k8s.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*corev1.Namespace) (*corev1.Namespace, error)) (*corev1.Namespace, error) {
+	return tryUpdateNamespace(ctx, k, backoff, meta, transform, func(k k8s.Interface, namespace *corev1.Namespace) (*corev1.Namespace, error) {
+		return k.CoreV1().Namespaces().Update(ctx, namespace, kubernetes.DefaultUpdateOptions())
+	}, func(cur, updated *corev1.Namespace) bool {
+		return equality.Semantic.DeepEqual(cur, updated)
+	})
+}
+
+// TryUpdateNamespaceLabels tries to update a namespace's labels and retries the operation with the given <backoff>.
+func TryUpdateNamespaceLabels(ctx context.Context, k k8s.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*corev1.Namespace) (*corev1.Namespace, error)) (*corev1.Namespace, error) {
+	return tryUpdateNamespace(ctx, k, backoff, meta, transform, func(k k8s.Interface, namespace *corev1.Namespace) (*corev1.Namespace, error) {
+		return k.CoreV1().Namespaces().Update(ctx, namespace, kubernetes.DefaultUpdateOptions())
+	}, func(cur, updated *corev1.Namespace) bool {
+		return equality.Semantic.DeepEqual(cur.Labels, updated.Labels)
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/object.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/object.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/utils/flow"
+)
+
+// ObjectName returns the name of the given object in the format <namespace>/<name>
+func ObjectName(obj client.Object) string {
+	return client.ObjectKeyFromObject(obj).String()
+}
+
+// DeleteObjects deletes a list of Kubernetes objects.
+func DeleteObjects(ctx context.Context, c client.Client, objects ...client.Object) error {
+	for _, obj := range objects {
+		if err := DeleteObject(ctx, c, obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteObject deletes a Kubernetes object. It ignores 'not found' and 'no match' errors.
+func DeleteObject(ctx context.Context, c client.Client, object client.Object) error {
+	if err := c.Delete(ctx, object); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
+		return err
+	}
+	return nil
+}
+
+// DeleteObjectsFromListConditionally takes a Kubernetes List object. It iterates over its items and, if provided,
+// executes the predicate function. If it evaluates to true then the object will be deleted.
+func DeleteObjectsFromListConditionally(ctx context.Context, c client.Client, listObj client.ObjectList, predicateFn func(runtime.Object) bool) error {
+	fns := make([]flow.TaskFn, 0, meta.LenList(listObj))
+
+	if err := meta.EachListItem(listObj, func(obj runtime.Object) error {
+		if predicateFn == nil || predicateFn(obj) {
+			fns = append(fns, func(ctx context.Context) error {
+				return client.IgnoreNotFound(c.Delete(ctx, obj.(client.Object)))
+			})
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/patch.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/patch.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	jsoniter "github.com/json-iterator/go"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var json = jsoniter.ConfigFastest
+
+// TryPatch tries to apply the given transformation function onto the given object, and to patch it afterwards with optimistic locking.
+// It retries the patch with an exponential backoff.
+func TryPatch(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, transform func() error) error {
+	return tryPatch(ctx, backoff, c, obj, c.Patch, transform)
+}
+
+// TryPatchStatus tries to apply the given transformation function onto the given object, and to patch its
+// status afterwards with optimistic locking. It retries the status patch with an exponential backoff.
+func TryPatchStatus(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, transform func() error) error {
+	return tryPatch(ctx, backoff, c, obj, c.Status().Patch, transform)
+}
+
+func tryPatch(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, patchFunc func(context.Context, client.Object, client.Patch, ...client.PatchOption) error, transform func() error) error {
+	resetCopy := obj.DeepCopyObject()
+	return exponentialBackoff(ctx, backoff, func() (bool, error) {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return false, err
+		}
+		beforeTransform := obj.DeepCopyObject()
+		if err := transform(); err != nil {
+			return false, err
+		}
+
+		if reflect.DeepEqual(obj, beforeTransform) {
+			return true, nil
+		}
+
+		patch := client.MergeFromWithOptions(beforeTransform, client.MergeFromWithOptimisticLock{})
+
+		if err := patchFunc(ctx, obj, patch); err != nil {
+			if apierrors.IsConflict(err) {
+				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+// CreateTwoWayMergePatch creates a two way merge patch of the given objects.
+// The two objects have to be pointers implementing the interfaces.
+func CreateTwoWayMergePatch(obj1 metav1.Object, obj2 metav1.Object) ([]byte, error) {
+	t1, t2 := reflect.TypeOf(obj1), reflect.TypeOf(obj2)
+	if t1 != t2 {
+		return nil, fmt.Errorf("cannot patch two objects of different type: %q - %q", t1, t2)
+	}
+	if t1.Kind() != reflect.Ptr {
+		return nil, fmt.Errorf("type has to be of kind pointer but got %q", t1)
+	}
+
+	obj1Data, err := json.Marshal(obj1)
+	if err != nil {
+		return nil, err
+	}
+
+	obj2Data, err := json.Marshal(obj2)
+	if err != nil {
+		return nil, err
+	}
+
+	dataStructType := t1.Elem()
+	dataStruct := reflect.New(dataStructType).Elem().Interface()
+
+	return strategicpatch.CreateTwoWayMergePatch(obj1Data, obj2Data, dataStruct)
+}
+
+// IsEmptyPatch checks if the given patch is empty. A patch is considered empty if it is
+// the empty string or if it json-decodes to an empty json map.
+func IsEmptyPatch(patch []byte) bool {
+	if len(strings.TrimSpace(string(patch))) == 0 {
+		return true
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(patch, &m); err != nil {
+		return false
+	}
+
+	return len(m) == 0
+}
+
+// SubmitEmptyPatch submits an empty patch to the given `obj` with the given `client` instance.
+func SubmitEmptyPatch(ctx context.Context, c client.Client, obj client.Object) error {
+	return c.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType, []byte("{}")))
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/project.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/project.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencore "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+func tryUpdateProject(
+	ctx context.Context,
+	g gardencore.Interface,
+	backoff wait.Backoff,
+	meta metav1.ObjectMeta,
+	transform func(*gardencorev1beta1.Project) (*gardencorev1beta1.Project, error),
+	updateFunc func(g gardencore.Interface, project *gardencorev1beta1.Project) (*gardencorev1beta1.Project, error),
+	compare func(cur, updated *gardencorev1beta1.Project) bool,
+) (*gardencorev1beta1.Project, error) {
+	var (
+		result  *gardencorev1beta1.Project
+		attempt int
+	)
+
+	err := retry.RetryOnConflict(backoff, func() (err error) {
+		attempt++
+		cur, err := g.CoreV1beta1().Projects().Get(ctx, meta.Name, kubernetes.DefaultGetOptions())
+		if err != nil {
+			return err
+		}
+
+		updated, err := transform(cur.DeepCopy())
+		if err != nil {
+			return err
+		}
+
+		if compare(cur, updated) {
+			result = cur
+			return nil
+		}
+
+		result, err = updateFunc(g, updated)
+		if err != nil {
+			logger.Logger.Errorf("Attempt %d failed to update Project %s due to %v", attempt, cur.Name, err)
+		}
+		return
+	})
+	if err != nil {
+		logger.Logger.Errorf("Failed to update Project %s after %d attempts due to %v", meta.Name, attempt, err)
+	}
+
+	return result, err
+}
+
+// TryUpdateProject tries to update a project and retries the operation with the given <backoff>.
+func TryUpdateProject(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Project) (*gardencorev1beta1.Project, error)) (*gardencorev1beta1.Project, error) {
+	return tryUpdateProject(ctx, g, backoff, meta, transform, func(g gardencore.Interface, project *gardencorev1beta1.Project) (*gardencorev1beta1.Project, error) {
+		return g.CoreV1beta1().Projects().Update(ctx, project, kubernetes.DefaultUpdateOptions())
+	}, func(cur, updated *gardencorev1beta1.Project) bool {
+		return equality.Semantic.DeepEqual(cur, updated)
+	})
+}
+
+// TryUpdateProjectStatus tries to update a project's status and retries the operation with the given <backoff>.
+func TryUpdateProjectStatus(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Project) (*gardencorev1beta1.Project, error)) (*gardencorev1beta1.Project, error) {
+	return tryUpdateProject(ctx, g, backoff, meta, transform, func(g gardencore.Interface, project *gardencorev1beta1.Project) (*gardencorev1beta1.Project, error) {
+		return g.CoreV1beta1().Projects().UpdateStatus(ctx, project, kubernetes.DefaultUpdateOptions())
+	}, func(cur, updated *gardencorev1beta1.Project) bool {
+		return equality.Semantic.DeepEqual(cur.Status, updated.Status)
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/secretref.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/secretref.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// GetSecretByReference returns the secret referenced by the given secret reference.
+func GetSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, Key(ref.Namespace, ref.Name), secret); err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+// CreateOrUpdateSecretByReference creates or updates the secret referenced by the given secret reference
+// with the given type, data, and owner references.
+func CreateOrUpdateSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference, secretType corev1.SecretType, data map[string][]byte, ownerRefs []metav1.OwnerReference) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ref.Name,
+			Namespace: ref.Namespace,
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, secret, func() error {
+		secret.ObjectMeta.OwnerReferences = ownerRefs
+		secret.Type = secretType
+		secret.Data = data
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteSecretByReference deletes the secret referenced by the given secret reference.
+func DeleteSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ref.Name,
+			Namespace: ref.Namespace,
+		},
+	}
+	return client.IgnoreNotFound(c.Delete(ctx, secret))
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/seed.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/seed.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencore "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+func tryUpdateSeed(
+	ctx context.Context,
+	g gardencore.Interface,
+	backoff wait.Backoff,
+	meta metav1.ObjectMeta,
+	transform func(*gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error),
+	updateFunc func(g gardencore.Interface, seed *gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error),
+	equalFunc func(cur, updated *gardencorev1beta1.Seed) bool,
+) (*gardencorev1beta1.Seed, error) {
+
+	var (
+		result  *gardencorev1beta1.Seed
+		attempt int
+	)
+	err := retry.RetryOnConflict(backoff, func() (err error) {
+		attempt++
+		cur, err := g.CoreV1beta1().Seeds().Get(ctx, meta.Name, kubernetes.DefaultGetOptions())
+		if err != nil {
+			return err
+		}
+
+		updated, err := transform(cur.DeepCopy())
+		if err != nil {
+			return err
+		}
+
+		if equalFunc(cur, updated) {
+			result = cur
+			return nil
+		}
+
+		result, err = updateFunc(g, updated)
+		if err != nil {
+			logger.Logger.Errorf("Attempt %d failed to update Seed %s due to %v", attempt, cur.Name, err)
+		}
+		return
+	})
+	if err != nil {
+		logger.Logger.Errorf("Failed to update Seed %s after %d attempts due to %v", meta.Name, attempt, err)
+	}
+	return result, err
+}
+
+// TryUpdateSeedWithEqualFunc tries to update the status of the seed matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the Seed object. If the equal
+// func concludes a semantically equal Seed, no update is done and the operation returns normally.
+func TryUpdateSeedWithEqualFunc(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error), equal func(cur, updated *gardencorev1beta1.Seed) bool) (*gardencorev1beta1.Seed, error) {
+	return tryUpdateSeed(ctx, g, backoff, meta, transform, func(g gardencore.Interface, seed *gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error) {
+		return g.CoreV1beta1().Seeds().Update(ctx, seed, kubernetes.DefaultUpdateOptions())
+	}, equal)
+}
+
+// TryUpdateSeed tries to update the status of the seed matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the Seed object. If the transformation
+// yields a semantically equal Seed, no update is done and the operation returns normally.
+func TryUpdateSeed(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error)) (*gardencorev1beta1.Seed, error) {
+	return TryUpdateSeedWithEqualFunc(ctx, g, backoff, meta, transform, func(cur, updated *gardencorev1beta1.Seed) bool {
+		return equality.Semantic.DeepEqual(cur, updated)
+	})
+}
+
+// TryUpdateSeedStatus tries to update the status of the seed matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the Seed object. If the transformation
+// yields a semantically equal Seed (regarding Status), no update is done and the operation returns normally.
+func TryUpdateSeedStatus(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error)) (*gardencorev1beta1.Seed, error) {
+	return tryUpdateSeed(ctx, g, backoff, meta, transform, func(g gardencore.Interface, seed *gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error) {
+		return g.CoreV1beta1().Seeds().UpdateStatus(ctx, seed, kubernetes.DefaultUpdateOptions())
+	}, func(cur, updated *gardencorev1beta1.Seed) bool {
+		return equality.Semantic.DeepEqual(cur.Status, updated.Status)
+	})
+}
+
+// TryUpdateSeedConditions tries to update the status of the seed matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the Seed object. If the transformation
+// yields a semantically equal Seed (regarding conditions), no update is done and the operation returns normally.
+func TryUpdateSeedConditions(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error)) (*gardencorev1beta1.Seed, error) {
+	return tryUpdateSeed(ctx, g, backoff, meta, transform, func(g gardencore.Interface, seed *gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error) {
+		return g.CoreV1beta1().Seeds().UpdateStatus(ctx, seed, kubernetes.DefaultUpdateOptions())
+	}, func(cur, updated *gardencorev1beta1.Seed) bool {
+		return equality.Semantic.DeepEqual(cur.Status.Conditions, updated.Status.Conditions)
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/service.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/service.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+// DNSNamesForService returns the possible DNS names for a service with the given name and namespace.
+func DNSNamesForService(name, namespace string) []string {
+	return []string{
+		name,
+		fmt.Sprintf("%s.%s", name, namespace),
+		fmt.Sprintf("%s.%s.svc", name, namespace),
+		fmt.Sprintf("%s.%s.svc.%s", name, namespace, v1beta1.DefaultDomain),
+	}
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/shoot.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/shoot.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencore "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+func tryUpdateShoot(
+	ctx context.Context,
+	g gardencore.Interface,
+	backoff wait.Backoff,
+	meta metav1.ObjectMeta,
+	transform func(*gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error),
+	updateFunc func(g gardencore.Interface, shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error),
+	equalFunc func(cur, updated *gardencorev1beta1.Shoot) bool,
+) (*gardencorev1beta1.Shoot, error) {
+
+	var (
+		result  *gardencorev1beta1.Shoot
+		attempt int
+	)
+	err := retry.RetryOnConflict(backoff, func() (err error) {
+		attempt++
+		cur, err := g.CoreV1beta1().Shoots(meta.Namespace).Get(ctx, meta.Name, kubernetes.DefaultGetOptions())
+		if err != nil {
+			return err
+		}
+
+		updated, err := transform(cur.DeepCopy())
+		if err != nil {
+			return err
+		}
+
+		if equalFunc(cur, updated) {
+			result = cur
+			return nil
+		}
+
+		result, err = updateFunc(g, updated)
+		if err != nil {
+			logger.Logger.Errorf("Attempt %d failed to update Shoot %s/%s due to %v", attempt, cur.Namespace, cur.Name, err)
+		}
+		return
+	})
+	if err != nil {
+		logger.Logger.Errorf("Failed to update Shoot %s/%s after %d attempts due to %v", meta.Namespace, meta.Name, attempt, err)
+	}
+	return result, err
+}
+
+// TryUpdateShoot tries to update the shoot matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the Shoot object. If the transformation
+// yields a semantically equal Shoot, no update is done and the operation returns normally.
+func TryUpdateShoot(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error)) (*gardencorev1beta1.Shoot, error) {
+	return tryUpdateShoot(ctx, g, backoff, meta, transform, func(g gardencore.Interface, shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
+		return g.CoreV1beta1().Shoots(shoot.Namespace).Update(ctx, shoot, kubernetes.DefaultUpdateOptions())
+	}, func(cur, updated *gardencorev1beta1.Shoot) bool {
+		return equality.Semantic.DeepEqual(cur, updated)
+	})
+}
+
+// TryUpdateShootHibernation tries to update the status of the shoot matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the Shoot object. If the transformation
+// yields a semantically equal Shoot, no update is done and the operation returns normally.
+func TryUpdateShootHibernation(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error)) (*gardencorev1beta1.Shoot, error) {
+	return tryUpdateShoot(ctx, g, backoff, meta, transform, func(g gardencore.Interface, shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
+		return g.CoreV1beta1().Shoots(shoot.Namespace).Update(ctx, shoot, kubernetes.DefaultUpdateOptions())
+	}, func(cur, updated *gardencorev1beta1.Shoot) bool {
+		return equality.Semantic.DeepEqual(cur.Spec.Hibernation, updated.Spec.Hibernation)
+	})
+}
+
+// TryUpdateShootStatus tries to update the status of the shoot matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the Shoot object. If the transformation
+// yields a semantically equal Shoot (regarding Status), no update is done and the operation returns normally.
+func TryUpdateShootStatus(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error)) (*gardencorev1beta1.Shoot, error) {
+	return tryUpdateShoot(ctx, g, backoff, meta, transform, func(g gardencore.Interface, shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
+		return g.CoreV1beta1().Shoots(shoot.Namespace).UpdateStatus(ctx, shoot, kubernetes.DefaultUpdateOptions())
+	}, func(cur, updated *gardencorev1beta1.Shoot) bool {
+		return equality.Semantic.DeepEqual(cur.Status, updated.Status)
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/sorter.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/sorter.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ByName returns a comparison function for sorting by name.
+func ByName() SortBy {
+	return func(o1, o2 client.Object) bool {
+		return o1.GetName() < o2.GetName()
+	}
+}
+
+// ByCreationTimestamp returns a comparison function for sorting by creation timestamp.
+func ByCreationTimestamp() SortBy {
+	return func(o1, o2 client.Object) bool {
+		return o1.GetCreationTimestamp().Time.Before(o2.GetCreationTimestamp().Time)
+	}
+}
+
+// SortBy the type of a "less" function that defines the ordering of its object arguments.
+type SortBy func(o1, o2 client.Object) bool
+
+// Sort sorts the items in the provided list objects according to the sort-by function.
+func (sortBy SortBy) Sort(objList runtime.Object) {
+	if !meta.IsListType(objList) {
+		panic("provided <objList> is not a list type")
+	}
+
+	items, err := meta.ExtractList(objList)
+	if err != nil {
+		panic(err)
+	}
+
+	ps := &objectSorter{objects: items, compareFn: sortBy}
+	sort.Sort(ps)
+
+	if err := meta.SetList(objList, ps.objects); err != nil {
+		panic(err)
+	}
+}
+
+type objectSorter struct {
+	objects   []runtime.Object
+	compareFn SortBy
+}
+
+func (s *objectSorter) Len() int {
+	return len(s.objects)
+}
+
+func (s *objectSorter) Swap(i, j int) {
+	s.objects[i], s.objects[j] = s.objects[j], s.objects[i]
+}
+
+func (s *objectSorter) Less(i, j int) bool {
+	return s.compareFn(
+		s.objects[i].(client.Object),
+		s.objects[j].(client.Object),
+	)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/statefulset.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/statefulset.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// StatefulSetSource is a function that produces a slice of StatefulSets or an error.
+type StatefulSetSource func() ([]*appsv1.StatefulSet, error)
+
+// StatefulSetLister is a lister of StatefulSets.
+type StatefulSetLister interface {
+	// List lists all StatefulSets that match the given selector.
+	List(selector labels.Selector) ([]*appsv1.StatefulSet, error)
+	// StatefulSets yields a StatefulSetNamespaceLister for the given namespace.
+	StatefulSets(namespace string) StatefulSetNamespaceLister
+}
+
+// StatefulSetNamespaceLister is a lister of StatefulSets for a specific namespace.
+type StatefulSetNamespaceLister interface {
+	// List lists all StatefulSets that match the given selector in the current namespace.
+	List(selector labels.Selector) ([]*appsv1.StatefulSet, error)
+	// Get retrieves the StatefulSet with the given name in the current namespace.
+	Get(name string) (*appsv1.StatefulSet, error)
+}
+
+type statefulSetLister struct {
+	source StatefulSetSource
+}
+
+type statefulSetNamespaceLister struct {
+	source    StatefulSetSource
+	namespace string
+}
+
+// NewStatefulSetLister creates a new StatefulSetLister form the given StatefulSetSource.
+func NewStatefulSetLister(source StatefulSetSource) StatefulSetLister {
+	return &statefulSetLister{source: source}
+}
+
+func filterStatefulSets(source StatefulSetSource, filter func(*appsv1.StatefulSet) bool) ([]*appsv1.StatefulSet, error) {
+	statefulSets, err := source()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*appsv1.StatefulSet
+	for _, statefulSet := range statefulSets {
+		if filter(statefulSet) {
+			out = append(out, statefulSet)
+		}
+	}
+	return out, nil
+}
+
+func (d *statefulSetLister) List(selector labels.Selector) ([]*appsv1.StatefulSet, error) {
+	return filterStatefulSets(d.source, func(statefulSet *appsv1.StatefulSet) bool {
+		return selector.Matches(labels.Set(statefulSet.Labels))
+	})
+}
+
+func (d *statefulSetLister) StatefulSets(namespace string) StatefulSetNamespaceLister {
+	return &statefulSetNamespaceLister{
+		source:    d.source,
+		namespace: namespace,
+	}
+}
+
+func (d *statefulSetNamespaceLister) Get(name string) (*appsv1.StatefulSet, error) {
+	statefulSets, err := filterStatefulSets(d.source, func(statefulSet *appsv1.StatefulSet) bool {
+		return statefulSet.Namespace == d.namespace && statefulSet.Name == name
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(statefulSets) == 0 {
+		return nil, apierrors.NewNotFound(appsv1.Resource("StatefulSets"), name)
+	}
+	return statefulSets[0], nil
+}
+
+func (d *statefulSetNamespaceLister) List(selector labels.Selector) ([]*appsv1.StatefulSet, error) {
+	return filterStatefulSets(d.source, func(statefulSet *appsv1.StatefulSet) bool {
+		return statefulSet.Namespace == d.namespace && selector.Matches(labels.Set(statefulSet.Labels))
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/update.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/update.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TryUpdate tries to apply the given transformation function onto the given object, and to update it afterwards.
+// It retries the update with an exponential backoff.
+func TryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, transform func() error) error {
+	return tryUpdate(ctx, backoff, c, obj, c.Update, transform)
+}
+
+// TryUpdateStatus tries to apply the given transformation function onto the given object, and to update its
+// status afterwards. It retries the status update with an exponential backoff.
+func TryUpdateStatus(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, transform func() error) error {
+	return tryUpdate(ctx, backoff, c, obj, c.Status().Update, transform)
+}
+
+func tryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, updateFunc func(context.Context, client.Object, ...client.UpdateOption) error, transform func() error) error {
+	resetCopy := obj.DeepCopyObject()
+	return exponentialBackoff(ctx, backoff, func() (bool, error) {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return false, err
+		}
+
+		beforeTransform := obj.DeepCopyObject()
+		if err := transform(); err != nil {
+			return false, err
+		}
+
+		if reflect.DeepEqual(obj, beforeTransform) {
+			return true, nil
+		}
+
+		if err := updateFunc(ctx, obj); err != nil {
+			if apierrors.IsConflict(err) {
+				// In case of a conflict we are resetting the obj to its original version, as it was
+				// passed to the function, to ensure that, on the next iteration the
+				// equality check of the obj recieved from the server and the object after
+				// its transformation would be valid. Otherwise the obj would be with mutated
+				// fields in result of the transform function from previous iteration.
+				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func exponentialBackoff(ctx context.Context, backoff wait.Backoff, condition wait.ConditionFunc) error {
+	duration := backoff.Duration
+
+	for i := 0; i < backoff.Steps; i++ {
+		if ok, err := condition(); err != nil || ok {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			adjusted := duration
+			if backoff.Jitter > 0.0 {
+				adjusted = wait.Jitter(duration, backoff.Jitter)
+			}
+			time.Sleep(adjusted)
+			duration = time.Duration(float64(duration) * backoff.Factor)
+		}
+
+		i++
+	}
+
+	return wait.ErrWaitTimeout
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/worker.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/worker.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// WorkerSource is a function that produces a slice of Workers or an error.
+type WorkerSource func() ([]*extensionsv1alpha1.Worker, error)
+
+// WorkerLister is a lister of Workers for a specific namespace.
+type WorkerLister interface {
+	// List lists all Workers that match the given selector in the current namespace.
+	List(selector labels.Selector) ([]*extensionsv1alpha1.Worker, error)
+	// Workers yields a WorkerNamespaceLister for the given namespace.
+	Workers(namespace string) WorkerNamespaceLister
+}
+
+// WorkerNamespaceLister is  a lister of Workers for a specific namespace.
+type WorkerNamespaceLister interface {
+	// List lists all Workers that match the given selector in the current namespace.
+	List(selector labels.Selector) ([]*extensionsv1alpha1.Worker, error)
+	// Get retrieves the MachineDeployment with the given name in the current namespace.
+	Get(name string) (*extensionsv1alpha1.Worker, error)
+}
+
+type workerLister struct {
+	source WorkerSource
+}
+
+type workerNamespaceLister struct {
+	source    WorkerSource
+	namespace string
+}
+
+// NewWorkerLister creates a new WorkerLister from the given WorkerSource.
+func NewWorkerLister(source WorkerSource) WorkerLister {
+	return &workerLister{source: source}
+}
+
+func filterWorkers(source WorkerSource, filter func(worker *extensionsv1alpha1.Worker) bool) ([]*extensionsv1alpha1.Worker, error) {
+	workers, err := source()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*extensionsv1alpha1.Worker
+	for _, worker := range workers {
+		if filter(worker) {
+			out = append(out, worker)
+		}
+	}
+	return out, nil
+}
+
+func (d *workerLister) List(selector labels.Selector) ([]*extensionsv1alpha1.Worker, error) {
+	return filterWorkers(d.source, func(worker *extensionsv1alpha1.Worker) bool {
+		return selector.Matches(labels.Set(worker.Labels))
+	})
+}
+
+func (d *workerLister) Workers(namespace string) WorkerNamespaceLister {
+	return &workerNamespaceLister{
+		source:    d.source,
+		namespace: namespace,
+	}
+}
+
+func (d *workerNamespaceLister) Get(name string) (*extensionsv1alpha1.Worker, error) {
+	workers, err := filterWorkers(d.source, func(worker *extensionsv1alpha1.Worker) bool {
+		return worker.Namespace == d.namespace && worker.Name == name
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(workers) == 0 {
+		return nil, apierrors.NewNotFound(extensionsv1alpha1.Resource("worker"), name)
+	}
+	return workers[0], nil
+}
+
+func (d *workerNamespaceLister) List(selector labels.Selector) ([]*extensionsv1alpha1.Worker, error) {
+	return filterWorkers(d.source, func(worker *extensionsv1alpha1.Worker) bool {
+		return worker.Namespace == d.namespace && selector.Matches(labels.Set(worker.Labels))
+	})
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/test/matchers/deep.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/test/matchers/deep.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matchers
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+	gomegatypes "github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	deepMatcherNilError = `refusing to compare <nil> to <nil>.
+Be explicit and use BeNil() instead.
+This is to avoid mistakes where both sides of an assertion are erroneously uninitialized`
+)
+
+type deepMatcher struct {
+	name      string
+	expected  interface{}
+	compareFn func(a1, a2 interface{}) bool
+}
+
+func newDeepDerivativeMatcher(expected interface{}) gomegatypes.GomegaMatcher {
+	return &deepMatcher{
+		name:      "deep derivative equal",
+		expected:  expected,
+		compareFn: equality.Semantic.DeepDerivative,
+	}
+}
+
+func newDeepEqualMatcher(expected interface{}) gomegatypes.GomegaMatcher {
+	return &deepMatcher{
+		name:      "deep equal",
+		expected:  expected,
+		compareFn: equality.Semantic.DeepEqual,
+	}
+}
+
+func (m *deepMatcher) Match(actual interface{}) (success bool, err error) {
+	if actual == nil && m.expected == nil {
+		return false, fmt.Errorf(deepMatcherNilError)
+	}
+
+	return m.compareFn(m.expected, actual), nil
+}
+
+func (m *deepMatcher) FailureMessage(actual interface{}) (message string) {
+	return m.failureMessage(actual, "to")
+}
+
+func (m *deepMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return m.failureMessage(actual, "not to")
+}
+
+func (m *deepMatcher) failureMessage(actual interface{}, messagePrefix string) (message string) {
+	var (
+		actualYAML, actualErr     = yaml.Marshal(actual)
+		expectedYAML, expectedErr = yaml.Marshal(m.expected)
+	)
+
+	if actualErr == nil && expectedErr == nil {
+		return format.MessageWithDiff(string(actualYAML), messagePrefix+" "+m.name, string(expectedYAML))
+	}
+
+	return format.Message(actual, messagePrefix+" "+m.name, m.expected)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/test/matchers/fields.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/test/matchers/fields.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matchers
+
+import (
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+)
+
+// HaveFields succeeds if actual is a pointer and has a specific fields.
+// Ignores extra elements or fields.
+func HaveFields(fields gstruct.Fields) types.GomegaMatcher {
+	return gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, fields))
+}
+
+// ConsistOfFields succeeds if actual matches all selected fields.
+// Actual must be an array, slice or map.  For maps, ConsistOfFields matches against the map's values.
+// Actual's elements must be pointers.
+func ConsistOfFields(fields ...gstruct.Fields) types.GomegaMatcher {
+	var m []interface{}
+	for _, f := range fields {
+		m = append(m, HaveFields(f))
+	}
+	return gomega.ConsistOf(m...)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/test/matchers/kubernetes_errors.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/test/matchers/kubernetes_errors.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matchers
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+)
+
+type kubernetesErrors struct {
+	checkFunc func(error) bool
+	message   string
+}
+
+func (k *kubernetesErrors) Match(actual interface{}) (success bool, err error) {
+	// is purely nil?
+	if actual == nil {
+		return false, nil
+	}
+
+	actualErr, actualOk := actual.(error)
+	if !actualOk {
+		return false, fmt.Errorf("expected an error-type.  got:\n%s", format.Object(actual, 1))
+	}
+
+	return k.checkFunc(actualErr), nil
+}
+
+func (k *kubernetesErrors) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("to be %s error", k.message))
+}
+func (k *kubernetesErrors) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("to not be %s error", k.message))
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/test/matchers/matchers.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/test/matchers/matchers.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matchers
+
+import (
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// DeepEqual returns a Gomega matcher which checks whether the expected object is deeply equal with the object it is
+// being compared against.
+func DeepEqual(expected interface{}) types.GomegaMatcher {
+	// if CharactersAroundMismatchToInclude is too small, then format.MessageWithDiff will be unable to output our
+	// mismatch message
+	if format.CharactersAroundMismatchToInclude < 50 {
+		format.CharactersAroundMismatchToInclude = 50
+	}
+
+	return newDeepEqualMatcher(expected)
+}
+
+// DeepDerivativeEqual is similar to DeepEqual except that unset fields in actual are
+// ignored (not compared). This allows us to focus on the fields that matter to
+// the semantic comparison.
+func DeepDerivativeEqual(expected interface{}) types.GomegaMatcher {
+	// if CharactersAroundMismatchToInclude is too small, then format.MessageWithDiff will be unable to output our
+	// mismatch message
+	if format.CharactersAroundMismatchToInclude < 50 {
+		format.CharactersAroundMismatchToInclude = 50
+	}
+
+	return newDeepDerivativeMatcher(expected)
+}
+
+// BeNotFoundError checks if error is NotFound.
+func BeNotFoundError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsNotFound,
+		message:   "NotFound",
+	}
+}
+
+// BeAlreadyExistsError checks if error is AlreadyExists.
+func BeAlreadyExistsError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsAlreadyExists,
+		message:   "AlreadyExists",
+	}
+}
+
+// BeForbiddenError checks if error is Forbidden.
+func BeForbiddenError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsForbidden,
+		message:   "Forbidden",
+	}
+}
+
+// BeBadRequestError checks if error is BadRequest.
+func BeBadRequestError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsBadRequest,
+		message:   "BadRequest",
+	}
+}
+
+// BeNoMatchError checks if error is a NoMatchError.
+func BeNoMatchError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: meta.IsNoMatchError,
+		message:   "NoMatch",
+	}
+}
+
+// BeMissingKindError checks if error is a MissingKindError.
+func BeMissingKindError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: runtime.IsMissingKind,
+		message:   "Object 'Kind' is missing",
+	}
+}
+
+// BeInternalServerError checks if error is a InternalServerError.
+func BeInternalServerError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsInternalError,
+		message:   "",
+	}
+}
+
+// BeInvalidError checks if error is an InvalidError.
+func BeInvalidError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsInvalid,
+		message:   "Invalid",
+	}
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/duration/duration.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/duration/duration.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package duration
+
+import (
+	"fmt"
+	"time"
+)
+
+// ShortHumanDuration returns a succint representation of the provided duration
+// with limited precision for consumption by humans.
+func ShortHumanDuration(d time.Duration) string {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return fmt.Sprintf("<invalid>")
+	} else if seconds < 0 {
+		return fmt.Sprintf("0s")
+	} else if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	} else if minutes := int(d.Minutes()); minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	} else if hours := int(d.Hours()); hours < 24 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*365 {
+		return fmt.Sprintf("%dd", hours/24)
+	}
+	return fmt.Sprintf("%dy", int(d.Hours()/24/365))
+}
+
+// HumanDuration returns a succint representation of the provided duration
+// with limited precision for consumption by humans. It provides ~2-3 significant
+// figures of duration.
+func HumanDuration(d time.Duration) string {
+	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time
+	// inconsistence, it can be considered as almost now.
+	if seconds := int(d.Seconds()); seconds < -1 {
+		return fmt.Sprintf("<invalid>")
+	} else if seconds < 0 {
+		return fmt.Sprintf("0s")
+	} else if seconds < 60*2 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	minutes := int(d / time.Minute)
+	if minutes < 10 {
+		s := int(d/time.Second) % 60
+		if s == 0 {
+			return fmt.Sprintf("%dm", minutes)
+		}
+		return fmt.Sprintf("%dm%ds", minutes, s)
+	} else if minutes < 60*3 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	hours := int(d / time.Hour)
+	if hours < 8 {
+		m := int(d/time.Minute) % 60
+		if m == 0 {
+			return fmt.Sprintf("%dh", hours)
+		}
+		return fmt.Sprintf("%dh%dm", hours, m)
+	} else if hours < 48 {
+		return fmt.Sprintf("%dh", hours)
+	} else if hours < 24*8 {
+		h := hours % 24
+		if h == 0 {
+			return fmt.Sprintf("%dd", hours/24)
+		}
+		return fmt.Sprintf("%dd%dh", hours/24, h)
+	} else if hours < 24*365*2 {
+		return fmt.Sprintf("%dd", hours/24)
+	} else if hours < 24*365*8 {
+		dy := int(hours/24) % 365
+		if dy == 0 {
+			return fmt.Sprintf("%dy", hours/24/365)
+		}
+		return fmt.Sprintf("%dy%dd", hours/24/365, dy)
+	}
+	return fmt.Sprintf("%dy", int(hours/24/365))
+}

--- a/vendor/k8s.io/cluster-bootstrap/LICENSE
+++ b/vendor/k8s.io/cluster-bootstrap/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/cluster-bootstrap/token/api/doc.go
+++ b/vendor/k8s.io/cluster-bootstrap/token/api/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package api (k8s.io/cluster-bootstrap/token/api) contains constants and types needed for
+// bootstrap tokens as maintained by the BootstrapSigner and TokenCleaner
+// controllers (in k8s.io/kubernetes/pkg/controller/bootstrap)
+package api // import "k8s.io/cluster-bootstrap/token/api"

--- a/vendor/k8s.io/cluster-bootstrap/token/api/types.go
+++ b/vendor/k8s.io/cluster-bootstrap/token/api/types.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+const (
+	// BootstrapTokenSecretPrefix is the prefix for bootstrap token names.
+	// Bootstrap tokens secrets must be named in the form
+	// `bootstrap-token-<token-id>`.  This is the prefix to be used before the
+	// token ID.
+	BootstrapTokenSecretPrefix = "bootstrap-token-"
+
+	// SecretTypeBootstrapToken is used during the automated bootstrap process (first
+	// implemented by kubeadm). It stores tokens that are used to sign well known
+	// ConfigMaps. They may also eventually be used for authentication.
+	SecretTypeBootstrapToken v1.SecretType = "bootstrap.kubernetes.io/token"
+
+	// BootstrapTokenIDKey is the id of this token. This can be transmitted in the
+	// clear and encoded in the name of the secret. It must be a random 6 character
+	// string that matches the regexp `^([a-z0-9]{6})$`. Required.
+	BootstrapTokenIDKey = "token-id"
+
+	// BootstrapTokenSecretKey is the actual secret. It must be a random 16 character
+	// string that matches the regexp `^([a-z0-9]{16})$`. Required.
+	BootstrapTokenSecretKey = "token-secret"
+
+	// BootstrapTokenExpirationKey is when this token should be expired and no
+	// longer used. A controller will delete this resource after this time. This
+	// is an absolute UTC time using RFC3339. If this cannot be parsed, the token
+	// should be considered invalid. Optional.
+	BootstrapTokenExpirationKey = "expiration"
+
+	// BootstrapTokenDescriptionKey is a description in human-readable format that
+	// describes what the bootstrap token is used for. Optional.
+	BootstrapTokenDescriptionKey = "description"
+
+	// BootstrapTokenExtraGroupsKey is a comma-separated list of group names.
+	// The  bootstrap token will authenticate as these groups in addition to the
+	// "system:bootstrappers" group.
+	BootstrapTokenExtraGroupsKey = "auth-extra-groups"
+
+	// BootstrapTokenUsagePrefix is the prefix for the other usage constants that specifies different
+	// functions of a bootstrap token
+	BootstrapTokenUsagePrefix = "usage-bootstrap-"
+
+	// BootstrapTokenUsageSigningKey signals that this token should be used to
+	// sign configs as part of the bootstrap process. Value must be "true". Any
+	// other value is assumed to be false. Optional.
+	BootstrapTokenUsageSigningKey = "usage-bootstrap-signing"
+
+	// BootstrapTokenUsageAuthentication signals that this token should be used
+	// as a bearer token to authenticate against the Kubernetes API. The bearer
+	// token takes the form "<token-id>.<token-secret>" and authenticates as the
+	// user "system:bootstrap:<token-id>" in the "system:bootstrappers" group
+	// as well as any groups specified using BootstrapTokenExtraGroupsKey.
+	// Value must be "true". Any other value is assumed to be false. Optional.
+	BootstrapTokenUsageAuthentication = "usage-bootstrap-authentication"
+
+	// ConfigMapClusterInfo defines the name for the ConfigMap where the information how to connect and trust the cluster exist
+	ConfigMapClusterInfo = "cluster-info"
+
+	// KubeConfigKey defines at which key in the Data object of the ConfigMap the KubeConfig object is stored
+	KubeConfigKey = "kubeconfig"
+
+	// JWSSignatureKeyPrefix defines what key prefix the JWS-signed tokens have
+	JWSSignatureKeyPrefix = "jws-kubeconfig-"
+
+	// BootstrapUserPrefix is the username prefix bootstrapping bearer tokens
+	// authenticate as. The full username given is "system:bootstrap:<token-id>".
+	BootstrapUserPrefix = "system:bootstrap:"
+
+	// BootstrapDefaultGroup is the default group for bootstrapping bearer
+	// tokens (in addition to any groups from BootstrapTokenExtraGroupsKey).
+	BootstrapDefaultGroup = "system:bootstrappers"
+
+	// BootstrapGroupPattern is the valid regex pattern that all groups
+	// assigned to a bootstrap token by BootstrapTokenExtraGroupsKey must match.
+	// See also util.ValidateBootstrapGroupName()
+	BootstrapGroupPattern = `\Asystem:bootstrappers:[a-z0-9:-]{0,255}[a-z0-9]\z`
+
+	// BootstrapTokenPattern defines the {id}.{secret} regular expression pattern
+	BootstrapTokenPattern = `\A([a-z0-9]{6})\.([a-z0-9]{16})\z`
+
+	// BootstrapTokenIDPattern defines token's id regular expression pattern
+	BootstrapTokenIDPattern = `\A([a-z0-9]{6})\z`
+
+	// BootstrapTokenIDBytes defines the number of bytes used for the Bootstrap Token's ID field
+	BootstrapTokenIDBytes = 6
+
+	// BootstrapTokenSecretBytes defines the number of bytes used the Bootstrap Token's Secret field
+	BootstrapTokenSecretBytes = 16
+)
+
+// KnownTokenUsages specifies the known functions a token will get.
+var KnownTokenUsages = []string{"signing", "authentication"}

--- a/vendor/k8s.io/cluster-bootstrap/token/util/helpers.go
+++ b/vendor/k8s.io/cluster-bootstrap/token/util/helpers.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bufio"
+	"crypto/rand"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cluster-bootstrap/token/api"
+)
+
+// TODO(dixudx): refactor this to util/secrets and util/tokens
+
+// validBootstrapTokenChars defines the characters a bootstrap token can consist of
+const validBootstrapTokenChars = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+var (
+	// BootstrapTokenRegexp is a compiled regular expression of TokenRegexpString
+	BootstrapTokenRegexp = regexp.MustCompile(api.BootstrapTokenPattern)
+	// BootstrapTokenIDRegexp is a compiled regular expression of TokenIDRegexpString
+	BootstrapTokenIDRegexp = regexp.MustCompile(api.BootstrapTokenIDPattern)
+	// BootstrapGroupRegexp is a compiled regular expression of BootstrapGroupPattern
+	BootstrapGroupRegexp = regexp.MustCompile(api.BootstrapGroupPattern)
+)
+
+// GenerateBootstrapToken generates a new, random Bootstrap Token.
+func GenerateBootstrapToken() (string, error) {
+	tokenID, err := randBytes(api.BootstrapTokenIDBytes)
+	if err != nil {
+		return "", err
+	}
+
+	tokenSecret, err := randBytes(api.BootstrapTokenSecretBytes)
+	if err != nil {
+		return "", err
+	}
+
+	return TokenFromIDAndSecret(tokenID, tokenSecret), nil
+}
+
+// randBytes returns a random string consisting of the characters in
+// validBootstrapTokenChars, with the length customized by the parameter
+func randBytes(length int) (string, error) {
+	// len("0123456789abcdefghijklmnopqrstuvwxyz") = 36 which doesn't evenly divide
+	// the possible values of a byte: 256 mod 36 = 4. Discard any random bytes we
+	// read that are >= 252 so the bytes we evenly divide the character set.
+	const maxByteValue = 252
+
+	var (
+		b     byte
+		err   error
+		token = make([]byte, length)
+	)
+
+	reader := bufio.NewReaderSize(rand.Reader, length*2)
+	for i := range token {
+		for {
+			if b, err = reader.ReadByte(); err != nil {
+				return "", err
+			}
+			if b < maxByteValue {
+				break
+			}
+		}
+
+		token[i] = validBootstrapTokenChars[int(b)%len(validBootstrapTokenChars)]
+	}
+
+	return string(token), nil
+}
+
+// TokenFromIDAndSecret returns the full token which is of the form "{id}.{secret}"
+func TokenFromIDAndSecret(id, secret string) string {
+	return fmt.Sprintf("%s.%s", id, secret)
+}
+
+// IsValidBootstrapToken returns whether the given string is valid as a Bootstrap Token and
+// in other words satisfies the BootstrapTokenRegexp
+func IsValidBootstrapToken(token string) bool {
+	return BootstrapTokenRegexp.MatchString(token)
+}
+
+// IsValidBootstrapTokenID returns whether the given string is valid as a Bootstrap Token ID and
+// in other words satisfies the BootstrapTokenIDRegexp
+func IsValidBootstrapTokenID(tokenID string) bool {
+	return BootstrapTokenIDRegexp.MatchString(tokenID)
+}
+
+// BootstrapTokenSecretName returns the expected name for the Secret storing the
+// Bootstrap Token in the Kubernetes API.
+func BootstrapTokenSecretName(tokenID string) string {
+	return fmt.Sprintf("%s%s", api.BootstrapTokenSecretPrefix, tokenID)
+}
+
+// ValidateBootstrapGroupName checks if the provided group name is a valid
+// bootstrap group name. Returns nil if valid or a validation error if invalid.
+// TODO(dixudx): should be moved to util/secrets
+func ValidateBootstrapGroupName(name string) error {
+	if BootstrapGroupRegexp.Match([]byte(name)) {
+		return nil
+	}
+	return fmt.Errorf("bootstrap group %q is invalid (must match %s)", name, api.BootstrapGroupPattern)
+}
+
+// ValidateUsages validates that the passed in string are valid usage strings for bootstrap tokens.
+func ValidateUsages(usages []string) error {
+	validUsages := sets.NewString(api.KnownTokenUsages...)
+	invalidUsages := sets.NewString()
+	for _, usage := range usages {
+		if !validUsages.Has(usage) {
+			invalidUsages.Insert(usage)
+		}
+	}
+	if len(invalidUsages) > 0 {
+		return fmt.Errorf("invalid bootstrap token usage string: %s, valid usage options: %s", strings.Join(invalidUsages.List(), ","), strings.Join(api.KnownTokenUsages, ","))
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,6 +40,7 @@ github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
 # github.com/gardener/gardener v1.17.1
 ## explicit
 github.com/gardener/gardener/.github
+github.com/gardener/gardener/extensions/pkg/util/test
 github.com/gardener/gardener/hack
 github.com/gardener/gardener/hack/.ci
 github.com/gardener/gardener/pkg/apis/core
@@ -72,9 +73,12 @@ github.com/gardener/gardener/pkg/logger
 github.com/gardener/gardener/pkg/utils
 github.com/gardener/gardener/pkg/utils/context
 github.com/gardener/gardener/pkg/utils/errors
+github.com/gardener/gardener/pkg/utils/flow
 github.com/gardener/gardener/pkg/utils/imagevector
+github.com/gardener/gardener/pkg/utils/kubernetes
 github.com/gardener/gardener/pkg/utils/kubernetes/health
 github.com/gardener/gardener/pkg/utils/retry
+github.com/gardener/gardener/pkg/utils/test/matchers
 github.com/gardener/gardener/pkg/utils/version
 # github.com/gardener/gardener-resource-manager v0.18.0
 github.com/gardener/gardener-resource-manager/pkg/apis/resources
@@ -505,6 +509,7 @@ k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/cache
 k8s.io/apimachinery/pkg/util/clock
 k8s.io/apimachinery/pkg/util/diff
+k8s.io/apimachinery/pkg/util/duration
 k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/framer
 k8s.io/apimachinery/pkg/util/httpstream
@@ -616,6 +621,9 @@ k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
+# k8s.io/cluster-bootstrap v0.19.6
+k8s.io/cluster-bootstrap/token/api
+k8s.io/cluster-bootstrap/token/util
 # k8s.io/code-generator v0.19.6 => k8s.io/code-generator v0.19.6
 k8s.io/code-generator
 k8s.io/code-generator/cmd/client-gen


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes Druid read events for PVCs if they are still unbound after a `StatefulSet` does not get ready. Respective warnings will appear in the `.status.lastError` description which makes it easier for operators to spot the root cause.

**Special notes for your reviewer**:
⚠️ This PR is based on #141. Only commit 924a361dcdf12cb4fc10092ece7791aadb5a9d92 is relevant for this PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
If an etcd `StatefulSet` remains pending, warning events of unbound `PVC`s are now added to the `.status.lastError` of the `etcd` resource. This makes it easier for operators to spot potential issues.
```
