### PR TITLE
To dynamically load IaaS credentials during runtime using secrets mount.

### DIFF
--- a/charts/etcd-copy-backups/templates/etcd-copy-backups-job.yaml
+++ b/charts/etcd-copy-backups/templates/etcd-copy-backups-job.yaml
@@ -76,152 +76,37 @@ spec:
           value: {{ .Values.sourceStore.storageContainer }}
 {{- end }}
 {{- if eq .Values.targetStore.storageProvider "S3" }}
-        - name: "AWS_REGION"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "region"
-        - name: "AWS_SECRET_ACCESS_KEY"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "secretAccessKey"
-        - name: "AWS_ACCESS_KEY_ID"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "accessKeyID"
+        - name: AWS_APPLICATION_CREDENTIALS
+          value: "/root/etcd-backup"
 {{- else if eq .Values.targetStore.storageProvider "ABS" }}
-        - name: "STORAGE_ACCOUNT"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "storageAccount"
-        - name: "STORAGE_KEY"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "storageKey"
+        - name: AZURE_APPLICATION_CREDENTIALS
+          value: "/root/etcd-backup"
 {{- else if eq .Values.targetStore.storageProvider "GCS" }}
-        - name: "GOOGLE_APPLICATION_CREDENTIALS"
+        - name: GOOGLE_APPLICATION_CREDENTIALS
           value: "/root/.gcp/serviceaccount.json"
 {{- else if eq .Values.targetStore.storageProvider "Swift" }}
-        - name: "OS_AUTH_URL"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "authURL"
-        - name: "OS_DOMAIN_NAME"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "domainName"
-        - name: "OS_USERNAME"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "username"
-        - name: "OS_PASSWORD"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "password"
-        - name: "OS_TENANT_NAME"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "tenantName"
+        - name: OPENSTACK_APPLICATION_CREDENTIALS
+          value: "/root/etcd-backup"
 {{- else if eq .Values.targetStore.storageProvider "OSS" }}
-        - name: "ALICLOUD_ENDPOINT"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "storageEndpoint"
-        - name: "ALICLOUD_ACCESS_KEY_SECRET"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "accessKeySecret"
-        - name: "ALICLOUD_ACCESS_KEY_ID"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.targetStore.storeSecret }}
-              key: "accessKeyID"
+        - name: ALICLOUD_APPLICATION_CREDENTIALS
+          value: "/root/etcd-backup"
 {{- end }}
 {{- if eq .Values.sourceStore.storageProvider "S3" }}
-        - name: "SOURCE_AWS_REGION"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "region"
-        - name: "SOURCE_AWS_SECRET_ACCESS_KEY"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "secretAccessKey"
-        - name: "SOURCE_AWS_ACCESS_KEY_ID"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "accessKeyID"
+        - name: SOURCE_AWS_APPLICATION_CREDENTIALS
+          value: "/root/source-etcd-backup"
 {{- else if eq .Values.sourceStore.storageProvider "ABS" }}
-        - name: "SOURCE_STORAGE_ACCOUNT"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "storageAccount"
-        - name: "SOURCE_STORAGE_KEY"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "storageKey"
+        - name: SOURCE_AZURE_APPLICATION_CREDENTIALS
+          value: "/root/source-etcd-backup"
 {{- else if eq .Values.sourceStore.storageProvider "GCS" }}
         - name: SOURCE_GOOGLE_APPLICATION_CREDENTIALS
           value: "/root/.source-gcp/serviceaccount.json"
 {{- else if eq .Values.sourceStore.storageProvider "Swift" }}
-        - name: "SOURCE_OS_AUTH_URL"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "authURL"
-        - name: "SOURCE_OS_DOMAIN_NAME"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "domainName"
-        - name: "SOURCE_OS_USERNAME"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "username"
-        - name: "SOURCE_OS_PASSWORD"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "password"
-        - name: "SOURCE_OS_TENANT_NAME"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "tenantName"
+        - name: SOURCE_OPENSTACK_APPLICATION_CREDENTIALS
+          value: "/root/source-etcd-backup"
 {{- else if eq .Values.sourceStore.storageProvider "OSS" }}
