### PR TITLE
Mounted peer certificates in backup-restore pod.

### DIFF
--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -335,6 +335,12 @@ spec:
         - name: client-url-etcd-client-tls
           mountPath: /var/etcd/ssl/client/client
 {{- end }}
+{{- if .Values.etcd.enablePeerTLS }}
+        - name: peer-url-ca-etcd
+          mountPath: /var/etcd/ssl/peer/ca
+        - name: peer-url-etcd-server-tls
+          mountPath: /var/etcd/ssl/peer/server
+{{- end }}
 {{- if eq .Values.store.storageProvider "GCS" }}
         - name: etcd-backup
           mountPath: "/root/.gcp/"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO

**What this PR does / why we need it**:
Backup restore pod runs embedded ETCD. We needed to supply peer certificates to the embedded etcd cluster by mounting the peer certificate secrets.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
