### PR TITLE
Fix reconciliation predicates.

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -82,31 +82,6 @@ func LastOperationNotSuccessful() predicate.Predicate {
 	}
 }
 
-// GenerationChangedPredicate implements a update predicate function on Generation or ResourceVersion change.
-type GenerationChangedPredicate struct {
-	predicate.Funcs
-}
-
-// Update implements default UpdateEvent filter for validating generation change
-func (GenerationChangedPredicate) Update(e event.UpdateEvent) bool {
-	etcd, ok := e.ObjectNew.(*druidv1alpha1.Etcd)
-	if !ok {
-		// Reconcile triggers for other resources should return true.
-		return true
-	}
-	return etcd.Status.ObservedGeneration == nil || *etcd.Status.ObservedGeneration != etcd.Generation
-}
-
-// Create implements default CreateEvent filter for validating generation change
-func (GenerationChangedPredicate) Create(e event.CreateEvent) bool {
-	etcd, ok := e.Object.(*druidv1alpha1.Etcd)
-	if !ok {
-		// We are creating the other resources so we needn't reconcile etcd here.
-		return false
-	}
-	return etcd.Status.ObservedGeneration == nil || *etcd.Status.ObservedGeneration != etcd.Generation
-}
-
 // StatefulSetStatusChange is a predicate for status changes of `StatefulSet` resources.
 func StatefulSetStatusChange() predicate.Predicate {
 	statusChange := func(objOld, objNew client.Object) bool {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
If operation annotation is to be honoured, the reconciliation predicates now match only if either operation annotation is present, or last operation didn't succeed or if the resource is undergoing deletion. No other change (if not accompanied by any of these conditions) will trigger reconciliation.

**Which issue(s) this PR fixes**:
Fixes #196 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
If operation annotation is to be honoured, the reconciliation predicates now match only if either operation annotation is present, or last operation didn't succeed or if the resource is undergoing deletion. No other change (if not accompanied by any of these conditions) will trigger reconciliation.
```
