### PR TITLE
Fix pipeline check

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash 
-# Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#!/usr/bin/env bash
+# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,53 +12,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -e
 
-# For the check step concourse will set the following environment variables:
-# SOURCE_PATH - path to component repository root directory.
+set -o errexit
+set -o nounset
+set -o pipefail
 
-if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
-else
-  export SOURCE_PATH="$(readlink -f ${SOURCE_PATH})"
-fi
-VCS="github.com"
-ORGANIZATION="gardener"
-PROJECT="etcd-druid"
-REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
+cd "$(dirname $0)/.."
 
-# The `go <cmd>` commands requires to see the target repository to be part of a
-# Go workspace. Thus, if we are not yet in a Go workspace, let's create one
-# temporarily by using symbolic links.
-if [[ "${SOURCE_PATH}" != *"src/${REPOSITORY}" ]]; then
-  SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/src/${REPOSITORY}"
-  if [[ -d "${SOURCE_PATH}/tmp" ]]; then
-    rm -rf "${SOURCE_PATH}/tmp"
-  fi
-  mkdir -p "${SOURCE_PATH}/tmp/src/${VCS}/${ORGANIZATION}"
-  ln -s "${SOURCE_PATH}" "${SOURCE_SYMLINK_PATH}"
-  cd "${SOURCE_SYMLINK_PATH}"
+mkdir -p /go/src/github.com/gardener/etcd-druid
+cp -r . /go/src/github.com/gardener/etcd-druid
+cd /go/src/github.com/gardener/etcd-druid
 
-  export GOPATH="${SOURCE_PATH}/tmp"
-  export GOBIN="${SOURCE_PATH}/tmp/bin"
-  export PATH="${GOBIN}:${PATH}"
-fi
-
-export GO111MODULE=on
-
-# Install Golint (linting tool).
-go get -u golang.org/x/lint/golint
-
-###############################################################################
-
-PACKAGES="$(go list -mod=vendor -e ./... | grep -vE '/api|/api/v1alpha1/|/tmp/|/vendor/')"
-LINT_FOLDERS="$(echo ${PACKAGES} | sed "s|github.com/gardener/etcd-druid|.|g")"
-
-# Execute static code checks.
-go vet ${PACKAGES}
-
-# Execute automatic code formatting directive.
-go fmt ${PACKAGES}
-
-# Execute lint checks.
-golint -set_exit_status ${LINT_FOLDERS}
+make install-requirements
+make check

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ docker-push:
 .PHONY: install-requirements
 install-requirements:
 	@go install -mod=vendor sigs.k8s.io/controller-tools/cmd/controller-gen
+	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/install-requirements.sh
 
 .PHONY: update-dependencies
 update-dependencies:

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug
/priority normal

**What this PR does / why we need it**:
Fixes the pipeline's `check` step after updating to a new Go version via #141.

https://concourse.ci.gardener.cloud/teams/gardener/pipelines/etcd-druid-master/jobs/master-pull-request-job/builds/1

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
