### PR TITLE
Updated compaction cronjob to use an emptyDir as volume and add resource values for the pod

### DIFF
--- a/charts/etcd/templates/etcd-compaction-cronjob.yaml
+++ b/charts/etcd/templates/etcd-compaction-cronjob.yaml
@@ -25,6 +25,11 @@ metadata:
 spec:
   schedule: {{ .Values.backup.backupCompactionSchedule }} 
   concurrencyPolicy: Forbid
+{{- if eq (int $.Values.statefulsetReplicas) 0 }}
+  suspend: true
+{{- else }}
+  suspend: false
+{{- end }}
   jobTemplate:
     spec:
       backoffLimit: 0
@@ -50,7 +55,8 @@ spec:
             command:
             - etcdbrctl
             - compact
-            - --data-dir=/var/etcd/data/new.etcd
+            - --data-dir=/var/etcd/data
+            - --snapstore-temp-directory=/var/etcd/data/tmp
 {{- if  .Values.store.storageProvider }}
             - --storage-provider={{ .Values.store.storageProvider }}
 {{- end }}
@@ -68,7 +74,11 @@ spec:
               name: server
               protocol: TCP
             resources:
-{{ toYaml .Values.backup.resources | indent 14 }}
+{{- if .Values.backup.enableBackupCompactionJobTempFS }}
+{{ toYaml .Values.backup.compactionResourcesTempFS | indent 14 }}
+{{- else }}
+{{ toYaml .Values.backup.compactionResources | indent 14 }}
+{{- end }}
             env:
             - name: STORAGE_CONTAINER
               value: {{ .Values.store.storageContainer }}
@@ -195,6 +205,8 @@ spec:
                   optional: true
 {{- end }}
             volumeMounts:
+            - name: etcd-workspace-dir
+              mountPath: /var/etcd/data
             - name: etcd-config-file
               mountPath: /var/etcd/config/
 {{- if eq .Values.store.storageProvider "GCS" }}
@@ -202,6 +214,13 @@ spec:
               mountPath: "/root/.gcp/"
 {{- end }}
           volumes:
+          - name: etcd-workspace-dir
+{{- if .Values.backup.enableBackupCompactionJobTempFS }}
+            emptyDir:
+              medium: Memory
+{{- else }}
+            emptyDir: {} 
+{{- end }}
           - name: etcd-config-file
             configMap:
               name: {{ .Values.configMapName }}

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -46,6 +46,20 @@ backup:
     requests:
       cpu: 50m
       memory: 128Mi
