### PR TITLE
Fix the bug to avoid Nil pointer exception in EtcdCopyBackupsTask.

### DIFF
--- a/controllers/etcdcopybackupstask_controller.go
+++ b/controllers/etcdcopybackupstask_controller.go
@@ -217,13 +217,13 @@ func (r *EtcdCopyBackupsTaskReconciler) doReconcile(ctx context.Context, task *d
 	// Render chart
 	renderedChart, err := r.chartApplier.Render(getEtcdCopyBackupsChartPath(), task.Name, task.Namespace, values)
 	if err != nil {
-		return nil, fmt.Errorf("could not render chart: %w", err)
+		return status, fmt.Errorf("could not render chart: %w", err)
 	}
 
 	// Decode job object from chart
 	job = &batchv1.Job{}
 	if err := decodeObject(renderedChart, getJobPath(), &job); err != nil {
-		return nil, fmt.Errorf("could not decode job object from chart: %w", err)
+		return status, fmt.Errorf("could not decode job object from chart: %w", err)
 	}
 
 	// Create job


### PR DESCRIPTION
**What this PR does / why we need it**:
During reconciliation of an `EtcdCopyBackupsTask` if there is an error when rendering the required charts, a nil pointer exception occurs
This PR fixes the bug to avoid Nil pointer exception in `EtcdCopyBackupsTask`.

**Which issue(s) this PR fixes**:
Fixes #303 

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
A bug has been fix which caused the Nil pointer exception in EtcdCopyBackupsTask.
```

cc @plkokanov 