### PR TITLE
Enable profiling of etcd-backup-restore-sidecar

### DIFF
--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -166,6 +166,9 @@ type EtcdConfig struct {
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// +optional
 	TLS *TLSConfig `json:"tls,omitempty"`
+	// EnableProfiling defines if profiling should be enabled for the etcd-backup-restore-sidecar
+	// +optional
+	EnableProfiling *bool `json:"enableProfiling,omitempty"`
 }
 
 // SharedConfig defines parameters shared and used by Etcd as well as backup-restore sidecar.

--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -138,6 +138,9 @@ type BackupSpec struct {
 	// SnapshotCompression defines the specification for compression of Snapshots.
 	// +optional
 	SnapshotCompression *CompressionSpec `json:"compression,omitempty"`
+	// EnableProfiling defines if profiling should be enabled for the etcd-backup-restore-sidecar
+	// +optional
+	EnableProfiling *bool `json:"enableProfiling,omitempty"`
 }
 
 // EtcdConfig defines parameters associated etcd deployed
@@ -166,9 +169,6 @@ type EtcdConfig struct {
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// +optional
 	TLS *TLSConfig `json:"tls,omitempty"`
-	// EnableProfiling defines if profiling should be enabled for the etcd-backup-restore-sidecar
-	// +optional
-	EnableProfiling *bool `json:"enableProfiling,omitempty"`
 }
 
 // SharedConfig defines parameters shared and used by Etcd as well as backup-restore sidecar.

--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -135,6 +135,9 @@ spec:
 {{- if .Values.backup.etcdQuotaBytes }}
         - --embedded-etcd-quota-bytes={{ int $.Values.backup.etcdQuotaBytes }}
 {{- end }}
+{{- if .Values.backup.enableProfiling }}
+        - --enable-profiling={{ .Values.backup.enableProfiling }}
+{{- end }}
 {{- if .Values.etcd.enableTLS }}
         - --cert=/var/etcd/ssl/client/tls.crt
         - --key=/var/etcd/ssl/client/tls.key

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -36,6 +36,7 @@ backup:
   snapstoreTempDir: "/var/etcd/data/temp"
   etcdConnectionTimeout: 5m
   etcdQuotaBytes: 8Gi
+  enableProfiling: true
   garbageCollectionPolicy: LimitBased
   maxBackups: 7
   resources:

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -36,7 +36,7 @@ backup:
   snapstoreTempDir: "/var/etcd/data/temp"
   etcdConnectionTimeout: 5m
   etcdQuotaBytes: 8Gi
-  enableProfiling: true
+  enableProfiling: false
   garbageCollectionPolicy: LimitBased
   maxBackups: 7
   resources:

--- a/config/crd/bases/druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/druid.gardener.cloud_etcds.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: etcds.druid.gardener.cloud
 spec:

--- a/config/crd/bases/druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/druid.gardener.cloud_etcds.yaml
@@ -78,6 +78,10 @@ spec:
                     description: DeltaSnapshotPeriod defines the period after which
                       delta snapshots will be taken
                     type: string
+                  enableProfiling:
+                    description: EnableProfiling defines if profiling should be enabled
+                      for the etcd-backup-restore-sidecar
+                    type: boolean
                   fullSnapshotSchedule:
                     description: FullSnapshotSchedule defines the cron standard schedule
                       for full snapshots.
@@ -229,10 +233,6 @@ spec:
                     description: DefragmentationSchedule defines the cron standard
                       schedule for defragmentation of etcd.
                     type: string
-                  enableProfiling:
-                    description: EnableProfiling defines if profiling should be enabled
-                      for the etcd-backup-restore-sidecar
-                    type: boolean
                   image:
                     description: Image defines the etcd container image and tag
                     type: string

--- a/config/crd/bases/druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/druid.gardener.cloud_etcds.yaml
@@ -229,6 +229,10 @@ spec:
                     description: DefragmentationSchedule defines the cron standard
                       schedule for defragmentation of etcd.
                     type: string