-        - name: "SOURCE_ALICLOUD_ENDPOINT"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "storageEndpoint"
-        - name: "SOURCE_ALICLOUD_ACCESS_KEY_SECRET"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "accessKeySecret"
-        - name: "SOURCE_ALICLOUD_ACCESS_KEY_ID"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sourceStore.storeSecret }}
-              key: "accessKeyID"
+        - name: SOURCE_ALICLOUD_APPLICATION_CREDENTIALS
+          value: "/root/source-etcd-backup"
 {{- end }}
-{{- if or (eq .Values.targetStore.storageProvider "GCS") (eq .Values.sourceStore.storageProvider "GCS") }}
         volumeMounts:
 {{- if eq .Values.targetStore.storageProvider "GCS" }}
         - name: etcd-backup
@@ -230,6 +115,38 @@ spec:
 {{- if eq .Values.sourceStore.storageProvider "GCS" }}
         - name: source-etcd-backup
           mountPath: "/root/.source-gcp/"
+{{- end }}
+{{- if eq .Values.targetStore.storageProvider "S3" }}
+        - name: etcd-backup
+          mountPath: "/root/etcd-backup"
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "S3" }}
+        - name: source-etcd-backup
+          mountPath: "/root/source-etcd-backup"
+{{- end }}
+{{- if eq .Values.targetStore.storageProvider "ABS" }}
+        - name: etcd-backup
+          mountPath: "/root/etcd-backup"
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "ABS" }}
+        - name: source-etcd-backup
+          mountPath: "/root/source-etcd-backup"
+{{- end }}
+{{- if eq .Values.targetStore.storageProvider "OSS" }}
+        - name: etcd-backup
+          mountPath: "/root/etcd-backup"
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "OSS" }}
+        - name: source-etcd-backup
+          mountPath: "/root/source-etcd-backup"
+{{- end }}
+{{- if eq .Values.targetStore.storageProvider "Swift" }}
+        - name: etcd-backup
+          mountPath: "/root/etcd-backup"
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "Swift" }}
+        - name: source-etcd-backup
+          mountPath: "/root/source-etcd-backup"
 {{- end }}
       volumes:
 {{- if eq .Values.targetStore.storageProvider "GCS" }}
@@ -242,4 +159,43 @@ spec:
         secret:
           secretName: {{ .Values.sourceStore.storeSecret }}
 {{- end }}
+{{- if eq .Values.targetStore.storageProvider "S3" }}
+      - name: etcd-backup
+        secret:
+          secretName: {{ .Values.targetStore.storeSecret }}
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "S3" }}
+      - name: source-etcd-backup
+        secret:
+          secretName: {{ .Values.sourceStore.storeSecret }}
+{{- end }}
+{{- if eq .Values.targetStore.storageProvider "ABS" }}
+      - name: etcd-backup
+        secret:
+          secretName: {{ .Values.targetStore.storeSecret }}
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "ABS" }}
+      - name: source-etcd-backup
+        secret:
+          secretName: {{ .Values.sourceStore.storeSecret }}
+{{- end }}
+{{- if eq .Values.targetStore.storageProvider "OSS" }}
+      - name: etcd-backup
+        secret:
+          secretName: {{ .Values.targetStore.storeSecret }}
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "OSS" }}
+      - name: source-etcd-backup
+        secret:
+          secretName: {{ .Values.sourceStore.storeSecret }}
+{{- end }}
+{{- if eq .Values.targetStore.storageProvider "Swift" }}
+      - name: etcd-backup
+        secret:
+          secretName: {{ .Values.targetStore.storeSecret }}
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "Swift" }}
+      - name: source-etcd-backup
+        secret:
+          secretName: {{ .Values.sourceStore.storeSecret }}
 {{- end }}

--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -242,77 +242,20 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
 {{- if eq .Values.store.storageProvider "S3" }}
-        - name: "AWS_REGION"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "region"
-        - name: "AWS_SECRET_ACCESS_KEY"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "secretAccessKey"
-        - name: "AWS_ACCESS_KEY_ID"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "accessKeyID"
+        - name: "AWS_APPLICATION_CREDENTIALS"
+          value: "/root/etcd-backup"
 {{- else if eq .Values.store.storageProvider "ABS" }}
