### PR TITLE
Updated the MultiNode proposal: To take out-of-sync snapshots delegate the incoming http request to backup-leader.

### DIFF
--- a/docs/proposals/multi-node/README.md
+++ b/docs/proposals/multi-node/README.md
@@ -1242,7 +1242,7 @@ The life-cycle of these work-flows is shown below.
 
 ### Work-flows independent of leader election in all members
 
-- Serve the HTTP API that all members are expected to support currently
+- Serve the [HTTP API](https://github.com/gardener/etcd-backup-restore/blob/master/pkg/server/httpAPI.go#L101-L107) that all members are expected to support currently but some HTTP API call which are used to take [out-of-sync delta or full snapshot](https://github.com/gardener/etcd-backup-restore/blob/5dfcc1f848a9f325d41a24eae4defb70d997c215/pkg/server/httpAPI.go#L103-L105) should delegate the incoming HTTP requests to the `leading-sidecar` and one of the possible approach to achieve this is via an [HTTP reverse proxy](https://pkg.go.dev/net/http/httputil#ReverseProxy.ServeHTTP).
 - Check the health of the respective etcd member and renew the corresponding [member `lease`](#member-leases).
 
 ### Work-flows only on the leading member


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updated the MultiNode proposal:
To take [out-of-sync  full/delta snapshots](https://github.com/gardener/etcd-backup-restore/blob/master/pkg/server/httpAPI.go#L103-L105) delegate the incoming http request to `backup-restore leader` and Let the `backup-restore leader` take/upload the out-of-sync snapshot(full as well as incremental)
I had already created a issue regarding this: https://github.com/gardener/etcd-backup-restore/issues/354

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