+  compactionResources:
+    limits:
+      cpu: 700m
+      memory: 3Gi
+    requests:
+      cpu: 500m
+      memory: 2Gi
+  compactionResourcesTempFS:
+    limits:
+      cpu: 900m
+      memory: 12Gi
+    requests:
+      cpu: 700m
+      memory: 10Gi
   # compression:
   #   enabled: true
   #   policy: "gzip"

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -104,7 +104,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(err).NotTo(HaveOccurred())
-	er, err := NewEtcdReconcilerWithImageVector(mgr)
+	er, err := NewEtcdReconcilerWithImageVector(mgr, false)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = er.SetupWithManager(mgr, 1, true)

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -829,7 +829,8 @@ func validateEtcdWithCronjob(s *appsv1.StatefulSet, cm *corev1.ConfigMap, svc *c
 							"Containers": MatchElements(containerIterator, IgnoreExtras, Elements{
 								"compact-backup": MatchFields(IgnoreExtras, Fields{
 									"Command": MatchElements(cmdIterator, IgnoreExtras, Elements{
-										"--data-dir=/var/etcd/data/new.etcd":                                                   Equal("--data-dir=/var/etcd/data/new.etcd"),
+										"--data-dir=/var/etcd/data":                                                            Equal("--data-dir=/var/etcd/data"),
+										"--snapstore-temp-directory=/var/etcd/data/tmp":                                        Equal("--snapstore-temp-directory=/var/etcd/data/tmp"),
 										fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix):              Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 										fmt.Sprintf("%s=%s", "--storage-provider", store):                                      Equal(fmt.Sprintf("%s=%s", "--storage-provider", store)),
 										fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container):       Equal(fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container)),
@@ -849,6 +850,10 @@ func validateEtcdWithCronjob(s *appsv1.StatefulSet, cm *corev1.ConfigMap, svc *c
 										"etcd-config-file": MatchFields(IgnoreExtras, Fields{
 											"Name":      Equal("etcd-config-file"),
 											"MountPath": Equal("/var/etcd/config/"),
+										}),
+										"etcd-workspace-dir": MatchFields(IgnoreExtras, Fields{
+											"Name":      Equal("etcd-workspace-dir"),
+											"MountPath": Equal("/var/etcd/data"),
 										}),
 									}),
 									"Env": MatchElements(envIterator, IgnoreExtras, Elements{
@@ -874,6 +879,15 @@ func validateEtcdWithCronjob(s *appsv1.StatefulSet, cm *corev1.ConfigMap, svc *c
 													"Path": Equal("etcd.conf.yaml"),
 												}),
 											}),
+										})),
+									}),
+								}),
+								"etcd-workspace-dir": MatchFields(IgnoreExtras, Fields{
+									"Name": Equal("etcd-workspace-dir"),
+									"VolumeSource": MatchFields(IgnoreExtras, Fields{
+										"HostPath": BeNil(),
+										"EmptyDir": PointTo(MatchFields(IgnoreExtras, Fields{
+											"SizeLimit": BeNil(),
 										})),
 									}),
 								}),

--- a/main.go
+++ b/main.go
@@ -50,15 +50,16 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr                string
-		enableLeaderElection       bool
-		leaderElectionID           string
-		leaderElectionResourceLock string
-		etcdWorkers                int
-		custodianWorkers           int
-		custodianSyncPeriod        time.Duration
-		disableLeaseCache          bool
-		ignoreOperationAnnotation  bool
+		metricsAddr                     string
+		enableLeaderElection            bool
+		leaderElectionID                string
+		leaderElectionResourceLock      string
+		etcdWorkers                     int
+		custodianWorkers                int
+		custodianSyncPeriod             time.Duration
+		disableLeaseCache               bool
+		ignoreOperationAnnotation       bool
+		enableBackupCompactionJobTempFS bool
 
 		etcdMemberNotReadyThreshold time.Duration
 
@@ -80,6 +81,7 @@ func main() {
 	flag.BoolVar(&disableLeaseCache, "disable-lease-cache", false, "Disable cache for lease.coordination.k8s.io resources.")
 	flag.BoolVar(&ignoreOperationAnnotation, "ignore-operation-annotation", true, "Ignore the operation annotation or not.")
 	flag.DurationVar(&etcdMemberNotReadyThreshold, "etcd-member-notready-threshold", 5*time.Minute, "Threshold after which an etcd member is considered not ready if the status was unknown before.")
+	flag.BoolVar(&enableBackupCompactionJobTempFS, "enable-backup-compaction-job-tempfs", false, "Enable the backup compaction job to use tempfs as its volume mount")
 
 	flag.Parse()
 
@@ -106,7 +108,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	etcd, err := controllers.NewEtcdReconcilerWithImageVector(mgr)
+	etcd, err := controllers.NewEtcdReconcilerWithImageVector(mgr, enableBackupCompactionJobTempFS)
 	if err != nil {
 		setupLog.Error(err, "Unable to initialize controller with image vector")
 		os.Exit(1)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR updates the compaction cronjob to add a new `emptyDir` volume mount and configure resources for the compaction job.
Also adds a new CLI flag `enable-compaction-tempfs` to etcd druid that decides if compaction job should use tempfs as it's volumeMount or not (defaults to false - does not use tempfs)

**Which issue(s) this PR fixes**:
Fixes #218 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added a new CLI flag `--enable-compaction-tempfs` to etcd druid to enable tempfs in the compaction job volumeMount (defaults to false)
```
