### PR TITLE
Add support for ETCD backups in the local provider extension

### DIFF
--- a/charts/etcd-copy-backups/templates/etcd-copy-backups-job.yaml
+++ b/charts/etcd-copy-backups/templates/etcd-copy-backups-job.yaml
@@ -108,6 +108,14 @@ spec:
           value: "/root/source-etcd-backup"
 {{- end }}
         volumeMounts:
+{{- if eq .Values.targetStore.storageProvider "Local" }}
+        - name: target-host-storage
+          mountPath: {{ .Values.targetStore.storageContainer }}
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "Local" }}
+        - name: source-host-storage
+          mountPath: {{ .Values.sourceStore.storageContainer }}
+{{- end }}
 {{- if eq .Values.targetStore.storageProvider "GCS" }}
         - name: etcd-backup
           mountPath: "/root/.gcp/"
@@ -149,6 +157,18 @@ spec:
           mountPath: "/root/source-etcd-backup"
 {{- end }}
       volumes:
+{{- if eq .Values.targetStore.storageProvider "Local" }}
+      - name: target-host-storage
+        hostPath:
+          path: {{ .Values.targetStore.storageMountPath }}/{{ .Values.targetStore.storageContainer }}
+          type: Directory
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "Local" }}
+      - name: source-host-storage
+        hostPath:
+          path: {{ .Values.sourceStore.storageMountPath }}/{{ .Values.sourceStore.storageContainer }}
+          type: Directory
+{{- end }}
 {{- if eq .Values.targetStore.storageProvider "GCS" }}
       - name: etcd-backup
         secret:

--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -307,6 +307,10 @@ spec:
               optional: true
 {{- end }}
         volumeMounts:
+{{- if eq .Values.store.storageProvider "Local" }}
+        - name: host-storage
+          mountPath: {{ .Values.store.storageContainer }}
+{{- end }}
         - name: {{ .Values.volumeClaimTemplateName }}
           mountPath: /var/etcd/data
         - name: etcd-config-file
@@ -345,6 +349,12 @@ spec:
             - SYS_PTRACE
       shareProcessNamespace: true
       volumes:
+{{- if eq .Values.store.storageProvider "Local" }}
+      - name: host-storage
+        hostPath:
+          path: {{ .Values.store.storageMountPath }}/{{ .Values.store.storageContainer }}
+          type: Directory
+{{- end }}
       - name: etcd-config-file
         configMap:
           name: {{ .Values.configMapName }}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,3 +50,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -963,7 +963,7 @@ func (r *EtcdReconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, 
 		Service: componentservice.GenerateValues(etcd),
 	}
 
-	values, err := getMapFromEtcd(r.ImageVector, etcd, val, r.disableEtcdServiceAccountAutomount)
+	values, err := getMapFromEtcd(ctx, r.Client, r.ImageVector, etcd, val, r.disableEtcdServiceAccountAutomount)
 
 	if err != nil {
 		return nil, nil, err
@@ -1051,7 +1051,7 @@ func checkEtcdAnnotations(annotations map[string]string, etcd metav1.Object) boo
 
 }
 
-func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd, val componentetcd.Values, disableEtcdServiceAccountAutomount bool) (map[string]interface{}, error) {
+func getMapFromEtcd(ctx context.Context, client client.Client, im imagevector.ImageVector, etcd *druidv1alpha1.Etcd, val componentetcd.Values, disableEtcdServiceAccountAutomount bool) (map[string]interface{}, error) {
 	var statefulsetReplicas int
 	if etcd.Spec.Replicas != 0 {
 		statefulsetReplicas = 1
@@ -1257,7 +1257,7 @@ func getMapFromEtcd(im imagevector.ImageVector, etcd *druidv1alpha1.Etcd, val co
 	}
 
 	if etcd.Spec.Backup.Store != nil {
-		if values["store"], err = utils.GetStoreValues(etcd.Spec.Backup.Store); err != nil {
+		if values["store"], err = utils.GetStoreValues(ctx, client, etcd.Spec.Backup.Store, etcd.Namespace); err != nil {
 			return nil, err
 		}
 

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -1509,6 +1509,10 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 									"Name":      Equal("etcd-client-tls"),
 									"MountPath": Equal("/var/etcd/ssl/client"),
 								}),
+								"host-storage": MatchFields(IgnoreExtras, Fields{
+									"Name":      Equal("host-storage"),
+									"MountPath": Equal(*instance.Spec.Backup.Store.Container),
+								}),
 							}),
 							"Env": MatchElements(envIterator, IgnoreExtras, Elements{
 								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
@@ -1543,6 +1547,15 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 					}),
 					"ShareProcessNamespace": Equal(pointer.BoolPtr(true)),
 					"Volumes": MatchAllElements(volumeIterator, Elements{
+						"host-storage": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("host-storage"),
+							"VolumeSource": MatchFields(IgnoreExtras, Fields{
+								"HostPath": PointTo(MatchFields(IgnoreExtras, Fields{
+									"Path": Equal(fmt.Sprintf("/etc/gardener/local-backupbuckets/%s", *instance.Spec.Backup.Store.Container)),
+									"Type": PointTo(Equal(corev1.HostPathType("Directory"))),
+								})),
+							}),
+						}),
 						"etcd-config-file": MatchFields(IgnoreExtras, Fields{
 							"Name": Equal("etcd-config-file"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{

--- a/controllers/etcdcopybackupstask_controller.go
+++ b/controllers/etcdcopybackupstask_controller.go
@@ -209,7 +209,7 @@ func (r *EtcdCopyBackupsTaskReconciler) doReconcile(ctx context.Context, task *d
 	}
 
 	// Get chart values
-	values, err := r.getChartValues(task)
+	values, err := r.getChartValues(ctx, task)
 	if err != nil {
 		return status, fmt.Errorf("could not get chart values: %w", err)
 	}
@@ -283,18 +283,18 @@ func (r *EtcdCopyBackupsTaskReconciler) updateStatus(ctx context.Context, task *
 	return r.Client.Status().Patch(ctx, task, patch)
 }
 
-func (r *EtcdCopyBackupsTaskReconciler) getChartValues(task *druidv1alpha1.EtcdCopyBackupsTask) (map[string]interface{}, error) {
+func (r *EtcdCopyBackupsTaskReconciler) getChartValues(ctx context.Context, task *druidv1alpha1.EtcdCopyBackupsTask) (map[string]interface{}, error) {
 	values := map[string]interface{}{
 		"name":      getCopyBackupsJobName(task),
 		"ownerName": task.Name,
 		"ownerUID":  task.UID,
 	}
 
-	sourceStoreValues, err := utils.GetStoreValues(&task.Spec.SourceStore)
+	sourceStoreValues, err := utils.GetStoreValues(ctx, r.Client, &task.Spec.SourceStore, task.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	targetStoreValues, err := utils.GetStoreValues(&task.Spec.TargetStore)
+	targetStoreValues, err := utils.GetStoreValues(ctx, r.Client, &task.Spec.TargetStore, task.Namespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind enhancement

**What this PR does / why we need it**:
This PR adds support for ETCD backups in the local provider extension by enhancing the Etcd StatefulSet and the Etcd-copy-backup-job yaml files to support the `Local` provider.
**Which issue(s) this PR fixes**:
Fixes #
#299 
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The ETCD backup restore is now configured to support Local provider in container environment.
```
