### PR TITLE
Editted label for compaction jobs to help scheduling

### DIFF
--- a/controllers/compaction_lease_controller.go
+++ b/controllers/compaction_lease_controller.go
@@ -323,7 +323,7 @@ func getLabels(etcd *druidv1alpha1.Etcd) map[string]string {
 	return map[string]string{
 		"name":                             "etcd-backup-compaction",
 		"instance":                         etcd.Name,
-		"garden.sapcloud.io/role":          "controlplane",
+		"gardener.cloud/role":              "controlplane",
 		"networking.gardener.cloud/to-dns": "allowed",
 		"networking.gardener.cloud/to-private-networks": "allowed",
 		"networking.gardener.cloud/to-public-networks":  "allowed",

--- a/controllers/compaction_lease_controller.go
+++ b/controllers/compaction_lease_controller.go
@@ -321,7 +321,7 @@ func getJobName(etcd *druidv1alpha1.Etcd) string {
 
 func getLabels(etcd *druidv1alpha1.Etcd) map[string]string {
 	return map[string]string{
-		"name":                             "etcd",
+		"name":                             "etcd-backup-compaction",
 		"instance":                         etcd.Name,
 		"garden.sapcloud.io/role":          "controlplane",
 		"networking.gardener.cloud/to-dns": "allowed",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR edits a label for the compaction job to uniquely identify it. This is needed so that the cluster pod scheduling policy can easily pick up these pods and schedule them on dedicated workers as needed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Updated deprecated label as per [this](https://github.com/gardener/gardener/blob/21550f99f6b4e649046bd69f7afac371932b7707/pkg/apis/core/v1beta1/constants/types_constants.go#:~:text=//%20Deprecated%3A%20Use%20%60GardenRole,gardener.cloud/role%22)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated labels used in compaction job to differentiate them from etcd pods. This allows for pod scheduling policies to schedule compaction jobs on predetermined nodes
```