+                  enableProfiling:
+                    description: EnableProfiling defines if profiling should be enabled
+                      for the etcd-backup-restore-sidecar
+                    type: boolean
                   image:
                     description: Image defines the etcd container image and tag
                     type: string

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -890,12 +890,19 @@ func (r *EtcdReconciler) getMapFromEtcd(etcd *druidv1alpha1.Etcd) (map[string]in
 		deltaSnapshotMemoryLimit = etcd.Spec.Backup.DeltaSnapshotMemoryLimit.Value()
 	}
 
+	var enableProfiling = false
+	if etcd.Spec.Etcd.EnableProfiling != nil {
+		enableProfiling = *etcd.Spec.Etcd.EnableProfiling
+
+	}
+
 	backupValues := map[string]interface{}{
 		"pullPolicy":               corev1.PullIfNotPresent,
 		"etcdQuotaBytes":           quota,
 		"etcdConnectionTimeout":    "5m",
 		"snapstoreTempDir":         "/var/etcd/data/temp",
 		"deltaSnapshotMemoryLimit": deltaSnapshotMemoryLimit,
+		"enableProfiling":          enableProfiling,
 	}
 
 	if etcd.Spec.Backup.Resources != nil {

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -891,8 +891,8 @@ func (r *EtcdReconciler) getMapFromEtcd(etcd *druidv1alpha1.Etcd) (map[string]in
 	}
 
 	var enableProfiling = false
-	if etcd.Spec.Etcd.EnableProfiling != nil {
-		enableProfiling = *etcd.Spec.Etcd.EnableProfiling
+	if etcd.Spec.Backup.EnableProfiling != nil {
+		enableProfiling = *etcd.Spec.Backup.EnableProfiling
 
 	}
 

--- a/vendor/github.com/gardener/etcd-druid/api/v1alpha1/etcd_types.go
+++ b/vendor/github.com/gardener/etcd-druid/api/v1alpha1/etcd_types.go
@@ -166,6 +166,9 @@ type EtcdConfig struct {
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// +optional
 	TLS *TLSConfig `json:"tls,omitempty"`
+	// EnableProfiling defines if profiling should be enabled for the etcd-backup-restore-sidecar
+	// +optional
+	EnableProfiling *bool `json:"enableProfiling,omitempty"`
 }
 
 // SharedConfig defines parameters shared and used by Etcd as well as backup-restore sidecar.

--- a/vendor/github.com/gardener/etcd-druid/api/v1alpha1/etcd_types.go
+++ b/vendor/github.com/gardener/etcd-druid/api/v1alpha1/etcd_types.go
@@ -138,6 +138,9 @@ type BackupSpec struct {
 	// SnapshotCompression defines the specification for compression of Snapshots.
 	// +optional
 	SnapshotCompression *CompressionSpec `json:"compression,omitempty"`
+	// EnableProfiling defines if profiling should be enabled for the etcd-backup-restore-sidecar
+	// +optional
+	EnableProfiling *bool `json:"enableProfiling,omitempty"`
 }
 
 // EtcdConfig defines parameters associated etcd deployed
@@ -166,9 +169,6 @@ type EtcdConfig struct {
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// +optional
 	TLS *TLSConfig `json:"tls,omitempty"`
-	// EnableProfiling defines if profiling should be enabled for the etcd-backup-restore-sidecar
-	// +optional
-	EnableProfiling *bool `json:"enableProfiling,omitempty"`
 }
 
 // SharedConfig defines parameters shared and used by Etcd as well as backup-restore sidecar.


### PR DESCRIPTION
**How to categorize this PR?**
  /area ops-productivity
  /area robustness
 /kind enhancement

**What this PR does / why we need it**:
We face currently a memory leak in the etcd-backup-restore-sidecar, but profiling is not configurable with the etcd-druid.

