### PR TITLE
Fix copying ETCd backups between OCS buckets

### DIFF
--- a/charts/etcd-copy-backups/templates/etcd-copy-backups-job.yaml
+++ b/charts/etcd-copy-backups/templates/etcd-copy-backups-job.yaml
@@ -87,7 +87,7 @@ spec:
 {{- else if eq .Values.targetStore.storageProvider "Swift" }}
         - name: OPENSTACK_APPLICATION_CREDENTIALS
           value: "/root/etcd-backup"
-{{- else if eq .Values.sourceStore.storageProvider "OCS" }}
+{{- else if eq .Values.targetStore.storageProvider "OCS" }}
         - name: OPENSHIFT_APPLICATION_CREDENTIALS
           value: "/root/etcd-backup"
 {{- else if eq .Values.targetStore.storageProvider "OSS" }}

--- a/charts/etcd-copy-backups/templates/etcd-copy-backups-job.yaml
+++ b/charts/etcd-copy-backups/templates/etcd-copy-backups-job.yaml
@@ -87,6 +87,9 @@ spec:
 {{- else if eq .Values.targetStore.storageProvider "Swift" }}
         - name: OPENSTACK_APPLICATION_CREDENTIALS
           value: "/root/etcd-backup"
+{{- else if eq .Values.sourceStore.storageProvider "OCS" }}
+        - name: OPENSHIFT_APPLICATION_CREDENTIALS
+          value: "/root/etcd-backup"
 {{- else if eq .Values.targetStore.storageProvider "OSS" }}
         - name: ALICLOUD_APPLICATION_CREDENTIALS
           value: "/root/etcd-backup"
@@ -102,6 +105,9 @@ spec:
           value: "/root/.source-gcp/serviceaccount.json"
 {{- else if eq .Values.sourceStore.storageProvider "Swift" }}
         - name: SOURCE_OPENSTACK_APPLICATION_CREDENTIALS
+          value: "/root/source-etcd-backup"
+{{- else if eq .Values.sourceStore.storageProvider "OCS" }}
+        - name: SOURCE_OPENSHIFT_APPLICATION_CREDENTIALS
           value: "/root/source-etcd-backup"
 {{- else if eq .Values.sourceStore.storageProvider "OSS" }}
         - name: SOURCE_ALICLOUD_APPLICATION_CREDENTIALS
@@ -153,6 +159,14 @@ spec:
           mountPath: "/root/etcd-backup"
 {{- end }}
 {{- if eq .Values.sourceStore.storageProvider "Swift" }}
+        - name: source-etcd-backup
+          mountPath: "/root/source-etcd-backup"
+{{- end }}
+{{- if eq .Values.targetStore.storageProvider "OCS" }}
+        - name: etcd-backup
+          mountPath: "/root/etcd-backup"
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "OCS" }}
         - name: source-etcd-backup
           mountPath: "/root/source-etcd-backup"
 {{- end }}
@@ -215,6 +229,16 @@ spec:
           secretName: {{ .Values.targetStore.storeSecret }}
 {{- end }}
 {{- if eq .Values.sourceStore.storageProvider "Swift" }}
+      - name: source-etcd-backup
+        secret:
+          secretName: {{ .Values.sourceStore.storeSecret }}
+{{- end }}
+{{- if eq .Values.targetStore.storageProvider "OCS" }}
+      - name: etcd-backup
+        secret:
+          secretName: {{ .Values.targetStore.storeSecret }}
+{{- end }}
+{{- if eq .Values.sourceStore.storageProvider "OCS" }}
       - name: source-etcd-backup
         secret:
           secretName: {{ .Values.sourceStore.storeSecret }}

--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -297,39 +297,6 @@ spec:
             secretKeyRef:
               name: {{ .Values.store.storeSecret }}
               key: "secretAccessKey"
-{{- else if eq .Values.store.storageProvider "OCS" }}
-        - name: "OCS_ENDPOINT"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "endpoint"
-        - name: "OCS_ACCESS_KEY_ID"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "accessKeyID"
-        - name: "OCS_SECRET_ACCESS_KEY"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "secretAccessKey"
-        - name: "OCS_REGION"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "region"
-        - name: "OCS_DISABLE_SSL"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "disableSSL"
-              optional: true
-        - name: "OCS_INSECURE_SKIP_VERIFY"
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.store.storeSecret }}
-              key: "insecureSkipVerify"
-              optional: true
 {{- end }}
         volumeMounts:
 {{- if eq .Values.store.storageProvider "Local" }}