-        - name: "STORAGE_ACCOUNT"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "storageAccount"
-        - name: "STORAGE_KEY"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "storageKey"
+        - name: "AZURE_APPLICATION_CREDENTIALS"
+          value: "/root/etcd-backup"
 {{- else if eq .Values.store.storageProvider "GCS" }}
         - name: "GOOGLE_APPLICATION_CREDENTIALS"
           value: "/root/.gcp/serviceaccount.json"
 {{- else if eq .Values.store.storageProvider "Swift" }}
-        - name: "OS_AUTH_URL"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "authURL"
-        - name: "OS_DOMAIN_NAME"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "domainName"
-        - name: "OS_USERNAME"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "username"
-        - name: "OS_PASSWORD"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "password"
-        - name: "OS_TENANT_NAME"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "tenantName"
+        - name: "OPENSTACK_APPLICATION_CREDENTIALS"
+          value: "/root/etcd-backup"
 {{- else if eq .Values.store.storageProvider "OSS" }}
-        - name: "ALICLOUD_ENDPOINT"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "storageEndpoint"
-        - name: "ALICLOUD_ACCESS_KEY_SECRET"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "accessKeySecret"
-        - name: "ALICLOUD_ACCESS_KEY_ID"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "accessKeyID"
+        - name: "ALICLOUD_APPLICATION_CREDENTIALS"
+          value: "/root/etcd-backup"
 {{- else if eq .Values.store.storageProvider "ECS" }}
         - name: "ECS_ENDPOINT"
           valueFrom:
@@ -380,6 +323,22 @@ spec:
         - name: etcd-backup
           mountPath: "/root/.gcp/"
 {{- end }}
+{{- if eq .Values.store.storageProvider "S3" }}
+        - name: etcd-backup
+          mountPath: "/root/etcd-backup"
+{{- end }}
+{{- if eq .Values.store.storageProvider "ABS" }}
+        - name: etcd-backup
+          mountPath: "/root/etcd-backup"
+{{- end }}
+{{- if eq .Values.store.storageProvider "OSS" }}
+        - name: etcd-backup
+          mountPath: "/root/etcd-backup"
+{{- end }}
+{{- if eq .Values.store.storageProvider "Swift" }}
+        - name: etcd-backup
+          mountPath: "/root/etcd-backup"
+{{- end }}
         securityContext:
           capabilities:
             add:
@@ -405,6 +364,26 @@ spec:
           secretName: {{ .Values.tlsCASecret }}
 {{- end }}
 {{- if eq .Values.store.storageProvider "GCS" }}
+      - name: etcd-backup
+        secret:
+          secretName: {{ .Values.store.storeSecret }}
+{{- end }}
+{{- if eq .Values.store.storageProvider "S3" }}
+      - name: etcd-backup
+        secret:
+          secretName: {{ .Values.store.storeSecret }}
+{{- end }}
+{{- if eq .Values.store.storageProvider "ABS" }}
+      - name: etcd-backup
+        secret:
+          secretName: {{ .Values.store.storeSecret }}
+{{- end }}
+{{- if eq .Values.store.storageProvider "OSS" }}
+      - name: etcd-backup
+        secret:
+          secretName: {{ .Values.store.storeSecret }}
+{{- end }}
+{{- if eq .Values.store.storageProvider "Swift" }}
       - name: etcd-backup
         secret:
           secretName: {{ .Values.store.storeSecret }}

--- a/controllers/compaction_lease_controller.go
+++ b/controllers/compaction_lease_controller.go
@@ -364,6 +364,11 @@ func getCmpctJobVolumeMounts(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.
 			Name:      "etcd-backup",
 			MountPath: "/root/.gcp/",
 		})
+	} else if provider == "S3" || provider == "ABS" || provider == "OSS" || provider == "Swift" {
+		vms = append(vms, v1.VolumeMount{
+			Name:      "etcd-backup",
+			MountPath: "/root/etcd-backup/",
+		})
 	}
 
 	return vms
@@ -390,7 +395,7 @@ func getCmpctJobVolumes(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.Volum
 		return vs
 	}
 
