### PR TITLE
Upgrade github_com_gardener_etcd-backup-restore to v0.12.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.12.0"
+  tag: "v0.12.1"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd


### PR DESCRIPTION
**How to categorize this PR?**

**What this PR does / why we need it**:
Upgrade github_com_gardener_etcd-backup-restore to v0.12.1

**Which issue(s) this PR fixes**:
Fixes https://github.tools.sap/kubernetes-canary/issues-canary/issues/817

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated number of chunks while uploading to never exceed the cloud provider limits.
```
