### PR TITLE
Reconcile `ServiceAccount`'s `automountServiceAccountToken` field

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -52,8 +52,6 @@ func NewSecret(mgr manager.Manager) *Secret {
 
 // Reconcile reconciles the secret.
 func (s *Secret) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	s.logger.Info("Secret controller reconciliation started")
-
 	secret := &corev1.Secret{}
 	if err := s.Get(ctx, req.NamespacedName, secret); err != nil {
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
Reconcile `ServiceAccount`'s `automountServiceAccountToken` field created for `Etcd` resources. Also drop noisy/useless log about secret reconciliation.

**Which issue(s) this PR fixes**:
Fixes #315

**Special notes for your reviewer**:
Obviously, this code is highly fragile and will start to fail tomorrow when another field is changed and expected to be reconciled by the controller. In this PR, I'm only focusing on fixing the acute problem with the `automountServiceAccountToken` field. I'm suggesting to invest into a more general and more sustainable solution.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented the `ServiceAccount`'s `automountServiceAccountToken` field from being reconciled.
```
