### PR TITLE
Add a correct apiGroup for leader-election role.

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: leader-election-role
 rules:
 - apiGroups:
-  - ""
+  - "coordination.k8s.io"
   resources:
   - leases
   verbs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a correct apiGroup for leader-election role which was missed in this [#PR281](https://github.com/gardener/etcd-druid/pull/281)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
