### PR TITLE
Make auto-compaction-mode and auto-compaction-retention configurable

### DIFF
--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -42,6 +42,11 @@ const (
 	DefaultCompression CompressionPolicy = GzipCompression
 	// DefaultCompressionEnabled is constant to define whether to compress the snapshots or not.
 	DefaultCompressionEnabled = false
+
+	// Periodic is a constant to set auto-compaction-mode 'periodic' for duration based retention.
+	Periodic CompactionMode = "periodic"
+	// Revision is a constant to set auto-compaction-mode 'revision' for revision number based retention.
+	Revision CompactionMode = "revision"
 )
 
 // MetricsLevel defines the level 'basic' or 'extensive'.
@@ -58,6 +63,11 @@ type StorageProvider string
 // CompressionPolicy defines the type of policy for compression of snapshots.
 // +kubebuilder:validation:Enum=gzip;lzw;zlib
 type CompressionPolicy string
+
+// CompactionMode defines the auto-compaction-mode: 'periodic' or 'revision'.
+// 'periodic' for duration based retention and 'revision' for revision number based retention.
+// +kubebuilder:validation:Enum=periodic;revision
+type CompactionMode string
 
 // StoreSpec defines parameters related to ObjectStore persisting backups
 type StoreSpec struct {
@@ -154,6 +164,16 @@ type EtcdConfig struct {
 	TLS *TLSConfig `json:"tls,omitempty"`
 }
 
+// SharedConfig defines parameters shared and used by Etcd as well as backup-restore sidecar.
+type SharedConfig struct {
+	// AutoCompactionMode defines the auto-compaction-mode:'periodic' mode or 'revision' mode for etcd and embedded-Etcd of backup-restore sidecar.
+	// +optional
+	AutoCompactionMode *CompactionMode `json:"autoCompactionMode,omitempty"`
+	//AutoCompactionRetention defines the auto-compaction-retention length for etcd as well as for embedded-Etcd of backup-restore sidecar.
+	// +optional
+	AutoCompactionRetention *string `json:"autoCompactionRetention,omitempty"`
+}
+
 // EtcdSpec defines the desired state of Etcd
 type EtcdSpec struct {
 	// selector is a label query over pods that should match the replica count.
@@ -168,6 +188,8 @@ type EtcdSpec struct {
 	Etcd EtcdConfig `json:"etcd"`
 	// +required
 	Backup BackupSpec `json:"backup"`
+	// +optional
+	Common SharedConfig `json:"sharedConfig,omitempty"`
 	// +required
 	Replicas int `json:"replicas"`
 	// PriorityClassName is the name of a priority class that shall be used for the etcd pods.

--- a/charts/etcd/templates/etcd-bootstrap-configmap.yaml
+++ b/charts/etcd/templates/etcd-bootstrap-configmap.yaml
@@ -125,9 +125,17 @@ data:
     # Initial cluster state ('new' or 'existing').
     initial-cluster-state: {{ .Values.etcd.initialClusterState }}
 
-    # keep one day of history
-    auto-compaction-mode: periodic
-    auto-compaction-retention: "24"
+    {{- if .Values.sharedConfig }}
+    # auto-compaction-mode ("periodic" or "revision").
+    {{- if .Values.sharedConfig.autoCompactionMode }}
+    auto-compaction-mode: {{ .Values.sharedConfig.autoCompactionMode }}
+    {{- end }}
+
+    # auto-compaction-retention defines Auto compaction retention length for etcd.
+    {{- if .Values.sharedConfig.autoCompactionRetention }}
+    auto-compaction-retention: {{ .Values.sharedConfig.autoCompactionRetention }}
+    {{- end }}
+    {{- end }}
 
 {{- if .Values.etcd.enableTLS }}
     client-transport-security:

--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -167,6 +167,14 @@ spec:
         - --compression-policy={{ .Values.backup.compression.policy }}
         {{- end }}
 {{- end }}
+{{- if .Values.sharedConfig }}
+        {{- if .Values.sharedConfig.autoCompactionMode }}
+        - --auto-compaction-mode={{ .Values.sharedConfig.autoCompactionMode }}
+        {{- end }}
+        {{- if .Values.sharedConfig.autoCompactionRetention }}
+        - --auto-compaction-retention={{ .Values.sharedConfig.autoCompactionRetention }}
+        {{- end }}
+{{- end }}
         - --snapstore-temp-directory={{ .Values.backup.snapstoreTempDir }}
         image: {{ .Values.backup.image }}
         imagePullPolicy: {{ .Values.backup.pullPolicy }}

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -49,6 +49,14 @@ backup:
   #   enabled: true
   #   policy: "gzip"
 
+# sharedConfig defines parameters shared and used by Etcd as well as backup-restore sidecar.
+sharedConfig: 
+  # autoCompaction defines the specification to be used by Etcd as well as by embedded-Etcd of backup-restore sidecar during restoration.
+  # auto-compaction mode: 'periodic' mode or 'revision' mode for etcd as well as for embedded-Etcd of backup-restore sidecar.
+  # auto-compaction retention length for etcd as well as for embedded-Etcd of backup-restore sidecar.
+  autoCompactionMode: periodic
+  autoCompactionRetention: "30m"
+
 volumeClaimTemplateName: test
 storageClass: ""
 storageCapacity: 16Gi

--- a/config/crd/bases/druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/druid.gardener.cloud_etcds.yaml
@@ -310,6 +310,19 @@ spec:
                     description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+              sharedConfig:
+                description: SharedConfig defines parameters shared and used by Etcd as well as backup-restore sidecar.
+                properties:
+                  autoCompactionMode:
+                    description: AutoCompactionMode defines the auto-compaction-mode:'periodic' mode or 'revision' mode for etcd and embedded-Etcd of backup-restore sidecar.
+                    enum:
+                    - periodic
+                    - revision
+                    type: string
+                  autoCompactionRetention:
+                    description: AutoCompactionRetention defines the auto-compaction-retention length for etcd as well as for embedded-Etcd of backup-restore sidecar.
+                    type: string
+                type: object
               storageCapacity:
                 anyOf:
                 - type: integer

--- a/config/samples/druid_v1alpha1_etcd.yaml
+++ b/config/samples/druid_v1alpha1_etcd.yaml
@@ -37,7 +37,7 @@ spec:
         clientPort: 2379
         serverPort: 2380
     backup:
-        image: eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.12.0-dev-e6df91b7463cf784f651bd6cc6ac7fc4d2e5a70b
+        image: eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.12.0-dev-34f854c06838d14d6e7b08099d6cfa6fca2ad50d
         port: 8080
         fullSnapshotSchedule: "0 */24 * * *"
         resources:
@@ -57,6 +57,11 @@ spec:
         compression:
             enabled: false
             policy: "gzip"
+    
+    sharedConfig:
+        autoCompactionMode: periodic
+        autoCompactionRetention: "30m"
+
     replicas: 1
     # priorityClassName: foo
     storageClass: gardener.cloud-fast


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR make auto-compaction-mode and auto-compaction-retention configurable for Etcd and for embedded-Etcd of backup-restore(CLI flags was Introduce in this [PR](https://github.com/gardener/etcd-backup-restore/pull/315)) via etcd-resource spec as well as via helm-charts.

**Which issue(s) this PR fixes**:
Fixes #136 

**Special notes for your reviewer**:

**Release note**:
```feature user
Configure auto-compaction policy for etcd and backup sidecar's embedded etcd via Etcd resource via `.spec.sharedConfig.autoCompactionMode` and `.spec.sharedConfig.autoCompactionRetention`.
```
