### PR TITLE
Added mutex lock before every update of ETCD instance.

### DIFF
--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Druid", func() {
 		})
 	})
 
-	Describe("Druid cuatodian controller", func() {
+	Describe("Druid custodian controller", func() {
 		Context("when adding etcd resources with statefulset already present", func() {
 			var (
 				instance *druidv1alpha1.Etcd
@@ -345,7 +345,12 @@ var _ = Describe("Druid", func() {
 				// Delete `etcd` instance
 				Expect(c.Delete(ctx, instance)).To(Succeed())
 				Eventually(func() error {
-					return c.Get(ctx, client.ObjectKeyFromObject(instance), &druidv1alpha1.Etcd{})
+					err := c.Get(ctx, client.ObjectKeyFromObject(instance), &druidv1alpha1.Etcd{})
+					if err != nil {
+						return err
+					}
+
+					return c.Get(ctx, client.ObjectKeyFromObject(instance), sts)
 				}, timeout, pollingInterval).Should(matchers.BeNotFoundError())
 			})
 		})

--- a/controllers/etcd_custodian_controller.go
+++ b/controllers/etcd_custodian_controller.go
@@ -124,10 +124,10 @@ func (ec *EtcdCustodian) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 func (ec *EtcdCustodian) updateEtcdStatus(ctx context.Context, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) error {
 	logger.Infof("Reconciling etcd status in Custodian Controller for etcd statefulset status:%s in namespace:%s", etcd.Name, etcd.Namespace)
-	if err := ec.Get(ctx, types.NamespacedName{Name: etcd.Name, Namespace: etcd.Namespace}, etcd); err != nil {
-		logger.Errorf("Error during fetching ETCD resource in ETCD controller: %v", err)
-		return err
-	}
+
+	m := getMutex()
+	m.Lock()
+	defer m.Unlock()
 
 	etcd.Status.Etcd = druidv1alpha1.CrossVersionObjectReference{
 		APIVersion: sts.APIVersion,
@@ -157,6 +157,10 @@ func (ec *EtcdCustodian) updateEtcdStatus(ctx context.Context, etcd *druidv1alph
 
 func (ec *EtcdCustodian) updateEtcdStatusWithNoSts(ctx context.Context, etcd *druidv1alpha1.Etcd) {
 	logger.Infof("Reconciling etcd status in Custodian Controller when no statefulset found:%s in namespace:%s", etcd.Name, etcd.Namespace)
+
+	m := getMutex()
+	m.Lock()
+	defer m.Unlock()
 
 	conditions := []druidv1alpha1.Condition{}
 	etcd.Status.Conditions = conditions


### PR DESCRIPTION
Sometimes the following error is coming while running the controllers:
```
Expected success, but got an error:
      <*errors.StatusError | 0xc0002314a0>: {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "Operation cannot be fulfilled on statefulsets.apps \"foo3\": the object has been modified; please apply your changes to the latest version and try again",
              Reason: "Conflict",
              Details: {Name: "foo3", Group: "apps", Kind: "statefulsets", UID: "", Causes: nil, RetryAfterSeconds: 0},
              Code: 409,
          },
      }
      Operation cannot be fulfilled on statefulsets.apps "foo3": the object has been modified; please apply your changes to the latest version and try again
```

Though this error is harmless as reconciler will reque after the error, but it is due to the fact that both the controllers(ETCD controller, custodian controller) are trying to update same ETCD resource. So to avoid data race condition, I added mutex lock/unlock before ETCD update operation.