### PR TITLE
[release-v0.7] Automated cherry pick of #263: Fix etcd update conflicts

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -114,7 +114,7 @@ var _ = BeforeSuite(func(done Done) {
 		},
 	})
 
-	err = custodian.SetupWithManager(mgrCtx, mgr, 1)
+	err = custodian.SetupWithManager(mgrCtx, mgr, 1, true)
 	Expect(err).NotTo(HaveOccurred())
 
 	etcdCopyBackupsTaskReconciler, err := NewEtcdCopyBackupsTaskReconcilerWithImageVector(mgr)

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -1620,8 +1620,9 @@ func (r *EtcdReconciler) fetchPVCEventsFor(ctx context.Context, ss *appsv1.State
 func (r *EtcdReconciler) removeOperationAnnotation(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd) error {
 	if _, ok := etcd.Annotations[v1beta1constants.GardenerOperation]; ok {
 		logger.Info("Removing operation annotation")
+		withOpAnnotation := etcd.DeepCopy()
 		delete(etcd.Annotations, v1beta1constants.GardenerOperation)
-		return r.Update(ctx, etcd)
+		return r.Patch(ctx, etcd, client.MergeFrom(withOpAnnotation))
 	}
 	return nil
 }

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -322,6 +322,7 @@ var _ = Describe("Druid", func() {
 
 				sts.Status.Replicas = 1
 				sts.Status.ReadyReplicas = 1
+				sts.Status.ObservedGeneration = 2
 				Expect(c.Status().Update(ctx, sts)).To(Succeed())
 
 				Eventually(func() error {

--- a/controllers/etcd_custodian_controller.go
+++ b/controllers/etcd_custodian_controller.go
@@ -177,13 +177,15 @@ func inBootstrap(etcd *druidv1alpha1.Etcd) bool {
 }
 
 // SetupWithManager sets up manager with a new controller and ec as the reconcile.Reconciler
-func (ec *EtcdCustodian) SetupWithManager(ctx context.Context, mgr ctrl.Manager, workers int) error {
+func (ec *EtcdCustodian) SetupWithManager(ctx context.Context, mgr ctrl.Manager, workers int, ignoreOperationAnnotation bool) error {
 	builder := ctrl.NewControllerManagedBy(mgr).WithOptions(controller.Options{
 		MaxConcurrentReconciles: workers,
 	})
 
 	return builder.
-		For(&druidv1alpha1.Etcd{}).
+		For(
+			&druidv1alpha1.Etcd{},
+			ctrlbuilder.WithPredicates(druidpredicates.EtcdReconciliationFinished(ignoreOperationAnnotation))).
 		Watches(
 			&source.Kind{Type: &appsv1.StatefulSet{}},
 			extensionshandler.EnqueueRequestsFromMapper(druidmapper.StatefulSetToEtcd(ctx, mgr.GetClient()), extensionshandler.UpdateWithNew),

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func main() {
 		SyncPeriod: custodianSyncPeriod,
 	})
 
-	if err := custodian.SetupWithManager(ctx, mgr, custodianWorkers); err != nil {
+	if err := custodian.SetupWithManager(ctx, mgr, custodianWorkers, ignoreOperationAnnotation); err != nil {
 		setupLog.Error(err, "Unable to create controller", "Controller", "Etcd Custodian")
 		os.Exit(1)
 	}


### PR DESCRIPTION
/area/quality
/kind/bug

Cherry pick of #263 on release-v0.7.

#263: Fix etcd update conflicts

**Release Notes:**
``` bugfix operator
A bug has been fixed that led to multiple update conflicts when the `etcd` resource was reconciled.
```