### PR TITLE
Fix `etcd.status.clusterSize` update

### DIFF
--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -230,7 +230,7 @@ type EtcdSpec struct {
 	// +optional
 	Common SharedConfig `json:"sharedConfig,omitempty"`
 	// +required
-	Replicas int `json:"replicas"`
+	Replicas int32 `json:"replicas"`
 	// PriorityClassName is the name of a priority class that shall be used for the etcd pods.
 	// +optional
 	PriorityClassName *string `json:"priorityClassName,omitempty"`

--- a/config/crd/bases/druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/druid.gardener.cloud_etcds.yaml
@@ -334,6 +334,7 @@ spec:
                 description: PriorityClassName is the name of a priority class that shall be used for the etcd pods.
                 type: string
               replicas:
+                format: int32
                 type: integer
               selector:
                 description: 'selector is a label query over pods that should match the replica count. It must match the pod template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'

--- a/controllers/controller_ref_manager.go
+++ b/controllers/controller_ref_manager.go
@@ -512,7 +512,7 @@ func CheckStatefulSet(etcd *druidv1alpha1.Etcd, statefulSet *appsv1.StatefulSet)
 	replicas := int32(1)
 
 	if etcd != nil {
-		replicas = int32(etcd.Spec.Replicas)
+		replicas = etcd.Spec.Replicas
 	}
 
 	if statefulSet.Status.ReadyReplicas < replicas {

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -1530,6 +1530,7 @@ func (r *EtcdReconciler) updateEtcdErrorStatus(ctx context.Context, op operation
 		if sts != nil {
 			ready := CheckStatefulSet(etcd, sts) == nil
 			etcd.Status.Ready = &ready
+			etcd.Status.Replicas = pointer.Int32PtrDerefOr(sts.Spec.Replicas, 0)
 
 			if op == bootstrapOp {
 				// Reset members in bootstrap phase to ensure dependent conditions can be calculated correctly.
@@ -1548,6 +1549,7 @@ func (r *EtcdReconciler) updateEtcdStatus(ctx context.Context, op operationResul
 		etcd.Status.ServiceName = &svcName
 		etcd.Status.LastError = nil
 		etcd.Status.ObservedGeneration = &etcd.Generation
+		etcd.Status.Replicas = pointer.Int32PtrDerefOr(sts.Spec.Replicas, 0)
 
 		if op == bootstrapOp {
 			// Reset members in bootstrap phase to ensure dependent conditions can be calculated correctly.

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -226,7 +226,7 @@ func (r *EtcdReconciler) reconcile(ctx context.Context, etcd *druidv1alpha1.Etcd
 		finalizers.Insert(FinalizerName)
 		etcd.Finalizers = finalizers.UnsortedList()
 		if err := r.Update(ctx, etcd); err != nil {
-			if err := r.updateEtcdErrorStatus(ctx, noOp, etcd, nil, err); err != nil {
+			if err := r.updateEtcdErrorStatus(ctx, etcd, nil, err); err != nil {
 				return ctrl.Result{
 					Requeue: true,
 				}, err
@@ -237,7 +237,7 @@ func (r *EtcdReconciler) reconcile(ctx context.Context, etcd *druidv1alpha1.Etcd
 		}
 	}
 	if err := r.addFinalizersToDependantSecrets(ctx, logger, etcd); err != nil {
-		if err := r.updateEtcdErrorStatus(ctx, noOp, etcd, nil, err); err != nil {
+		if err := r.updateEtcdErrorStatus(ctx, etcd, nil, err); err != nil {
 			return ctrl.Result{
 				Requeue: true,
 			}, err
@@ -294,9 +294,9 @@ func (r *EtcdReconciler) reconcile(ctx context.Context, etcd *druidv1alpha1.Etcd
 		logger.Info("The running cron job is: " + cronJob.Name)
 	}
 
-	op, svc, sts, err := r.reconcileEtcd(ctx, logger, etcd)
+	svc, sts, err := r.reconcileEtcd(ctx, logger, etcd)
 	if err != nil {
-		if err := r.updateEtcdErrorStatus(ctx, op, etcd, sts, err); err != nil {
+		if err := r.updateEtcdErrorStatus(ctx, etcd, sts, err); err != nil {
 			logger.Error(err, "Error during reconciling ETCD")
 			return ctrl.Result{
 				Requeue: true,
@@ -306,7 +306,7 @@ func (r *EtcdReconciler) reconcile(ctx context.Context, etcd *druidv1alpha1.Etcd
 			Requeue: true,
 		}, err
 	}
-	if err := r.updateEtcdStatus(ctx, op, etcd, svc, sts); err != nil {
+	if err := r.updateEtcdStatus(ctx, etcd, svc, sts); err != nil {
 		return ctrl.Result{
 			Requeue: true,
 		}, err
@@ -370,7 +370,7 @@ func (r *EtcdReconciler) delete(ctx context.Context, etcd *druidv1alpha1.Etcd) (
 	}
 
 	if waitForStatefulSetCleanup, err := r.removeDependantStatefulset(ctx, logger, etcd); err != nil {
-		if err = r.updateEtcdErrorStatus(ctx, deleteOp, etcd, nil, err); err != nil {
+		if err = r.updateEtcdErrorStatus(ctx, etcd, nil, err); err != nil {
 			return ctrl.Result{
 				Requeue: true,
 			}, err
@@ -385,7 +385,7 @@ func (r *EtcdReconciler) delete(ctx context.Context, etcd *druidv1alpha1.Etcd) (
 	}
 
 	if err := r.removeFinalizersToDependantSecrets(ctx, logger, etcd); err != nil {
-		if err := r.updateEtcdErrorStatus(ctx, deleteOp, etcd, nil, err); err != nil {
+		if err := r.updateEtcdErrorStatus(ctx, etcd, nil, err); err != nil {
 			return ctrl.Result{
 				Requeue: true,
 			}, err
@@ -667,16 +667,7 @@ func (r *EtcdReconciler) getConfigMapFromEtcd(etcd *druidv1alpha1.Etcd, rendered
 	return decoded, nil
 }
 
-type operationResult string
-
-const (
-	bootstrapOp operationResult = "bootstrap"
-	reconcileOp operationResult = "reconcile"
-	deleteOp    operationResult = "delete"
-	noOp        operationResult = "none"
-)
-
-func (r *EtcdReconciler) reconcileStatefulSet(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd, values map[string]interface{}) (operationResult, *appsv1.StatefulSet, error) {
+func (r *EtcdReconciler) reconcileStatefulSet(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd, values map[string]interface{}) (*appsv1.StatefulSet, error) {
 	logger.Info("Reconciling etcd statefulset")
 
 	// If any adoptions are attempted, we should first recheck for deletion with
@@ -701,19 +692,19 @@ func (r *EtcdReconciler) reconcileStatefulSet(ctx context.Context, logger logr.L
 	selector, err := metav1.LabelSelectorAsSelector(etcd.Spec.Selector)
 	if err != nil {
 		logger.Error(err, "Error converting etcd selector to selector")
-		return noOp, nil, err
+		return nil, err
 	}
 	dm := NewEtcdDruidRefManager(r.Client, r.Scheme, etcd, selector, etcdGVK, canAdoptFunc)
 	statefulSets, err := dm.FetchStatefulSet(ctx, etcd)
 	if err != nil {
 		logger.Error(err, "Error while fetching StatefulSet")
-		return noOp, nil, err
+		return nil, err
 	}
 
 	logger.Info("Claiming existing etcd StatefulSet")
 	claimedStatefulSets, err := dm.ClaimStatefulsets(ctx, statefulSets)
 	if err != nil {
-		return noOp, nil, err
+		return nil, err
 	}
 
 	if len(claimedStatefulSets) > 0 {
@@ -731,42 +722,42 @@ func (r *EtcdReconciler) reconcileStatefulSet(ctx context.Context, logger logr.L
 		// TODO: (timuthy) Check if this is really needed.
 		sts := &appsv1.StatefulSet{}
 		if err := r.Get(ctx, types.NamespacedName{Name: claimedStatefulSets[0].Name, Namespace: claimedStatefulSets[0].Namespace}, sts); err != nil {
-			return noOp, nil, err
+			return nil, err
 		}
 
 		// Statefulset is claimed by for this etcd. Just sync the specs
 		if sts, err = r.syncStatefulSetSpec(ctx, logger, sts, etcd, values); err != nil {
-			return noOp, nil, err
+			return nil, err
 		}
 
 		// restart etcd pods in crashloop backoff
 		selector, err := metav1.LabelSelectorAsSelector(sts.Spec.Selector)
 		if err != nil {
 			logger.Error(err, "error converting StatefulSet selector to selector")
-			return noOp, nil, err
+			return nil, err
 		}
 		podList := &corev1.PodList{}
 		if err := r.List(ctx, podList, client.InNamespace(etcd.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
-			return noOp, nil, err
+			return nil, err
 		}
 
 		for _, pod := range podList.Items {
 			if utils.IsPodInCrashloopBackoff(pod.Status) {
 				if err := r.Delete(ctx, &pod); err != nil {
 					logger.Error(err, fmt.Sprintf("error deleting etcd pod in crashloop: %s/%s", pod.Namespace, pod.Name))
-					return noOp, nil, err
+					return nil, err
 				}
 			}
 		}
 
 		sts, err = r.waitUntilStatefulSetReady(ctx, logger, etcd, sts)
-		return reconcileOp, sts, err
+		return sts, err
 	}
 
 	// Required statefulset doesn't exist. Create new
 	sts, err := r.getStatefulSetFromEtcd(etcd, values)
 	if err != nil {
-		return noOp, nil, err
+		return nil, err
 	}
 
 	err = r.Create(ctx, sts)
@@ -778,11 +769,11 @@ func (r *EtcdReconciler) reconcileStatefulSet(ctx context.Context, logger logr.L
 		err = nil
 	}
 	if err != nil {
-		return noOp, nil, err
+		return nil, err
 	}
 
 	sts, err = r.waitUntilStatefulSetReady(ctx, logger, etcd, sts)
-	return bootstrapOp, sts, err
+	return sts, err
 }
 
 func getContainerMapFromPodTemplateSpec(spec corev1.PodSpec) map[string]corev1.Container {
@@ -1087,21 +1078,21 @@ func (r *EtcdReconciler) reconcileRoleBinding(ctx context.Context, logger logr.L
 	return err
 }
 
-func (r *EtcdReconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd) (operationResult, *corev1.Service, *appsv1.StatefulSet, error) {
+func (r *EtcdReconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd) (*corev1.Service, *appsv1.StatefulSet, error) {
 	values, err := getMapFromEtcd(r.ImageVector, etcd)
 	if err != nil {
-		return noOp, nil, nil, err
+		return nil, nil, err
 	}
 
 	chartPath := getChartPath()
 	renderedChart, err := r.chartApplier.Render(chartPath, etcd.Name, etcd.Namespace, values)
 	if err != nil {
-		return noOp, nil, nil, err
+		return nil, nil, err
 	}
 
 	svc, err := r.reconcileServices(ctx, logger, etcd, renderedChart)
 	if err != nil {
-		return noOp, nil, nil, err
+		return nil, nil, err
 	}
 	if svc != nil {
 		values["serviceName"] = svc.Name
@@ -1109,7 +1100,7 @@ func (r *EtcdReconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, 
 
 	cm, err := r.reconcileConfigMaps(ctx, logger, etcd, renderedChart)
 	if err != nil {
-		return noOp, nil, nil, err
+		return nil, nil, err
 	}
 	if cm != nil {
 		values["configMapName"] = cm.Name
@@ -1117,25 +1108,25 @@ func (r *EtcdReconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, 
 
 	err = r.reconcileServiceAccount(ctx, logger, etcd, values)
 	if err != nil {
-		return noOp, nil, nil, err
+		return nil, nil, err
 	}
 
 	err = r.reconcileRole(ctx, logger, etcd, values)
 	if err != nil {
-		return noOp, nil, nil, err
+		return nil, nil, err
 	}
 
 	err = r.reconcileRoleBinding(ctx, logger, etcd, values)
 	if err != nil {
-		return noOp, nil, nil, err
+		return nil, nil, err
 	}
 
-	op, sts, err := r.reconcileStatefulSet(ctx, logger, etcd, values)
+	sts, err := r.reconcileStatefulSet(ctx, logger, etcd, values)
 	if err != nil {
-		return noOp, nil, nil, err
+		return nil, nil, err
 	}
 
-	return op, svc, sts, nil
+	return svc, sts, nil
 }
 
 func checkEtcdOwnerReference(refs []metav1.OwnerReference, etcd *druidv1alpha1.Etcd) bool {
@@ -1522,27 +1513,37 @@ func bootstrapReset(etcd *druidv1alpha1.Etcd) {
 	etcd.Status.ClusterSize = pointer.Int32Ptr(etcd.Spec.Replicas)
 }
 
-func (r *EtcdReconciler) updateEtcdErrorStatus(ctx context.Context, op operationResult, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet, lastError error) error {
+func clusterInBootstrap(etcd *druidv1alpha1.Etcd) bool {
+	return etcd.Status.Replicas == 0 ||
+		(etcd.Spec.Replicas > 1 && etcd.Status.Replicas == 1)
+}
+
+func (r *EtcdReconciler) updateEtcdErrorStatus(ctx context.Context, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet, lastError error) error {
 	return kutil.TryUpdateStatus(ctx, retry.DefaultBackoff, r.Client, etcd, func() error {
 		lastErrStr := fmt.Sprintf("%v", lastError)
 		etcd.Status.LastError = &lastErrStr
 		etcd.Status.ObservedGeneration = &etcd.Generation
 		if sts != nil {
-			ready := CheckStatefulSet(etcd, sts) == nil
-			etcd.Status.Ready = &ready
-			etcd.Status.Replicas = pointer.Int32PtrDerefOr(sts.Spec.Replicas, 0)
-
-			if op == bootstrapOp {
+			if clusterInBootstrap(etcd) {
 				// Reset members in bootstrap phase to ensure dependent conditions can be calculated correctly.
 				bootstrapReset(etcd)
 			}
+
+			ready := CheckStatefulSet(etcd, sts) == nil
+			etcd.Status.Ready = &ready
+			etcd.Status.Replicas = pointer.Int32PtrDerefOr(sts.Spec.Replicas, 0)
 		}
 		return nil
 	})
 }
 
-func (r *EtcdReconciler) updateEtcdStatus(ctx context.Context, op operationResult, etcd *druidv1alpha1.Etcd, svc *corev1.Service, sts *appsv1.StatefulSet) error {
+func (r *EtcdReconciler) updateEtcdStatus(ctx context.Context, etcd *druidv1alpha1.Etcd, svc *corev1.Service, sts *appsv1.StatefulSet) error {
 	return kutil.TryUpdateStatus(ctx, retry.DefaultBackoff, r.Client, etcd, func() error {
+		if clusterInBootstrap(etcd) {
+			// Reset members in bootstrap phase to ensure dependent conditions can be calculated correctly.
+			bootstrapReset(etcd)
+		}
+
 		ready := CheckStatefulSet(etcd, sts) == nil
 		etcd.Status.Ready = &ready
 		svcName := svc.Name
@@ -1550,11 +1551,6 @@ func (r *EtcdReconciler) updateEtcdStatus(ctx context.Context, op operationResul
 		etcd.Status.LastError = nil
 		etcd.Status.ObservedGeneration = &etcd.Generation
 		etcd.Status.Replicas = pointer.Int32PtrDerefOr(sts.Spec.Replicas, 0)
-
-		if op == bootstrapOp {
-			// Reset members in bootstrap phase to ensure dependent conditions can be calculated correctly.
-			bootstrapReset(etcd)
-		}
 		return nil
 	})
 }

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -1519,7 +1519,7 @@ func canDeleteStatefulset(sts *appsv1.StatefulSet, etcd *druidv1alpha1.Etcd) boo
 
 func bootstrapReset(etcd *druidv1alpha1.Etcd) {
 	etcd.Status.Members = nil
-	etcd.Status.ClusterSize = pointer.Int32Ptr(int32(etcd.Spec.Replicas))
+	etcd.Status.ClusterSize = pointer.Int32Ptr(etcd.Spec.Replicas)
 }
 
 func (r *EtcdReconciler) updateEtcdErrorStatus(ctx context.Context, op operationResult, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet, lastError error) error {
@@ -1532,7 +1532,7 @@ func (r *EtcdReconciler) updateEtcdErrorStatus(ctx context.Context, op operation
 			etcd.Status.Ready = &ready
 
 			if op == bootstrapOp {
-				// Reset members in bootstrap phase to ensure depending conditions can be calculated correctly.
+				// Reset members in bootstrap phase to ensure dependent conditions can be calculated correctly.
 				bootstrapReset(etcd)
 			}
 		}
@@ -1550,7 +1550,7 @@ func (r *EtcdReconciler) updateEtcdStatus(ctx context.Context, op operationResul
 		etcd.Status.ObservedGeneration = &etcd.Generation
 
 		if op == bootstrapOp {
-			// Reset members in bootstrap phase to ensure depending conditions can be calculated correctly.
+			// Reset members in bootstrap phase to ensure dependent conditions can be calculated correctly.
 			bootstrapReset(etcd)
 		}
 		return nil

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Druid", func() {
 					return nil, err
 				}
 				return instance.Status.ClusterSize, nil
-			}, timeout, pollingInterval).Should(Equal(pointer.Int32Ptr(int32(instance.Spec.Replicas))))
+			}, timeout, pollingInterval).Should(Equal(pointer.Int32Ptr(instance.Spec.Replicas)))
 		})
 		It("should create and adopt statefulset and printing events", func() {
 			// Check StatefulSet requirements

--- a/controllers/etcd_custodian_controller.go
+++ b/controllers/etcd_custodian_controller.go
@@ -173,7 +173,7 @@ func inBootstrap(etcd *druidv1alpha1.Etcd) bool {
 		return true
 	}
 	return len(etcd.Status.Members) == 0 ||
-		(len(etcd.Status.Members) < etcd.Spec.Replicas && int32(etcd.Spec.Replicas) == *etcd.Status.ClusterSize)
+		(len(etcd.Status.Members) < int(etcd.Spec.Replicas) && etcd.Spec.Replicas == *etcd.Status.ClusterSize)
 }
 
 // SetupWithManager sets up manager with a new controller and ec as the reconcile.Reconciler


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR fixes a referenced bug by making the `etcd.status.clusterSize` update idempotent.

**Which issue(s) this PR fixes**:
Fixes #255

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused the `etcd.status.clusterSize` only being set for new `etcd` resources
```