-	if provider == "GCS" {
+	if provider == "GCS" || provider == "S3" || provider == "OSS" || provider == "ABS" || provider == "Swift" {
 		vs = append(vs, v1.Volume{
 			Name: "etcd-backup",
 			VolumeSource: v1.VolumeSource{
@@ -422,14 +427,11 @@ func getCmpctJobEnvVar(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.EnvVar
 	}
 
 	if provider == "S3" {
-		env = append(env, getEnvVarFromSecrets("AWS_REGION", storeValues.SecretRef.Name, "region"))
-		env = append(env, getEnvVarFromSecrets("AWS_SECRET_ACCESS_KEY", storeValues.SecretRef.Name, "secretAccessKey"))
-		env = append(env, getEnvVarFromSecrets("AWS_ACCESS_KEY_ID", storeValues.SecretRef.Name, "accessKeyID"))
+		env = append(env, getEnvVarFromValues("AWS_APPLICATION_CREDENTIALS", "/root/etcd-backup"))
 	}
 
 	if provider == "ABS" {
-		env = append(env, getEnvVarFromSecrets("STORAGE_ACCOUNT", storeValues.SecretRef.Name, "storageAccount"))
-		env = append(env, getEnvVarFromSecrets("STORAGE_KEY", storeValues.SecretRef.Name, "storageKey"))
+		env = append(env, getEnvVarFromValues("AZURE_APPLICATION_CREDENTIALS", "/root/etcd-backup"))
 	}
 
 	if provider == "GCS" {
@@ -437,17 +439,11 @@ func getCmpctJobEnvVar(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.EnvVar
 	}
 
 	if provider == "Swift" {
-		env = append(env, getEnvVarFromSecrets("OS_AUTH_URL", storeValues.SecretRef.Name, "authURL"))
-		env = append(env, getEnvVarFromSecrets("OS_DOMAIN_NAME", storeValues.SecretRef.Name, "domainName"))
-		env = append(env, getEnvVarFromSecrets("OS_USERNAME", storeValues.SecretRef.Name, "username"))
-		env = append(env, getEnvVarFromSecrets("OS_PASSWORD", storeValues.SecretRef.Name, "password"))
-		env = append(env, getEnvVarFromSecrets("OS_TENANT_NAME", storeValues.SecretRef.Name, "tenantName"))
+		env = append(env, getEnvVarFromValues("OPENSTACK_APPLICATION_CREDENTIALS", "/root/etcd-backup"))
 	}
 
 	if provider == "OSS" {
-		env = append(env, getEnvVarFromSecrets("ALICLOUD_ENDPOINT", storeValues.SecretRef.Name, "storageEndpoint"))
-		env = append(env, getEnvVarFromSecrets("ALICLOUD_ACCESS_KEY_SECRET", storeValues.SecretRef.Name, "accessKeySecret"))
-		env = append(env, getEnvVarFromSecrets("ALICLOUD_ACCESS_KEY_ID", storeValues.SecretRef.Name, "accessKeyID"))
+		env = append(env, getEnvVarFromValues("ALICLOUD_APPLICATION_CREDENTIALS", "/root/etcd-backup"))
 	}
 
 	if provider == "ECS" {

--- a/controllers/compaction_lease_controller_test.go
+++ b/controllers/compaction_lease_controller_test.go
@@ -535,39 +535,20 @@ func validateStoreAWSForCmpctJob(instance *druidv1alpha1.Etcd, j *batchv1.Job) {
 										})),
 									})),
 								}),
-								"AWS_REGION": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("AWS_REGION"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("region"),
-										})),
-									})),
+								"AWS_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal("AWS_APPLICATION_CREDENTIALS"),
+									"Value": Equal("/root/etcd-backup"),
 								}),
-								"AWS_SECRET_ACCESS_KEY": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("AWS_SECRET_ACCESS_KEY"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("secretAccessKey"),
-										})),
-									})),
-								}),
-								"AWS_ACCESS_KEY_ID": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("AWS_ACCESS_KEY_ID"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("accessKeyID"),
-										})),
-									})),
-								}),
+							}),
+						}),
+					}),
+					"Volumes": MatchElements(volumeIterator, IgnoreExtras, Elements{
+						"etcd-backup": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("etcd-backup"),
+							"VolumeSource": MatchFields(IgnoreExtras, Fields{
+								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
+									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+								})),
 							}),
 						}),
 					}),
