### PR TITLE
Add service component and peer service

### DIFF
--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -21,8 +21,6 @@ etcd:
   enableTLS: false
   pullPolicy: IfNotPresent
   metrics: basic
-  clientPort: 2379
-  serverPort: 2380
   etcdDefragTimeout: 8m
   resources:
     limits:
@@ -36,7 +34,6 @@ etcd:
   heartbeatDuration: 10s
 
 backup:
-  port: 8080
   pullPolicy: IfNotPresent
   snapstoreTempDir: "/var/etcd/data/temp"
   etcdConnectionTimeout: 5m

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/etcd-druid/pkg/common"
 	componentetcd "github.com/gardener/etcd-druid/pkg/component/etcd"
 	componentlease "github.com/gardener/etcd-druid/pkg/component/etcd/lease"
+	componentservice "github.com/gardener/etcd-druid/pkg/component/etcd/service"
 	druidpredicates "github.com/gardener/etcd-druid/pkg/predicate"
 	"github.com/gardener/etcd-druid/pkg/utils"
 
@@ -283,7 +284,7 @@ func (r *EtcdReconciler) reconcile(ctx context.Context, etcd *druidv1alpha1.Etcd
 		logger.Info("The running cron job is: " + cronJob.Name)
 	}
 
-	svc, sts, err := r.reconcileEtcd(ctx, logger, etcd)
+	svcName, sts, err := r.reconcileEtcd(ctx, logger, etcd)
 	if err != nil {
 		if err := r.updateEtcdErrorStatus(ctx, etcd, sts, err); err != nil {
 			logger.Error(err, "Error during reconciling ETCD")
@@ -295,7 +296,7 @@ func (r *EtcdReconciler) reconcile(ctx context.Context, etcd *druidv1alpha1.Etcd
 			Requeue: true,
 		}, err
 	}
-	if err := r.updateEtcdStatus(ctx, etcd, svc, sts); err != nil {
+	if err := r.updateEtcdStatus(ctx, etcd, *svcName, sts); err != nil {
 		return ctrl.Result{
 			Requeue: true,
 		}, err
@@ -408,87 +409,6 @@ func (r *EtcdReconciler) delete(ctx context.Context, etcd *druidv1alpha1.Etcd) (
 	}
 	logger.Info("Deleted etcd successfully.")
 	return ctrl.Result{}, nil
-}
-
-func (r *EtcdReconciler) reconcileServices(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd, renderedChart *chartrenderer.RenderedChart) (*corev1.Service, error) {
-	logger.Info("Reconciling etcd services")
-
-	selector, err := metav1.LabelSelectorAsSelector(etcd.Spec.Selector)
-	if err != nil {
-		logger.Error(err, "Error converting etcd selector to selector")
-		return nil, err
-	}
-
-	// list all services to include the services that don't match the etcd`s selector
-	// anymore but has the stale controller ref.
-	services := &corev1.ServiceList{}
-	err = r.List(ctx, services, client.InNamespace(etcd.Namespace), client.MatchingLabelsSelector{Selector: selector})
-	if err != nil {
-		logger.Error(err, "Error listing services")
-		return nil, err
-	}
-
-	// NOTE: filteredStatefulSets are pointing to deepcopies of the cache, but this could change in the future.
-	// Ref: https://github.com/kubernetes-sigs/controller-runtime/blob/release-0.2/pkg/cache/internal/cache_reader.go#L74
-	// if you need to modify them, you need to copy it first.
-	filteredServices, err := r.claimServices(ctx, etcd, selector, services)
-	if err != nil {
-		logger.Error(err, "Error claiming service")
-		return nil, err
-	}
-
-	if len(filteredServices) > 0 {
-		logger.Info("Claiming existing etcd services")
-
-		// Keep only 1 Service. Delete the rest
-		for i := 1; i < len(filteredServices); i++ {
-			ss := filteredServices[i]
-			if err := r.Delete(ctx, ss); err != nil {
-				logger.Error(err, "Error in deleting duplicate StatefulSet")
-				continue
-			}
-		}
-
-		// Return the updated Service
-		service := &corev1.Service{}
-		err = r.Get(ctx, types.NamespacedName{Name: filteredServices[0].Name, Namespace: filteredServices[0].Namespace}, service)
-		if err != nil {
-			return nil, err
-		}
-
-		// Service is claimed by for this etcd. Just sync the specs
-		if service, err = r.syncServiceSpec(ctx, logger, service, etcd, renderedChart); err != nil {
-			return nil, err
-		}
-
-		return service, err
-	}
-
-	// Required Service doesn't exist. Create new
-
-	svc, err := r.getServiceFromEtcd(etcd, renderedChart)
-	if err != nil {
-		return nil, err
-	}
-
-	err = r.Create(ctx, svc)
-
-	// Ignore the precondition violated error, this service is already updated
-	// with the desired label.
-	if err == errorsutil.ErrPreconditionViolated {
-		logger.Info("Service precondition doesn't hold, skip updating it.", "service", kutil.Key(svc.Namespace, svc.Name).String())
-		err = nil
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	if err := controllerutil.SetControllerReference(etcd, svc, r.Scheme); err != nil {
-		return nil, err
-	}
-
-	return svc.DeepCopy(), err
 }
 
 func (r *EtcdReconciler) syncServiceSpec(ctx context.Context, logger logr.Logger, svc *corev1.Service, etcd *druidv1alpha1.Etcd, renderedChart *chartrenderer.RenderedChart) (*corev1.Service, error) {
@@ -1056,12 +976,14 @@ func (r *EtcdReconciler) reconcileRoleBinding(ctx context.Context, logger logr.L
 	return err
 }
 
-func (r *EtcdReconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd) (*corev1.Service, *appsv1.StatefulSet, error) {
+func (r *EtcdReconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd) (*string, *appsv1.StatefulSet, error) {
 	val := componentetcd.Values{
-		Lease: componentlease.GenerateValues(etcd),
+		Lease:   componentlease.GenerateValues(etcd),
+		Service: componentservice.GenerateValues(etcd),
 	}
 
 	values, err := getMapFromEtcd(r.ImageVector, etcd, val, r.disableEtcdServiceAccountAutomount)
+
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1078,12 +1000,10 @@ func (r *EtcdReconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, 
 		return nil, nil, err
 	}
 
-	svc, err := r.reconcileServices(ctx, logger, etcd, renderedChart)
-	if err != nil {
+	serviceDeployer := componentservice.New(r.Client, etcd.Namespace, val.Service)
+
+	if err := serviceDeployer.Deploy(ctx); err != nil {
 		return nil, nil, err
-	}
-	if svc != nil {
-		values["serviceName"] = svc.Name
 	}
 
 	cm, err := r.reconcileConfigMaps(ctx, logger, etcd, renderedChart)
@@ -1119,7 +1039,7 @@ func (r *EtcdReconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, 
 		return nil, nil, err
 	}
 
-	return svc, sts, nil
+	return &val.Service.ClientServiceName, sts, nil
 }
 
 func checkEtcdOwnerReference(refs []metav1.OwnerReference, etcd *druidv1alpha1.Etcd) bool {
@@ -1157,9 +1077,11 @@ func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd, val co
 	}
 
 	etcdValues := map[string]interface{}{
+		"clientPort":              val.Service.ClientPort,
 		"defragmentationSchedule": etcd.Spec.Etcd.DefragmentationSchedule,
 		"enableTLS":               (etcd.Spec.Etcd.TLS != nil),
 		"pullPolicy":              corev1.PullIfNotPresent,
+		"serverPort":              val.Service.ServerPort,
 		// "username":                etcd.Spec.Etcd.Username,
 		// "password":                etcd.Spec.Etcd.Password,
 	}
@@ -1170,14 +1092,6 @@ func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd, val co
 
 	if etcd.Spec.Etcd.Metrics != nil {
 		etcdValues["metrics"] = etcd.Spec.Etcd.Metrics
-	}
-
-	if etcd.Spec.Etcd.ServerPort != nil {
-		etcdValues["serverPort"] = etcd.Spec.Etcd.ServerPort
-	}
-
-	if etcd.Spec.Etcd.ClientPort != nil {
-		etcdValues["clientPort"] = etcd.Spec.Etcd.ClientPort
 	}
 
 	if etcd.Spec.Etcd.EtcdDefragTimeout != nil {
@@ -1214,6 +1128,7 @@ func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd, val co
 
 	backupValues := map[string]interface{}{
 		"pullPolicy":               corev1.PullIfNotPresent,
+		"port":                     val.Service.BackupPort,
 		"etcdQuotaBytes":           quota,
 		"etcdConnectionTimeout":    "5m",
 		"snapstoreTempDir":         "/var/etcd/data/temp",
@@ -1243,10 +1158,6 @@ func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd, val co
 
 	if etcd.Spec.Backup.EtcdSnapshotTimeout != nil {
 		backupValues["etcdSnapshotTimeout"] = etcd.Spec.Backup.EtcdSnapshotTimeout
-	}
-
-	if etcd.Spec.Backup.Port != nil {
-		backupValues["port"] = etcd.Spec.Backup.Port
 	}
 
 	if etcd.Spec.Backup.SnapshotCompression != nil {
@@ -1320,7 +1231,7 @@ func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd, val co
 		"sharedConfig":                       sharedConfigValues,
 		"replicas":                           etcd.Spec.Replicas,
 		"statefulsetReplicas":                statefulsetReplicas,
-		"serviceName":                        fmt.Sprintf("%s-client", etcd.Name),
+		"serviceName":                        val.Service.ClientServiceName,
 		"configMapName":                      fmt.Sprintf("etcd-bootstrap-%s", string(etcd.UID[:6])),
 		"jobName":                            getJobName(etcd),
 		"pdbMinAvailable":                    pdbMinAvailable,
@@ -1541,7 +1452,7 @@ func (r *EtcdReconciler) updateEtcdErrorStatus(ctx context.Context, etcd *druidv
 	})
 }
 
-func (r *EtcdReconciler) updateEtcdStatus(ctx context.Context, etcd *druidv1alpha1.Etcd, svc *corev1.Service, sts *appsv1.StatefulSet) error {
+func (r *EtcdReconciler) updateEtcdStatus(ctx context.Context, etcd *druidv1alpha1.Etcd, serviceName string, sts *appsv1.StatefulSet) error {
 	return controllerutils.TryUpdateStatus(ctx, retry.DefaultBackoff, r.Client, etcd, func() error {
 		if clusterInBootstrap(etcd) {
 			// Reset members in bootstrap phase to ensure dependent conditions can be calculated correctly.
@@ -1550,7 +1461,7 @@ func (r *EtcdReconciler) updateEtcdStatus(ctx context.Context, etcd *druidv1alph
 
 		ready := CheckStatefulSet(etcd, sts) == nil
 		etcd.Status.Ready = &ready
-		svcName := svc.Name
+		svcName := serviceName
 		etcd.Status.ServiceName = &svcName
 		etcd.Status.LastError = nil
 		etcd.Status.ObservedGeneration = &etcd.Generation
@@ -1636,24 +1547,6 @@ func (r *EtcdReconciler) updateEtcdStatusAsNotReady(ctx context.Context, etcd *d
 		return nil
 	})
 	return etcd, err
-}
-
-func (r *EtcdReconciler) claimServices(ctx context.Context, etcd *druidv1alpha1.Etcd, selector labels.Selector, ss *corev1.ServiceList) ([]*corev1.Service, error) {
-	// If any adoptions are attempted, we should first recheck for deletion with
-	// an uncached quorum read sometime after listing Machines (see #42639).
-	canAdoptFunc := RecheckDeletionTimestamp(func() (metav1.Object, error) {
-		foundEtcd := &druidv1alpha1.Etcd{}
-		err := r.Get(ctx, types.NamespacedName{Name: etcd.Name, Namespace: etcd.Namespace}, foundEtcd)
-		if err != nil {
-			return nil, err
-		}
-		if foundEtcd.UID != etcd.UID {
-			return nil, fmt.Errorf("original %v/%v hvpa gone: got uid %v, wanted %v", etcd.Namespace, etcd.Name, foundEtcd.UID, etcd.UID)
-		}
-		return foundEtcd, nil
-	})
-	cm := NewEtcdDruidRefManager(r.Client, r.Scheme, etcd, selector, etcdGVK, canAdoptFunc)
-	return cm.ClaimServices(ctx, ss)
 }
 
 func (r *EtcdReconciler) claimPodDisruptionBudget(ctx context.Context, etcd *druidv1alpha1.Etcd, selector labels.Selector, pdb *policyv1beta1.PodDisruptionBudget) (*policyv1beta1.PodDisruptionBudget, error) {

--- a/pkg/component/etcd/service/service.go
+++ b/pkg/component/etcd/service/service.go
@@ -34,9 +34,16 @@ type component struct {
 }
 
 func (c *component) Deploy(ctx context.Context) error {
-	var clientService = c.emptyService(c.values.ClientServiceName)
+	var (
+		clientService = c.emptyService(c.values.ClientServiceName)
+		peerService   = c.emptyService(c.values.PeerServiceName)
+	)
 
 	if err := c.syncClientService(ctx, clientService); err != nil {
+		return err
+	}
+
+	if err := c.syncPeerService(ctx, peerService); err != nil {
 		return err
 	}
 
@@ -44,9 +51,20 @@ func (c *component) Deploy(ctx context.Context) error {
 }
 
 func (c *component) Destroy(ctx context.Context) error {
-	var clientService = c.emptyService(c.values.ClientServiceName)
+	var (
+		clientService = c.emptyService(c.values.ClientServiceName)
+		peerService   = c.emptyService(c.values.PeerServiceName)
+	)
 
-	return client.IgnoreNotFound(c.client.Delete(ctx, clientService))
+	if err := client.IgnoreNotFound(c.client.Delete(ctx, clientService)); err != nil {
+		return err
+	}
+
+	if err := client.IgnoreNotFound(c.client.Delete(ctx, peerService)); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // New creates a new service deployer instance.

--- a/pkg/component/etcd/service/service.go
+++ b/pkg/component/etcd/service/service.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+
+	gardenercomponent "github.com/gardener/gardener/pkg/operation/botanist/component"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type component struct {
+	client    client.Client
+	namespace string
+
+	values Values
+}
+
+func (c *component) Deploy(ctx context.Context) error {
+	var clientService = c.emptyService(c.values.ClientServiceName)
+
+	if err := c.syncClientService(ctx, clientService); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *component) Destroy(ctx context.Context) error {
+	var clientService = c.emptyService(c.values.ClientServiceName)
+
+	return client.IgnoreNotFound(c.client.Delete(ctx, clientService))
+}
+
+// New creates a new service deployer instance.
+func New(c client.Client, namespace string, values Values) gardenercomponent.Deployer {
+	return &component{
+		client:    c,
+		namespace: namespace,
+		values:    values,
+	}
+}
+
+func (c *component) emptyService(name string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: c.namespace,
+		},
+	}
+}
+
+func getOwnerReferences(val Values) []metav1.OwnerReference {
+	return []metav1.OwnerReference{
+		{
+			APIVersion:         druidv1alpha1.GroupVersion.String(),
+			Kind:               "Etcd",
+			Name:               val.EtcdName,
+			UID:                val.EtcdUID,
+			Controller:         pointer.BoolPtr(true),
+			BlockOwnerDeletion: pointer.BoolPtr(true),
+		},
+	}
+}
+
+func getLabels(val Values) map[string]string {
+	labels := map[string]string{
+		"instance": val.EtcdName,
+	}
+
+	for k, v := range val.Labels {
+		labels[k] = v
+	}
+
+	return labels
+}

--- a/pkg/component/etcd/service/service_client.go
+++ b/pkg/component/etcd/service/service_client.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/controllerutils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func (c *component) syncClientService(ctx context.Context, svc *corev1.Service) error {
+	_, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, c.client, svc, func() error {
+		// TODO: check strategic merge patch because of labels and finalizers
+		svc.Labels = getLabels(c.values)
+		svc.OwnerReferences = getOwnerReferences(c.values)
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
+		svc.Spec.Selector = getLabels(c.values)
+		svc.Spec.Ports = []corev1.ServicePort{
+			{
+				Name:       "client",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       c.values.ClientPort,
+				TargetPort: intstr.FromInt(int(c.values.ClientPort)),
+			},
+			{
+				Name:       "server",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       c.values.ServerPort,
+				TargetPort: intstr.FromInt(int(c.values.ServerPort)),
+			},
+			{
+				Name:       "backuprestore",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       c.values.BackupPort,
+				TargetPort: intstr.FromInt(int(c.values.BackupPort)),
+			},
+		}
+
+		return nil
+	})
+	return err
+}

--- a/pkg/component/etcd/service/service_peer.go
+++ b/pkg/component/etcd/service/service_peer.go
@@ -22,32 +22,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (c *component) syncClientService(ctx context.Context, svc *corev1.Service) error {
+func (c *component) syncPeerService(ctx context.Context, svc *corev1.Service) error {
 	_, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, c.client, svc, func() error {
 		svc.Labels = getLabels(c.values)
 		svc.OwnerReferences = getOwnerReferences(c.values)
 		svc.Spec.Type = corev1.ServiceTypeClusterIP
 		svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
 		svc.Spec.Selector = getLabels(c.values)
+		svc.Spec.PublishNotReadyAddresses = true
 		svc.Spec.Ports = []corev1.ServicePort{
 			{
-				Name:       "client",
-				Protocol:   corev1.ProtocolTCP,
-				Port:       c.values.ClientPort,
-				TargetPort: intstr.FromInt(int(c.values.ClientPort)),
-			},
-			// TODO: Remove the "server" port in a future release
-			{
-				Name:       "server",
+				Name:       "peer",
 				Protocol:   corev1.ProtocolTCP,
 				Port:       c.values.ServerPort,
 				TargetPort: intstr.FromInt(int(c.values.ServerPort)),
-			},
-			{
-				Name:       "backuprestore",
-				Protocol:   corev1.ProtocolTCP,
-				Port:       c.values.BackupPort,
-				TargetPort: intstr.FromInt(int(c.values.BackupPort)),
 			},
 		}
 

--- a/pkg/component/etcd/service/service_suite_test.go
+++ b/pkg/component/etcd/service/service_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestService(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Service Component Suite")
+}

--- a/pkg/component/etcd/service/service_test.go
+++ b/pkg/component/etcd/service/service_test.go
@@ -60,22 +60,9 @@ var _ = Describe("Service", func() {
 		backupPort = 1111
 		clientPort = 2222
 		serverPort = 3333
+
 		labels = map[string]string{
 			"foo": "bar",
-		}
-		services = []*corev1.Service{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      values.ClientServiceName,
-					Namespace: values.EtcdName,
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      values.PeerServiceName,
-					Namespace: values.EtcdName,
-				},
-			},
 		}
 
 		etcd = &druidv1alpha1.Etcd{
@@ -97,6 +84,22 @@ var _ = Describe("Service", func() {
 		}
 
 		values = GenerateValues(etcd)
+
+		services = []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      values.ClientServiceName,
+					Namespace: values.EtcdName,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      values.PeerServiceName,
+					Namespace: values.EtcdName,
+				},
+			},
+		}
+
 		serviceDeployer = New(cl, namespace, values)
 	})
 

--- a/pkg/component/etcd/service/service_test.go
+++ b/pkg/component/etcd/service/service_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service_test
+
+import (
+	"context"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"github.com/gardener/etcd-druid/pkg/client/kubernetes"
+	. "github.com/gardener/etcd-druid/pkg/component/etcd/service"
+
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Service", func() {
+	var (
+		ctx context.Context
+		cl  client.Client
+
+		etcd                               *druidv1alpha1.Etcd
+		backupPort, clientPort, serverPort int32
+		namespace                          string
+		name                               string
+		uid                                types.UID
+		labels                             map[string]string
+
+		values          Values
+		serviceDeployer component.Deployer
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = "default"
+		cl = fakeclient.NewClientBuilder().WithScheme(kubernetes.Scheme).Build()
+
+		backupPort = 1111
+		clientPort = 2222
+		serverPort = 3333
+		labels = map[string]string{
+			"foo": "bar",
+		}
+
+		etcd = &druidv1alpha1.Etcd{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				UID:       uid,
+			},
+			Spec: druidv1alpha1.EtcdSpec{
+				Selector: metav1.SetAsLabelSelector(labels),
+				Backup: druidv1alpha1.BackupSpec{
+					Port: pointer.Int32Ptr(backupPort),
+				},
+				Etcd: druidv1alpha1.EtcdConfig{
+					ClientPort: pointer.Int32Ptr(clientPort),
+					ServerPort: pointer.Int32Ptr(serverPort),
+				},
+			},
+		}
+
+		values = GenerateValues(etcd)
+		serviceDeployer = New(cl, namespace, values)
+	})
+
+	Describe("#Deploy", func() {
+		Context("when service does not exist", func() {
+			It("should create the service successfully", func() {
+				Expect(serviceDeployer.Deploy(ctx)).To(Succeed())
+
+				svc := &corev1.Service{}
+				Expect(cl.Get(ctx, kutil.Key(namespace, values.ClientServiceName), svc)).To(Succeed())
+				checkService(svc, values)
+			})
+		})
+
+		Context("when service exists", func() {
+			It("should update the service successfully", func() {
+				existingService := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      values.ClientServiceName,
+						Namespace: values.EtcdName,
+					},
+				}
+				Expect(cl.Create(ctx, existingService)).To(Succeed())
+				Expect(serviceDeployer.Deploy(ctx)).To(Succeed())
+
+				svc := &corev1.Service{}
+				Expect(cl.Get(ctx, kutil.Key(namespace, values.ClientServiceName), svc)).To(Succeed())
+				checkService(svc, values)
+			})
+		})
+	})
+
+	Describe("#Deploy", func() {
+		Context("when service does not exist", func() {
+			It("should destroy successfully", func() {
+				Expect(serviceDeployer.Destroy(ctx)).To(Succeed())
+				Expect(cl.Get(ctx, kutil.Key(namespace, values.ClientServiceName), &corev1.Service{})).To(BeNotFoundError())
+			})
+		})
+
+		Context("when service exists", func() {
+			It("should destroy successfully", func() {
+				existingService := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      values.ClientServiceName,
+						Namespace: values.EtcdName,
+					},
+				}
+				Expect(cl.Create(ctx, existingService)).To(Succeed())
+				Expect(serviceDeployer.Destroy(ctx)).To(Succeed())
+				Expect(cl.Get(ctx, kutil.Key(namespace, values.ClientServiceName), &corev1.Service{})).To(BeNotFoundError())
+			})
+		})
+	})
+})
+
+func checkService(svc *corev1.Service, values Values) {
+	Expect(svc.OwnerReferences).To(ConsistOf(Equal(metav1.OwnerReference{
+		APIVersion:         druidv1alpha1.GroupVersion.String(),
+		Kind:               "Etcd",
+		Name:               values.EtcdName,
+		UID:                values.EtcdUID,
+		Controller:         pointer.BoolPtr(true),
+		BlockOwnerDeletion: pointer.BoolPtr(true),
+	})))
+	Expect(svc.Labels).To(Equal(serviceLabels(values)))
+	Expect(svc.Spec.Ports).To(ConsistOf(
+		Equal(corev1.ServicePort{
+			Name:       "client",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       values.ClientPort,
+			TargetPort: intstr.FromInt(int(values.ClientPort)),
+		}),
+		Equal(corev1.ServicePort{
+			Name:       "server",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       values.ServerPort,
+			TargetPort: intstr.FromInt(int(values.ServerPort)),
+		}),
+		Equal(corev1.ServicePort{
+			Name:       "backuprestore",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       values.BackupPort,
+			TargetPort: intstr.FromInt(int(values.BackupPort)),
+		}),
+	))
+}
+
+func serviceLabels(val Values) map[string]string {
+	labels := map[string]string{
+		"instance": val.EtcdName,
+	}
+
+	for k, v := range val.Labels {
+		labels[k] = v
+	}
+
+	return labels
+}

--- a/pkg/component/etcd/service/values.go
+++ b/pkg/component/etcd/service/values.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import "k8s.io/apimachinery/pkg/types"
+
+type Values struct {
+	// BackupPort is the port exposed by the etcd-backup-restore side-car.
+	BackupPort int32
+	// ClientPort is the port exposed by etcd for client communication.
+	ClientPort int32
+	// ClientServiceName is the name of the service responsible for client traffic.
+	ClientServiceName string
+	// EtcdName is the name of the etcd resource.
+	EtcdName string
+	// EtcdName is the UID of the etcd resource.
+	EtcdUID types.UID
+	// Labels are the service labels.
+	Labels map[string]string
+	// ServerPort is the port used for etcd peer communication.
+	ServerPort int32
+}

--- a/pkg/component/etcd/service/values.go
+++ b/pkg/component/etcd/service/values.go
@@ -29,6 +29,8 @@ type Values struct {
 	EtcdUID types.UID
 	// Labels are the service labels.
 	Labels map[string]string
+	// PeerServiceName is the name of the service responsible for peer traffic.
+	PeerServiceName string
 	// ServerPort is the port used for etcd peer communication.
 	ServerPort int32
 }

--- a/pkg/component/etcd/service/values_helper.go
+++ b/pkg/component/etcd/service/values_helper.go
@@ -37,6 +37,7 @@ func GenerateValues(etcd *druidv1alpha1.Etcd) Values {
 		EtcdName:          etcd.Name,
 		EtcdUID:           etcd.UID,
 		Labels:            etcd.Spec.Labels,
+		PeerServiceName:   fmt.Sprintf("%s-peer", etcd.Name),
 		ServerPort:        pointer.Int32Deref(etcd.Spec.Etcd.ServerPort, defaultServerPort),
 	}
 }

--- a/pkg/component/etcd/service/values_helper.go
+++ b/pkg/component/etcd/service/values_helper.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"fmt"
+
+	"k8s.io/utils/pointer"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+)
+
+const (
+	defaultBackupPort = 8080
+	defaultClientPort = 2379
+	defaultServerPort = 2380
+)
+
+// GenerateValues generates `service.Values` for the service component with the given `etcd` object.
+func GenerateValues(etcd *druidv1alpha1.Etcd) Values {
+	return Values{
+		BackupPort:        pointer.Int32Deref(etcd.Spec.Backup.Port, defaultBackupPort),
+		ClientPort:        pointer.Int32Deref(etcd.Spec.Etcd.ClientPort, defaultClientPort),
+		ClientServiceName: fmt.Sprintf("%s-client", etcd.Name),
+		EtcdName:          etcd.Name,
+		EtcdUID:           etcd.UID,
+		Labels:            etcd.Spec.Labels,
+		ServerPort:        pointer.Int32Deref(etcd.Spec.Etcd.ServerPort, defaultServerPort),
+	}
+}

--- a/pkg/component/etcd/service/values_helper_test.go
+++ b/pkg/component/etcd/service/values_helper_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service_test
+
+import (
+	"fmt"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	. "github.com/gardener/etcd-druid/pkg/component/etcd/service"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("#GenerateValues", func() {
+	var (
+		etcd *druidv1alpha1.Etcd
+
+		labels                             map[string]string
+		backupPort, clientPort, serverPort *int32
+	)
+
+	JustBeforeEach(func() {
+		labels = map[string]string{
+			"foo": "bar",
+		}
+
+		etcd = &druidv1alpha1.Etcd{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "etcd",
+				Namespace: "default",
+				UID:       "123",
+			},
+			Spec: druidv1alpha1.EtcdSpec{
+				Selector: metav1.SetAsLabelSelector(labels),
+				Backup: druidv1alpha1.BackupSpec{
+					Port: backupPort,
+				},
+				Etcd: druidv1alpha1.EtcdConfig{
+					ClientPort: clientPort,
+					ServerPort: serverPort,
+				},
+			},
+		}
+	})
+
+	Context("when ports are specified", func() {
+		BeforeEach(func() {
+			backupPort = pointer.Int32Ptr(1111)
+			clientPort = pointer.Int32Ptr(2222)
+			serverPort = pointer.Int32Ptr(3333)
+		})
+
+		It("should generate values correctly", func() {
+			values := GenerateValues(etcd)
+
+			Expect(values).To(MatchFields(IgnoreExtras, Fields{
+				"BackupPort":        Equal(*etcd.Spec.Backup.Port),
+				"ClientPort":        Equal(*etcd.Spec.Etcd.ClientPort),
+				"ClientServiceName": Equal(fmt.Sprintf("%s-client", etcd.Name)),
+				"EtcdName":          Equal(etcd.Name),
+				"EtcdUID":           Equal(etcd.UID),
+				"Labels":            Equal(etcd.Labels),
+				"ServerPort":        Equal(*etcd.Spec.Etcd.ServerPort),
+			}))
+		})
+	})
+
+	Context("when ports aren't specified", func() {
+		BeforeEach(func() {
+			backupPort = nil
+			clientPort = nil
+			serverPort = nil
+		})
+
+		It("should generate values correctly", func() {
+			values := GenerateValues(etcd)
+
+			Expect(values).To(MatchFields(IgnoreExtras, Fields{
+				"BackupPort":        Equal(int32(8080)),
+				"ClientPort":        Equal(int32(2379)),
+				"ClientServiceName": Equal(fmt.Sprintf("%s-client", etcd.Name)),
+				"EtcdName":          Equal(etcd.Name),
+				"EtcdUID":           Equal(etcd.UID),
+				"Labels":            Equal(etcd.Labels),
+				"ServerPort":        Equal(int32(2380)),
+			}))
+		})
+	})
+})

--- a/pkg/component/etcd/service/values_helper_test.go
+++ b/pkg/component/etcd/service/values_helper_test.go
@@ -76,6 +76,7 @@ var _ = Describe("#GenerateValues", func() {
 				"EtcdName":          Equal(etcd.Name),
 				"EtcdUID":           Equal(etcd.UID),
 				"Labels":            Equal(etcd.Labels),
+				"PeerServiceName":   Equal(fmt.Sprintf("%s-peer", etcd.Name)),
 				"ServerPort":        Equal(*etcd.Spec.Etcd.ServerPort),
 			}))
 		})
