### PR TITLE
Introducing constants for snapshot compression policy

### DIFF
--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -30,6 +30,18 @@ const (
 	Basic MetricsLevel = "basic"
 	// Extensive is a constant for metrics level extensive.
 	Extensive MetricsLevel = "extensive"
+
+	// GzipCompression is constant for gzip compression policy.
+	GzipCompression CompressionPolicy = "gzip"
+	// LzwCompression is constant for lzw compression policy.
+	LzwCompression CompressionPolicy = "lzw"
+	// ZlibCompression is constant for zlib compression policy.
+	ZlibCompression CompressionPolicy = "zlib"
+
+	// DefaultCompression is constant for default compression policy(only if compression is enabled).
+	DefaultCompression CompressionPolicy = GzipCompression
+	// DefaultCompressionEnabled is constant to define whether to compress the snapshots or not.
+	DefaultCompressionEnabled = false
 )
 
 // MetricsLevel defines the level 'basic' or 'extensive'.
@@ -42,6 +54,10 @@ type GarbageCollectionPolicy string
 
 // StorageProvider defines the type of object store provider for storing backups.
 type StorageProvider string
+
+// CompressionPolicy defines the type of policy for compression of snapshots.
+// +kubebuilder:validation:Enum=gzip;lzw;zlib
+type CompressionPolicy string
 
 // StoreSpec defines parameters related to ObjectStore persisting backups
 type StoreSpec struct {
@@ -70,7 +86,7 @@ type CompressionSpec struct {
 	// +optional
 	Enabled bool `json:"enabled,omitempty"`
 	// +optional
-	CompressionPolicy *string `json:"policy,omitempty"`
+	Policy *CompressionPolicy `json:"policy,omitempty"`
 }
 
 // BackupSpec defines parametes associated with the full and delta snapshots of etcd

--- a/config/crd/bases/druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/druid.gardener.cloud_etcds.yaml
@@ -52,6 +52,11 @@ spec:
                       enabled:
                         type: boolean
                       policy:
+                        description: CompressionPolicy defines the type of policy for compression of snapshots.
+                        enum:
+                        - gzip
+                        - lzw
+                        - zlib
                         type: string
                     type: object
                   deltaSnapshotMemoryLimit:

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -917,8 +917,8 @@ func (r *EtcdReconciler) getMapFromEtcd(etcd *druidv1alpha1.Etcd) (map[string]in
 		if etcd.Spec.Backup.SnapshotCompression.Enabled {
 			compressionValues["enabled"] = etcd.Spec.Backup.SnapshotCompression.Enabled
 		}
-		if etcd.Spec.Backup.SnapshotCompression.CompressionPolicy != nil {
-			compressionValues["policy"] = etcd.Spec.Backup.SnapshotCompression.CompressionPolicy
+		if etcd.Spec.Backup.SnapshotCompression.Policy != nil {
+			compressionValues["policy"] = etcd.Spec.Backup.SnapshotCompression.Policy
 		}
 		backupValues["compression"] = compressionValues
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
To Integrate [Compression Feature](https://github.com/gardener/etcd-backup-restore/pull/293) with Gardener, Introducing few helpful constant.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
