### PR TITLE
Upgrade etcd-backup-restore:v0.15.0->v0.15.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.15.0"
+  tag: "v0.15.1"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade etcd-backup-restore to v0.15.1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
``` bugfix operator github.com/gardener/etcd-backup-restore #459 @ishan16696
Fix defragmentation fail issue which occurs due to x509: failed to validate certificate for 0.0.0.0 because it doesn't contain any IP SANs.
```
