### PR TITLE
Switch leader election to leases

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -7,7 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - leases
   verbs:
   - get

--- a/main.go
+++ b/main.go
@@ -56,8 +56,7 @@ func main() {
 		etcdMemberNotReadyThreshold time.Duration
 		etcdMemberUnknownThreshold  time.Duration
 
-		// TODO: migrate default to `leases` in one of the next releases
-		defaultLeaderElectionResourceLock = resourcelock.ConfigMapsLeasesResourceLock
+		defaultLeaderElectionResourceLock = resourcelock.LeasesResourceLock
 		defaultLeaderElectionID           = "druid-leader-election"
 	)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

Which issue(s) this PR fixes:
Part of gardener/gardener#4742

CC: @ialidzhikov 

```breaking operator
The default leader election resource lock of `etcd-druid` has been changed from `configmapsleases` to `leases`.
Please make sure, that you had at least `etcd-druid@v0.5.0 ` running before upgrading so that it has successfully acquired leadership with the hybrid resource lock (`configmapsleases`) at least once.
```