@@ -602,28 +583,20 @@ func validateStoreAzureForCmpctJob(instance *druidv1alpha1.Etcd, j *batchv1.Job)
 										})),
 									})),
 								}),
-								"STORAGE_ACCOUNT": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("STORAGE_ACCOUNT"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("storageAccount"),
-										})),
-									})),
+								"AZURE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal("AZURE_APPLICATION_CREDENTIALS"),
+									"Value": Equal("/root/etcd-backup"),
 								}),
-								"STORAGE_KEY": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("STORAGE_KEY"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("storageKey"),
-										})),
-									})),
-								}),
+							}),
+						}),
+					}),
+					"Volumes": MatchElements(volumeIterator, IgnoreExtras, Elements{
+						"etcd-backup": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("etcd-backup"),
+							"VolumeSource": MatchFields(IgnoreExtras, Fields{
+								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
+									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+								})),
 							}),
 						}),
 					}),
@@ -658,61 +631,20 @@ func validateStoreOpenstackForCmpctJob(instance *druidv1alpha1.Etcd, j *batchv1.
 										})),
 									})),
 								}),
-								"OS_AUTH_URL": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("OS_AUTH_URL"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("authURL"),
-										})),
-									})),
+								"OPENSTACK_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal("OPENSTACK_APPLICATION_CREDENTIALS"),
+									"Value": Equal("/root/etcd-backup"),
 								}),
-								"OS_USERNAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("OS_USERNAME"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("username"),
-										})),
-									})),
-								}),
-								"OS_TENANT_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("OS_TENANT_NAME"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("tenantName"),
-										})),
-									})),
-								}),
-								"OS_PASSWORD": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("OS_PASSWORD"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("password"),
-										})),
-									})),
-								}),
-								"OS_DOMAIN_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("OS_DOMAIN_NAME"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("domainName"),
-										})),
-									})),
-								}),
+							}),
+						}),
+					}),
+					"Volumes": MatchElements(volumeIterator, IgnoreExtras, Elements{
+						"etcd-backup": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("etcd-backup"),
+							"VolumeSource": MatchFields(IgnoreExtras, Fields{
+								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
+									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+								})),
 							}),
 						}),
 					}),
@@ -748,39 +680,20 @@ func validateStoreAlicloudForCmpctJob(instance *druidv1alpha1.Etcd, j *batchv1.J
 										})),
 									})),
 								}),
-								"ALICLOUD_ENDPOINT": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("ALICLOUD_ENDPOINT"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("storageEndpoint"),
-										})),
-									})),
+								"ALICLOUD_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal("ALICLOUD_APPLICATION_CREDENTIALS"),
+									"Value": Equal("/root/etcd-backup"),
 								}),
-								"ALICLOUD_ACCESS_KEY_SECRET": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("ALICLOUD_ACCESS_KEY_SECRET"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("accessKeySecret"),
-										})),
-									})),
-								}),
-								"ALICLOUD_ACCESS_KEY_ID": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("ALICLOUD_ACCESS_KEY_ID"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("accessKeyID"),
-										})),
-									})),
-								}),
+							}),
+						}),
+					}),
+					"Volumes": MatchElements(volumeIterator, IgnoreExtras, Elements{
+						"etcd-backup": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("etcd-backup"),
+							"VolumeSource": MatchFields(IgnoreExtras, Fields{
+								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
+									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+								})),
 							}),
 						}),
 					}),

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -1706,28 +1706,20 @@ func validateStoreAzure(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm 
 										})),
 									})),
 								}),
-								"STORAGE_ACCOUNT": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("STORAGE_ACCOUNT"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("storageAccount"),
-										})),
-									})),
+								"AZURE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal("AZURE_APPLICATION_CREDENTIALS"),
+									"Value": Equal("/root/etcd-backup"),
 								}),
-								"STORAGE_KEY": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("STORAGE_KEY"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("storageKey"),
-										})),
-									})),
-								}),
+							}),
+						}),
+					}),
+					"Volumes": MatchElements(volumeIterator, IgnoreExtras, Elements{
+						"etcd-backup": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("etcd-backup"),
+							"VolumeSource": MatchFields(IgnoreExtras, Fields{
+								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
+									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+								})),
 							}),
 						}),
 					}),