--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -278,6 +278,9 @@ spec:
 {{- else if eq .Values.store.storageProvider "OSS" }}
         - name: "ALICLOUD_APPLICATION_CREDENTIALS"
           value: "/root/etcd-backup"
+{{- else if eq .Values.store.storageProvider "OCS" }}
+        - name: OPENSHIFT_APPLICATION_CREDENTIALS
+          value: "/root/etcd-backup"
 {{- else if eq .Values.store.storageProvider "ECS" }}
         - name: "ECS_ENDPOINT"
           valueFrom:
@@ -367,6 +370,10 @@ spec:
         - name: etcd-backup
           mountPath: "/root/etcd-backup"
 {{- end }}
+{{- if eq .Values.store.storageProvider "OCS" }}
+        - name: etcd-backup
+          mountPath: "/root/etcd-backup"
+{{- end }}
 {{- if eq .Values.store.storageProvider "Swift" }}
         - name: etcd-backup
           mountPath: "/root/etcd-backup"
@@ -425,6 +432,11 @@ spec:
           secretName: {{ .Values.store.storeSecret }}
 {{- end }}
 {{- if eq .Values.store.storageProvider "OSS" }}
+      - name: etcd-backup
+        secret:
+          secretName: {{ .Values.store.storeSecret }}
+{{- end }}
+{{- if eq .Values.store.storageProvider "OCS" }}
       - name: etcd-backup
         secret:
           secretName: {{ .Values.store.storeSecret }}

--- a/controllers/compaction_lease_controller.go
+++ b/controllers/compaction_lease_controller.go
@@ -358,7 +358,7 @@ func getCmpctJobVolumeMounts(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.
 			Name:      "etcd-backup",
 			MountPath: "/root/.gcp/",
 		})
-	} else if provider == "S3" || provider == "ABS" || provider == "OSS" || provider == "Swift" {
+	} else if provider == "S3" || provider == "ABS" || provider == "OSS" || provider == "Swift" || provider == "OCS" {
 		vms = append(vms, v1.VolumeMount{
 			Name:      "etcd-backup",
 			MountPath: "/root/etcd-backup/",
@@ -389,7 +389,7 @@ func getCmpctJobVolumes(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.Volum
 		return vs
 	}
 
-	if provider == "GCS" || provider == "S3" || provider == "OSS" || provider == "ABS" || provider == "Swift" {
+	if provider == "GCS" || provider == "S3" || provider == "OSS" || provider == "ABS" || provider == "Swift" || provider == "OCS" {
 		vs = append(vs, v1.Volume{
 			Name: "etcd-backup",
 			VolumeSource: v1.VolumeSource{
@@ -447,12 +447,7 @@ func getCmpctJobEnvVar(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.EnvVar
 	}
 
 	if provider == "OCS" {
-		env = append(env, getEnvVarFromSecrets("OCS_ENDPOINT", storeValues.SecretRef.Name, "endpoint"))
-		env = append(env, getEnvVarFromSecrets("OCS_ACCESS_KEY_ID", storeValues.SecretRef.Name, "accessKeyID"))
-		env = append(env, getEnvVarFromSecrets("OCS_SECRET_ACCESS_KEY", storeValues.SecretRef.Name, "secretAccessKey"))
-		env = append(env, getEnvVarFromSecrets("OCS_REGION", storeValues.SecretRef.Name, "region"))
-		env = append(env, getEnvVarFromSecrets("OCS_DISABLE_SSL", storeValues.SecretRef.Name, "disableSSL"))
-		env = append(env, getEnvVarFromSecrets("OCS_INSECURE_SKIP_VERIFY", storeValues.SecretRef.Name, "insecureSkipVerify"))
+		env = append(env, getEnvVarFromValues("OPENSHIFT_APPLICATION_CREDENTIALS", "/root/etcd-backup"))
 	}
 
 	return env

--- a/controllers/etcdcopybackupstask_controller_test.go
+++ b/controllers/etcdcopybackupstask_controller_test.go
@@ -364,6 +364,13 @@ func getProviderEnvElements(storeProvider, prefix, volumePrefix string, store *d
 				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
 			}),
 		}
+	case "OCS":
+		return Elements{
+			prefix + "OPENSHIFT_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
+				"Name":  Equal(prefix + "OPENSHIFT_APPLICATION_CREDENTIALS"),
+				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+			}),
+		}
 	default:
 		return nil
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
The proposed changes (in combination with https://github.com/gardener/etcd-backup-restore/pull/465) enable etcd-druid to successfully copy ETCd backups between OCS buckets.
It utilizies the new way of supplying access information to the etcd-backup-restore job (mounting a secret to a specific directory).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
ETCd backups can now be successfully copied between OCS buckets.
```
