### PR TITLE
Several improvements for compaction feature

### DIFF
--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -116,6 +116,11 @@ spec:
         command:
         - etcdbrctl
         - server
+{{- if and .Values.backup.fullSnapLeaseName .Values.backup.deltaSnapLeaseName }}
+        - --enable-snapshot-lease-renewal=true
+        - --delta-snapshot-lease-name={{ .Values.backup.deltaSnapLeaseName }}
+        - --full-snapshot-lease-name={{ .Values.backup.fullSnapLeaseName }}
+{{- end }}
 {{- if .Values.etcd.defragmentationSchedule }}
         - --defragmentation-schedule={{ .Values.etcd.defragmentationSchedule }}
 {{- end }}

--- a/controllers/compaction_lease_controller.go
+++ b/controllers/compaction_lease_controller.go
@@ -104,17 +104,15 @@ func (lc *CompactionLeaseController) Reconcile(ctx context.Context, req ctrl.Req
 		return lc.delete(ctx, lc.logger, etcd)
 	}
 
-	logger := lc.logger.WithValues("etcd", kutil.Key(etcd.Namespace, etcd.Name).String())
-
-	// Get delta snapshot lease to check the HolderIdentity value to take decision on compaction job
-	nsName := types.NamespacedName{
-		Name:      getFullSnapshotLeaseName(etcd),
-		Namespace: etcd.Namespace,
+	if etcd.Spec.Backup.Store == nil {
+		return ctrl.Result{}, nil
 	}
 
+	logger := lc.logger.WithValues("etcd", kutil.Key(etcd.Namespace, etcd.Name).String())
+
+	// Get full and delta snapshot lease to check the HolderIdentity value to take decision on compaction job
 	fullLease := &coordinationv1.Lease{}
-	err := lc.Get(ctx, nsName, fullLease)
-	if err != nil {
+	if err := lc.Get(ctx, kutil.Key(etcd.Namespace, getFullSnapshotLeaseName(etcd)), fullLease); err != nil {
 		logger.Info("Couldn't fetch full snap lease because: " + err.Error())
 
 		return ctrl.Result{
@@ -122,14 +120,8 @@ func (lc *CompactionLeaseController) Reconcile(ctx context.Context, req ctrl.Req
 		}, err
 	}
 
-	nsName = types.NamespacedName{
-		Name:      getDeltaSnapshotLeaseName(etcd),
-		Namespace: etcd.Namespace,
-	}
-
 	deltaLease := &coordinationv1.Lease{}
-	err = lc.Get(ctx, nsName, deltaLease)
-	if err != nil {
+	if err := lc.Get(ctx, kutil.Key(etcd.Namespace, getDeltaSnapshotLeaseName(etcd)), deltaLease); err != nil {
 		logger.Info("Couldn't fetch delta snap lease because: " + err.Error())
 
 		return ctrl.Result{
@@ -137,35 +129,36 @@ func (lc *CompactionLeaseController) Reconcile(ctx context.Context, req ctrl.Req
 		}, err
 	}
 
-	// Run compaction job
-	if etcd.Spec.Backup.Store != nil {
-		full, err := strconv.ParseInt(*fullLease.Spec.HolderIdentity, 10, 64)
-		if err != nil {
-			logger.Error(err, "Can't convert holder identity of full snap lease to integer")
-			return ctrl.Result{
-				RequeueAfter: 10 * time.Second,
-			}, err
-		}
-
-		delta, err := strconv.ParseInt(*deltaLease.Spec.HolderIdentity, 10, 64)
-		if err != nil {
-			logger.Error(err, "Can't convert holder identity of delta snap lease to integer")
-			return ctrl.Result{
-				RequeueAfter: 10 * time.Second,
-			}, err
-		}
-
-		diff := delta - full
-
-		// Reconcile job only when number of accumulated revisions over the last full snapshot is more than the configured threshold value via 'events-threshold' flag
-		if diff >= lc.config.EventsThreshold {
-			return lc.reconcileJob(ctx, logger, etcd)
-		}
+	// Revisions have not been set yet by etcd-back-restore container.
+	// Skip further processing as we cannot calculate a revision delta.
+	if fullLease.Spec.HolderIdentity == nil || deltaLease.Spec.HolderIdentity == nil {
+		return ctrl.Result{}, nil
 	}
 
-	return ctrl.Result{
-		Requeue: false,
-	}, nil
+	full, err := strconv.ParseInt(*fullLease.Spec.HolderIdentity, 10, 64)
+	if err != nil {
+		logger.Error(err, "Can't convert holder identity of full snap lease to integer")
+		return ctrl.Result{
+			RequeueAfter: 10 * time.Second,
+		}, err
+	}
+
+	delta, err := strconv.ParseInt(*deltaLease.Spec.HolderIdentity, 10, 64)
+	if err != nil {
+		logger.Error(err, "Can't convert holder identity of delta snap lease to integer")
+		return ctrl.Result{
+			RequeueAfter: 10 * time.Second,
+		}, err
+	}
+
+	diff := delta - full
+
+	// Reconcile job only when number of accumulated revisions over the last full snapshot is more than the configured threshold value via 'events-threshold' flag
+	if diff >= lc.config.EventsThreshold {
+		return lc.reconcileJob(ctx, logger, etcd)
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func (lc *CompactionLeaseController) reconcileJob(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd) (ctrl.Result, error) {

--- a/controllers/config/compaction.go
+++ b/controllers/config/compaction.go
@@ -18,6 +18,8 @@ import "time"
 
 // CompactionLeaseConfig contains configuration for the compaction controller.
 type CompactionLeaseConfig struct {
+	// CompactionEnabled defines of compaction jobs should be created.
+	CompactionEnabled bool
 	// ActiveDeadlineDuration is the duration after which a running compaction job will be killed (Ex: "300ms", "20s", "-1.5h" or "2h45m")
 	ActiveDeadlineDuration time.Duration
 	// EventsThreshold is total number of etcd events that can be allowed before a backup compaction job is triggered

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -127,6 +127,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 
 	lc, err := NewCompactionLeaseControllerWithImageVector(mgr, controllersconfig.CompactionLeaseConfig{
+		CompactionEnabled:      true,
 		EventsThreshold:        1000000,
 		ActiveDeadlineDuration: activeDeadlineDuration,
 	})

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -946,7 +946,6 @@ func getDeltaSnapshotLeaseName(etcd *druidv1alpha1.Etcd) string {
 }
 
 func createSnapshotLease(etcd *druidv1alpha1.Etcd, snapshotLeaseName string) *coordinationv1.Lease {
-	renewTime := metav1.NewMicroTime(time.Now())
 	return &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      snapshotLeaseName,
@@ -961,10 +960,6 @@ func createSnapshotLease(etcd *druidv1alpha1.Etcd, snapshotLeaseName string) *co
 					UID:                etcd.UID,
 				},
 			},
-		},
-		Spec: coordinationv1.LeaseSpec{
-			HolderIdentity: pointer.StringPtr("0"),
-			RenewTime:      &renewTime,
 		},
 	}
 }

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -1350,8 +1350,8 @@ func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd) (map[s
 		"jobName":                 getJobName(etcd),
 		"volumeClaimTemplateName": volumeClaimTemplateName,
 		"serviceAccountName":      getServiceAccountName(etcd),
-		"roleName":                fmt.Sprintf("%s-br-role", etcd.Name),
-		"roleBindingName":         fmt.Sprintf("%s-br-rolebinding", etcd.Name),
+		"roleName":                fmt.Sprintf("druid.gardener.cloud:etcd:%s", etcd.Name),
+		"roleBindingName":         fmt.Sprintf("druid.gardener.cloud:etcd:%s", etcd.Name),
 	}
 
 	if etcd.Spec.StorageCapacity != nil {
@@ -1385,7 +1385,7 @@ func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd) (map[s
 }
 
 func getServiceAccountName(etcd *druidv1alpha1.Etcd) string {
-	return fmt.Sprintf("%s-br-serviceaccount", etcd.Name)
+	return etcd.Name
 }
 
 func getEtcdImages(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd) (string, string, error) {

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -1347,8 +1347,6 @@ func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd) (map[s
 		"statefulsetReplicas":     statefulsetReplicas,
 		"serviceName":             fmt.Sprintf("%s-client", etcd.Name),
 		"configMapName":           fmt.Sprintf("etcd-bootstrap-%s", string(etcd.UID[:6])),
-		"fullSnapLeaseName":       getFullSnapshotLeaseName(etcd),
-		"deltaSnapLeaseName":      getDeltaSnapshotLeaseName(etcd),
 		"jobName":                 getJobName(etcd),
 		"volumeClaimTemplateName": volumeClaimTemplateName,
 		"serviceAccountName":      getServiceAccountName(etcd),
@@ -1378,6 +1376,9 @@ func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd) (map[s
 		if values["store"], err = utils.GetStoreValues(etcd.Spec.Backup.Store); err != nil {
 			return nil, err
 		}
+
+		backupValues["fullSnapLeaseName"] = getFullSnapshotLeaseName(etcd)
+		backupValues["deltaSnapLeaseName"] = getDeltaSnapshotLeaseName(etcd)
 	}
 
 	return values, nil

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -165,15 +165,15 @@ func accessModeIterator(element interface{}) string {
 }
 
 func cmdIterator(element interface{}) string {
-	return string(element.(string))
+	return element.(string)
 }
 
 func ruleIterator(element interface{}) string {
-	return string(element.(rbac.PolicyRule).APIGroups[0])
+	return element.(rbac.PolicyRule).APIGroups[0]
 }
 
 func stringArrayIterator(element interface{}) string {
-	return string(element.(string))
+	return element.(string)
 }
 
 var _ = Describe("Druid", func() {
@@ -767,7 +767,7 @@ var _ = Describe("Cron Job", func() {
 func validateRole(instance *druidv1alpha1.Etcd, role *rbac.Role) {
 	Expect(*role).To(MatchFields(IgnoreExtras, Fields{
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-			"Name":      Equal(fmt.Sprintf("%s-br-role", instance.Name)),
+			"Name":      Equal(fmt.Sprintf("druid.gardener.cloud:etcd:%s", instance.Name)),
 			"Namespace": Equal(instance.Namespace),
 			"Labels": MatchKeys(IgnoreExtras, Keys{
 				"name":     Equal("etcd"),
@@ -2120,7 +2120,7 @@ func serviceAccountIsCorrectlyReconciled(c client.Client, instance *druidv1alpha
 	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 	defer cancel()
 	req := types.NamespacedName{
-		Name:      fmt.Sprintf("%s-br-serviceaccount", instance.Name),
+		Name:      instance.Name,
 		Namespace: instance.Namespace,
 	}
 
@@ -2134,7 +2134,7 @@ func roleIsCorrectlyReconciled(c client.Client, instance *druidv1alpha1.Etcd, ro
 	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 	defer cancel()
 	req := types.NamespacedName{
-		Name:      fmt.Sprintf("%s-br-role", instance.Name),
+		Name:      fmt.Sprintf("druid.gardener.cloud:etcd:%s", instance.Name),
 		Namespace: instance.Namespace,
 	}
 
@@ -2148,7 +2148,7 @@ func roleBindingIsCorrectlyReconciled(c client.Client, instance *druidv1alpha1.E
 	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 	defer cancel()
 	req := types.NamespacedName{
-		Name:      fmt.Sprintf("%s-br-rolebinding", instance.Name),
+		Name:      fmt.Sprintf("druid.gardener.cloud:etcd:%s", instance.Name),
 		Namespace: instance.Namespace,
 	}
 

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -1450,6 +1450,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								"--snapstore-temp-directory=/var/etcd/data/temp": Equal("--snapstore-temp-directory=/var/etcd/data/temp"),
 								"--etcd-process-name=etcd":                       Equal("--etcd-process-name=etcd"),
 								"--etcd-connection-timeout=5m":                   Equal("--etcd-connection-timeout=5m"),
+								"--enable-snapshot-lease-renewal=true":           Equal("--enable-snapshot-lease-renewal=true"),
 								fmt.Sprintf("--defragmentation-schedule=%s", *instance.Spec.Etcd.DefragmentationSchedule):                           Equal(fmt.Sprintf("--defragmentation-schedule=%s", *instance.Spec.Etcd.DefragmentationSchedule)),
 								fmt.Sprintf("--schedule=%s", *instance.Spec.Backup.FullSnapshotSchedule):                                            Equal(fmt.Sprintf("--schedule=%s", *instance.Spec.Backup.FullSnapshotSchedule)),
 								fmt.Sprintf("%s=%s", "--garbage-collection-policy", *instance.Spec.Backup.GarbageCollectionPolicy):                  Equal(fmt.Sprintf("%s=%s", "--garbage-collection-policy", *instance.Spec.Backup.GarbageCollectionPolicy)),
@@ -1470,6 +1471,8 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								fmt.Sprintf("%s=%s", "--owner-check-interval", instance.Spec.Backup.OwnerCheck.Interval.Duration.String()):          Equal(fmt.Sprintf("%s=%s", "--owner-check-interval", instance.Spec.Backup.OwnerCheck.Interval.Duration.String())),
 								fmt.Sprintf("%s=%s", "--owner-check-timeout", instance.Spec.Backup.OwnerCheck.Timeout.Duration.String()):            Equal(fmt.Sprintf("%s=%s", "--owner-check-timeout", instance.Spec.Backup.OwnerCheck.Timeout.Duration.String())),
 								fmt.Sprintf("%s=%s", "--owner-check-dns-cache-ttl", instance.Spec.Backup.OwnerCheck.DNSCacheTTL.Duration.String()):  Equal(fmt.Sprintf("%s=%s", "--owner-check-dns-cache-ttl", instance.Spec.Backup.OwnerCheck.DNSCacheTTL.Duration.String())),
+								fmt.Sprintf("%s=%s", "--delta-snapshot-lease-name", getDeltaSnapshotLeaseName(instance)):                            Equal(fmt.Sprintf("%s=%s", "--delta-snapshot-lease-name", getDeltaSnapshotLeaseName(instance))),
+								fmt.Sprintf("%s=%s", "--full-snapshot-lease-name", getFullSnapshotLeaseName(instance)):                              Equal(fmt.Sprintf("%s=%s", "--full-snapshot-lease-name", getFullSnapshotLeaseName(instance))),
 							}),
 							"Ports": ConsistOf([]corev1.ContainerPort{
 								corev1.ContainerPort{

--- a/docs/compactor.md
+++ b/docs/compactor.md
@@ -33,10 +33,11 @@ To help with the problem mentioned earlier, our proposal is to introduce `compac
 The newly introduced compact command does not disturb the running ETCD while compacting the backup snapshots. The command is designed to run potentially separately (from the main ETCD process/container/pod). ETCD Druid can be configured to run the newly introduced compact command as a separate job (scheduled periodically) based on total number of ETCD events accumulated after the most recent full snapshot.
 
 ### Druid flags:
-ETCD druid introduced following three flags to configure the compaction job:
-`compaction-workers` : If this flag is set to zero, no compaction job will be running. If it's set to any value greater than zero, druid controller will have that many threads to kickstart the compaction job.
-`etcd-events-threshold`: Set this flag with the value which will signify the number of ETCD events allowed after the most recent full snapshot. Once the number of ETCD events crosses the value mentioned in this flag, compaction job will be kickstarted. 
-`active-deadline-duration`: This flag signifies the maximum duration till which a compaction job won't be garbage-collected.
+ETCD druid introduced following flags to configure the compaction job:
+- `--enable-backup-compaction` (default `false`): Set this flag to `true` to enable the automatic compaction of etcd backups when `etcd-events-threshold` is exceeded.
+- `--compaction-workers` (default `3`): If this flag is set to zero, no compaction job will be running. If it's set to any value greater than zero, druid controller will have that many threads to kickstart the compaction job.
+- `--etcd-events-threshold` (default `1000000`): Set this flag with the value which will signify the number of ETCD events allowed after the most recent full snapshot. Once the number of ETCD events crosses the value mentioned in this flag, compaction job will be kickstarted. 
+- `--active-deadline-duration` (default `3h`): This flag signifies the maximum duration till which a compaction job won't be garbage-collected.
 
 ### **Points to take care while saving the compacted snapshot:**
 As compacted snapshot and the existing periodic full snapshots are taken by different processes running in different pods but accessing same store to save the snapshots, some problems may arise:

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func main() {
 	var (
 		metricsAddr                string
 		enableLeaderElection       bool
+		enableBackupCompaction     bool
 		leaderElectionID           string
 		leaderElectionResourceLock string
 		etcdWorkers                int
@@ -75,6 +76,8 @@ func main() {
 	flag.IntVar(&custodianWorkers, "custodian-workers", 3, "Number of worker threads of the custodian controller.")
 	flag.IntVar(&etcdCopyBackupsTaskWorkers, "etcd-copy-backups-task-workers", 3, "Number of worker threads of the EtcdCopyBackupsTask controller.")
 	flag.DurationVar(&custodianSyncPeriod, "custodian-sync-period", 30*time.Second, "Sync period of the custodian controller.")
+	flag.BoolVar(&enableBackupCompaction, "enable-backup-compaction", false,
+		"Enable automatic compaction of etcd backups.")
 	flag.IntVar(&compactionWorkers, "compaction-workers", 3, "Number of worker threads of the CompactionJob controller. The controller creates a backup compaction job if a certain etcd event threshold is reached. Setting this flag to 0 disabled the controller.")
 	flag.Int64Var(&eventsThreshold, "etcd-events-threshold", 1000000, "Total number of etcd events that can be allowed before a backup compaction job is triggered.")
 	flag.DurationVar(&activeDeadlineDuration, "active-deadline-duration", 3*time.Hour, "Duration after which a running backup compaction job will be killed (Ex: \"300ms\", \"20s\", \"-1.5h\" or \"2h45m\").")
@@ -148,6 +151,7 @@ func main() {
 	}
 
 	lc, err := controllers.NewCompactionLeaseControllerWithImageVector(mgr, controllersconfig.CompactionLeaseConfig{
+		CompactionEnabled:      enableBackupCompaction,
 		EventsThreshold:        eventsThreshold,
 		ActiveDeadlineDuration: activeDeadlineDuration,
 	})

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -124,7 +124,8 @@ func LeaseHolderIdentityChange() predicate.Predicate {
 		if !ok {
 			return false
 		}
-		return *leaseOld.Spec.HolderIdentity != *leaseNew.Spec.HolderIdentity
+
+		return !reflect.DeepEqual(leaseOld.Spec.HolderIdentity, leaseNew.Spec.HolderIdentity)
 	}
 
 	return predicate.Funcs{

--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -116,6 +116,20 @@ var _ = Describe("Druid Predicate", func() {
 			pred = LeaseHolderIdentityChange()
 		})
 
+		Context("when holder identity is nil", func() {
+			BeforeEach(func() {
+				obj = &coordinationv1.Lease{}
+				oldObj = &coordinationv1.Lease{}
+			})
+
+			It("should return false", func() {
+				gomega.Expect(pred.Create(createEvent)).To(gomega.BeTrue())
+				gomega.Expect(pred.Update(updateEvent)).To(gomega.BeFalse())
+				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeTrue())
+				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeTrue())
+			})
+		})
+
 		Context("when holder identity matches", func() {
 			BeforeEach(func() {
 				obj = &coordinationv1.Lease{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR adds some additions after merging #235 for release `v0.7.0`. Please have a look at the individual commit messages for more information.


**Special notes for your reviewer**:
~This PR will stay in draft mode until #235 is merged.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A new flag `--enable-backup-compation` has been introduced which globally enables automatic compaction of backups.
```