@@ -98,6 +99,7 @@ var _ = Describe("#GenerateValues", func() {
 				"EtcdName":          Equal(etcd.Name),
 				"EtcdUID":           Equal(etcd.UID),
 				"Labels":            Equal(etcd.Labels),
+				"PeerServiceName":   Equal(fmt.Sprintf("%s-peer", etcd.Name)),
 				"ServerPort":        Equal(int32(2380)),
 			}))
 		})

--- a/pkg/component/etcd/values.go
+++ b/pkg/component/etcd/values.go
@@ -14,9 +14,13 @@
 
 package etcd
 
-import "github.com/gardener/etcd-druid/pkg/component/etcd/lease"
+import (
+	"github.com/gardener/etcd-druid/pkg/component/etcd/lease"
+	"github.com/gardener/etcd-druid/pkg/component/etcd/service"
+)
 
 // Values contains all values relevant for deploying etcd components.
 type Values struct {
-	Lease lease.Values
+	Lease   lease.Values
+	Service service.Values
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR does two things:
- Adds a `service` component (similar to #262). As part of this transition the earlier used claim logic was removed as proposed in #208.
- Adds a new `service` object for peer-communication. 

**Which issue(s) this PR fixes**:
Fixes parts of #158

**Special notes for your reviewer**:
~This PR is based on #262 and therefore place ignore b3a437c415004fe401e1459ff99c3b8208149a68 during your review. Because of this dependency, the draft state will remain until #262 is merged.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A new service (`<etcd-name>-peer`) for etcd peer communication (default port `2380`) is now created by Etcd-Druid.
```
```breaking operator
Using the etcd `client` service for server communication (default port `2380`) has been deprecated. The port will be removed from the service in the near future. If necessary, switch to the new `peer` service instead.
```
```breaking operator
The claiming logic for services has been removed from Etcd-Druid. This means that existing `service` objects cannot be adopted anymore but a new and dedicated object is created. Please check any usages for already adopted `services` and switch to the dedicated `<etcd-name>-client` service.
```