### PR TITLE
Introduce make check-generate

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -19,9 +19,13 @@ set -o pipefail
 
 cd "$(dirname $0)/.."
 
+git config --global user.email "gardener@sap.com"
+git config --global user.name "Gardener CI/CD"
+
 mkdir -p /go/src/github.com/gardener/etcd-druid
 cp -r . /go/src/github.com/gardener/etcd-druid
 cd /go/src/github.com/gardener/etcd-druid
 
 make install-requirements
 make check
+make check-generate

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ deploy: manifests
 
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
-manifests: install-requirements
+manifests:
 	@cd "$(REPO_ROOT)/api" && controller-gen $(CRD_OPTIONS) paths="./..." output:crd:artifacts:config=../config/crd/bases
 	@controller-gen rbac:roleName=manager-role paths="./controllers/..."
 
@@ -73,16 +73,24 @@ manifests: install-requirements
 fmt:
 	@env GO111MODULE=on go fmt ./...
 
+.PHONY: clean
+clean:
+	@"$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/clean.sh" ./api/... ./controllers/... ./pkg/...
+
 # Check packages
 .PHONY: check
 check:
 	@cd "$(REPO_ROOT)/api" && "$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check.sh" --golangci-lint-config=../.golangci.yaml ./...
 	@"$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check.sh" --golangci-lint-config=./.golangci.yaml ./pkg/... ./controllers/...
 
+.PHONY: check-generate
+check-generate:
+	@"$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check-generate.sh" "$(REPO_ROOT)"
+
 # Generate code
 .PHONY: generate
-generate: install-requirements
-	cd "$(REPO_ROOT)/api" && controller-gen object:headerFile=../hack/boilerplate.go.txt paths=./...
+generate:
+	@"$(REPO_ROOT)/hack/update-codegen.sh"
 
 # Build the docker image
 .PHONY: docker-build

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "> Update Code Generation"
+
+cd "$PROJECT_DIR/api" && controller-gen object:headerFile=$SCRIPT_DIR/boilerplate.go.txt paths=./...
+
+# needed as long as https://github.com/kubernetes-sigs/controller-tools/issues/559 is not fixed
+find "$PROJECT_DIR/api" -type f -name "zz_*.go" -exec goimports -w '{}' \;

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -23,7 +23,7 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 echo "> Update Code Generation"
 
-cd "$PROJECT_DIR/api" && controller-gen object:headerFile=$SCRIPT_DIR/boilerplate.go.txt paths=./...
+cd "$PROJECT_DIR/api" && controller-gen "object:headerFile=$SCRIPT_DIR/boilerplate.go.txt" paths=./...
 
 # needed as long as https://github.com/kubernetes-sigs/controller-tools/issues/559 is not fixed
 find "$PROJECT_DIR/api" -type f -name "zz_*.go" -exec goimports -w '{}' \;


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
A new make target `make check-generate` has been added. Like other for other Gardener projects, the target checks if generation and re-vendoring happened correctly. After merging this PR, the check is executed by the pipeline and will prevent cases as experienced in https://github.com/gardener/etcd-druid/issues/171#issuecomment-844046045.

**Special notes for your reviewer**:
For performance reasons, the `install-requirements` target has been removed as a dependency from other targets and thus must be called explicitly whenever required.
Also, `goimports` is invoked for generated files with `make generate` because `controller-gen` does not generate compliant files at the moment (see this [issue](https://github.com/kubernetes-sigs/controller-tools/issues/559)).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
A new Make target `check-generate` has been added to check if generated code and the vendor dir are up-to-date.
```