@@ -1770,61 +1762,20 @@ func validateStoreOpenstack(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet,
 										})),
 									})),
 								}),
-								"OS_AUTH_URL": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("OS_AUTH_URL"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("authURL"),
-										})),
-									})),
+								"OPENSTACK_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal("OPENSTACK_APPLICATION_CREDENTIALS"),
+									"Value": Equal("/root/etcd-backup"),
 								}),
-								"OS_USERNAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("OS_USERNAME"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("username"),
-										})),
-									})),
-								}),
-								"OS_TENANT_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("OS_TENANT_NAME"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("tenantName"),
-										})),
-									})),
-								}),
-								"OS_PASSWORD": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("OS_PASSWORD"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("password"),
-										})),
-									})),
-								}),
-								"OS_DOMAIN_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("OS_DOMAIN_NAME"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("domainName"),
-										})),
-									})),
-								}),
+							}),
+						}),
+					}),
+					"Volumes": MatchElements(volumeIterator, IgnoreExtras, Elements{
+						"etcd-backup": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("etcd-backup"),
+							"VolumeSource": MatchFields(IgnoreExtras, Fields{
+								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
+									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+								})),
 							}),
 						}),
 					}),
@@ -1869,39 +1820,20 @@ func validateStoreAlicloud(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, 
 										})),
 									})),
 								}),
-								"ALICLOUD_ENDPOINT": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("ALICLOUD_ENDPOINT"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("storageEndpoint"),
-										})),
-									})),
+								"ALICLOUD_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal("ALICLOUD_APPLICATION_CREDENTIALS"),
+									"Value": Equal("/root/etcd-backup"),
 								}),
-								"ALICLOUD_ACCESS_KEY_SECRET": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("ALICLOUD_ACCESS_KEY_SECRET"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("accessKeySecret"),
-										})),
-									})),
-								}),
-								"ALICLOUD_ACCESS_KEY_ID": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("ALICLOUD_ACCESS_KEY_ID"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("accessKeyID"),
-										})),
-									})),
-								}),
+							}),
+						}),
+					}),
+					"Volumes": MatchElements(volumeIterator, IgnoreExtras, Elements{
+						"etcd-backup": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("etcd-backup"),
+							"VolumeSource": MatchFields(IgnoreExtras, Fields{
+								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
+									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+								})),
 							}),
 						}),
 					}),
@@ -1946,39 +1878,20 @@ func validateStoreAWS(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *c
 										})),
 									})),
 								}),
-								"AWS_REGION": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("AWS_REGION"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("region"),
-										})),
-									})),
+								"AWS_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal("AWS_APPLICATION_CREDENTIALS"),
+									"Value": Equal("/root/etcd-backup"),
 								}),
-								"AWS_SECRET_ACCESS_KEY": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("AWS_SECRET_ACCESS_KEY"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("secretAccessKey"),
-										})),
-									})),
-								}),
-								"AWS_ACCESS_KEY_ID": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("AWS_ACCESS_KEY_ID"),
-									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
-										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
-											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
-											}),
-											"Key": Equal("accessKeyID"),
-										})),
-									})),
-								}),
+							}),
+						}),
+					}),
+					"Volumes": MatchElements(volumeIterator, IgnoreExtras, Elements{
+						"etcd-backup": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("etcd-backup"),
+							"VolumeSource": MatchFields(IgnoreExtras, Fields{
+								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
+									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+								})),
 							}),
 						}),
 					}),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR integrates the feature to [dynamically load IaaS credentials during runtime using secret file mount](https://github.com/gardener/etcd-backup-restore/pull/435) with etcd-druid. 

**Which issue(s) this PR fixes**:
Fixes [#422](https://github.com/gardener/etcd-backup-restore/issues/422)

**Special notes for your reviewer**:

**Release note**:
```other operator
To Dynamically load Iaas credentials, added support to pass the credentials through secret mount.
```
```other operator
Set File Path through Env: <ProviderName>_APPLICATION_CREDENTIALS
```
