### PR TITLE
Remove default CPU and memory limits

### DIFF
--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -23,9 +23,6 @@ etcd:
   metrics: basic
   etcdDefragTimeout: 8m
   resources:
-    limits:
-      cpu: 100m
-      memory: 512Gi
     requests:
       cpu: 50m
       memory: 128Mi
@@ -43,16 +40,10 @@ backup:
   maxBackups: 7
   etcdSnapshotTimeout: 8m
   resources:
-    limits:
-      cpu: 100m
-      memory: 512Gi
     requests:
       cpu: 50m
       memory: 128Mi
   compactionResources:
-    limits:
-      cpu: 700m
-      memory: 4Gi
     requests:
       cpu: 500m
       memory: 3Gi

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -852,9 +852,6 @@ func validateEtcdWithDefaults(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSe
 
 	// Validate Resources
 	// resources:
-	//	  limits:
-	//		cpu: 100m
-	//		memory: 512Gi
 	//	  requests:
 	//		cpu: 50m
 	//		memory: 128Mi
@@ -1008,10 +1005,6 @@ func validateEtcdWithDefaults(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSe
 								"Requests": MatchKeys(IgnoreExtras, Keys{
 									corev1.ResourceCPU:    Equal(resource.MustParse("50m")),
 									corev1.ResourceMemory: Equal(resource.MustParse("128Mi")),
-								}),
-								"Limits": MatchKeys(IgnoreExtras, Keys{
-									corev1.ResourceCPU:    Equal(resource.MustParse("100m")),
-									corev1.ResourceMemory: Equal(resource.MustParse("512Gi")),
 								}),
 							}),
 							"ReadinessProbe": PointTo(MatchFields(IgnoreExtras, Fields{


### PR DESCRIPTION
**How to categorize this PR?**

/kind fix

**What this PR does / why we need it**:
Removes the default CPU and memory limits from the `etcd` and `backup-restore` containers. This is done in order to enable removal of limits via the `Etcd` resource. Currently, the default limits are used if no limits are specified in the `Etcd` resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
The default CPU and memory limits for `etcd` and `backup-restore` containers have been removed to enable removal of limits via the `Etcd` resource.
```
