### PR TITLE
Disable `ServiceAccount automount when `--disable-etcd-serviceaccount-automount=true`

### DIFF
--- a/charts/etcd/templates/etcd-serviceaccount.yaml
+++ b/charts/etcd/templates/etcd-serviceaccount.yaml
@@ -16,3 +16,6 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
+{{- if .Values.disableEtcdServiceAccountAutomount }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -3,6 +3,8 @@ uid: uuid-of-etcd-resource
 serviceName: test
 configMapName: test
 jobName: test
+serviceAccountName: test
+disableEtcdServiceAccountAutomount: false
 
 replicas: 1
 #priorityClassName: foo

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -102,7 +102,7 @@ var _ = BeforeSuite(func(done Done) {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	er, err := NewEtcdReconcilerWithImageVector(mgr)
+	er, err := NewEtcdReconcilerWithImageVector(mgr, false)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = er.SetupWithManager(mgr, 1, true)

--- a/main.go
+++ b/main.go
@@ -50,20 +50,21 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr                string
-		enableLeaderElection       bool
-		enableBackupCompaction     bool
-		leaderElectionID           string
-		leaderElectionResourceLock string
-		etcdWorkers                int
-		custodianWorkers           int
-		etcdCopyBackupsTaskWorkers int
-		custodianSyncPeriod        time.Duration
-		disableLeaseCache          bool
-		compactionWorkers          int
-		eventsThreshold            int64
-		activeDeadlineDuration     time.Duration
-		ignoreOperationAnnotation  bool
+		metricsAddr                        string
+		enableLeaderElection               bool
+		enableBackupCompaction             bool
+		leaderElectionID                   string
+		leaderElectionResourceLock         string
+		etcdWorkers                        int
+		custodianWorkers                   int
+		etcdCopyBackupsTaskWorkers         int
+		custodianSyncPeriod                time.Duration
+		disableLeaseCache                  bool
+		compactionWorkers                  int
+		eventsThreshold                    int64
+		activeDeadlineDuration             time.Duration
+		ignoreOperationAnnotation          bool
+		disableEtcdServiceAccountAutomount bool
 
 		etcdMemberNotReadyThreshold time.Duration
 
@@ -91,6 +92,7 @@ func main() {
 	flag.BoolVar(&disableLeaseCache, "disable-lease-cache", false, "Disable cache for lease.coordination.k8s.io resources.")
 	flag.BoolVar(&ignoreOperationAnnotation, "ignore-operation-annotation", true, "Ignore the operation annotation or not.")
 	flag.DurationVar(&etcdMemberNotReadyThreshold, "etcd-member-notready-threshold", 5*time.Minute, "Threshold after which an etcd member is considered not ready if the status was unknown before.")
+	flag.BoolVar(&disableEtcdServiceAccountAutomount, "disable-etcd-serviceaccount-automount", false, "If true then .automountServiceAccountToken will be set to false for the ServiceAccount created for etcd statefulsets.")
 
 	flag.Parse()
 
@@ -117,7 +119,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	etcd, err := controllers.NewEtcdReconcilerWithImageVector(mgr)
+	etcd, err := controllers.NewEtcdReconcilerWithImageVector(mgr, disableEtcdServiceAccountAutomount)
 	if err != nil {
 		setupLog.Error(err, "Unable to initialize etcd controller with image vector")
 		os.Exit(1)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR introduces a new CLI flag `--disable-etcd-serviceaccount-automount` (default: `false`) which sets the `.automountServiceAccountToken=false` in the `ServiceAccount` for etcds if set to `true`. This can be used in conjunction with 

**Which issue(s) this PR fixes**:
Part of gardener/gardener#4659
Part of gardener/gardener#4878

**Special notes for your reviewer**:
/cc @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
When `--disable-etcd-serviceaccount-automount` is set to `true` then the `.automountServiceAccountToken` will be set to `false` for the `ServiceAccount` created for etcd.
```
