### PR TITLE
Increase the etcdSnapshotTimeout and etcdDefragTimeout.

### DIFF
--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -30,7 +30,7 @@ etcd:
   enablePeerTLS: false
   pullPolicy: IfNotPresent
   metrics: basic
-  etcdDefragTimeout: 8m
+  etcdDefragTimeout: 15m
   resources:
     requests:
       cpu: 50m
@@ -49,7 +49,7 @@ backup:
   enableProfiling: false
   garbageCollectionPolicy: LimitBased
   maxBackups: 7
-  etcdSnapshotTimeout: 8m
+  etcdSnapshotTimeout: 15m
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase the `--etcd-snapshot-timeout` and `--etcd-defrag-timeout` from `8mins` to `15mins`.
More Info: check this [issue](https://github.com/gardener/etcd-druid/issues/307)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```
