### PR TITLE
Added restoration indicator lease.

### DIFF
--- a/pkg/component/etcd/lease/lease-cluster-restoration.go
+++ b/pkg/component/etcd/lease/lease-cluster-restoration.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lease
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/controllerutils"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (c *component) deleteClusterRestoreLease(ctx context.Context, lease *coordinationv1.Lease) error {
+	return client.IgnoreNotFound(c.client.Delete(ctx, lease))
+}
+
+func (c *component) syncClusterRestoreLease(ctx context.Context, lease *coordinationv1.Lease) error {
+	fmt.Println("The lease name is: ", lease.ObjectMeta.Name)
+	if c.values.Replicas <= 1 {
+		return c.deleteClusterRestoreLease(ctx, lease)
+	}
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, lease, func() error {
+		lease.OwnerReferences = getOwnerReferences(c.values)
+		return nil
+	})
+	return err
+}

--- a/pkg/component/etcd/lease/lease.go
+++ b/pkg/component/etcd/lease/lease.go
@@ -35,8 +35,9 @@ type component struct {
 
 func (c *component) Deploy(ctx context.Context) error {
 	var (
-		deltaSnapshotLease = c.emptyLease(c.values.DeltaSnapshotLeaseName)
-		fullSnapshotLease  = c.emptyLease(c.values.FullSnapshotLeaseName)
+		deltaSnapshotLease  = c.emptyLease(c.values.DeltaSnapshotLeaseName)
+		fullSnapshotLease   = c.emptyLease(c.values.FullSnapshotLeaseName)
+		clusterRestoreLease = c.emptyLease(c.values.ClusterRestoreLeaseName)
 	)
 
 	if err := c.syncSnapshotLease(ctx, deltaSnapshotLease); err != nil {
@@ -44,6 +45,10 @@ func (c *component) Deploy(ctx context.Context) error {
 	}
 
 	if err := c.syncSnapshotLease(ctx, fullSnapshotLease); err != nil {
+		return err
+	}
+
+	if err := c.syncClusterRestoreLease(ctx, clusterRestoreLease); err != nil {
 		return err
 	}
 
@@ -56,8 +61,9 @@ func (c *component) Deploy(ctx context.Context) error {
 
 func (c *component) Destroy(ctx context.Context) error {
 	var (
-		deltaSnapshotLease = c.emptyLease(c.values.DeltaSnapshotLeaseName)
-		fullSnapshotLease  = c.emptyLease(c.values.FullSnapshotLeaseName)
+		deltaSnapshotLease  = c.emptyLease(c.values.DeltaSnapshotLeaseName)
+		fullSnapshotLease   = c.emptyLease(c.values.FullSnapshotLeaseName)
+		clusterRestoreLease = c.emptyLease(c.values.ClusterRestoreLeaseName)
 	)
 
 	if err := c.deleteSnapshotLease(ctx, deltaSnapshotLease); err != nil {
@@ -65,6 +71,10 @@ func (c *component) Destroy(ctx context.Context) error {
 	}
 
 	if err := c.deleteSnapshotLease(ctx, fullSnapshotLease); err != nil {
+		return err
+	}
+
+	if err := c.deleteSnapshotLease(ctx, clusterRestoreLease); err != nil {
 		return err
 	}
 

--- a/pkg/component/etcd/lease/values.go
+++ b/pkg/component/etcd/lease/values.go
@@ -29,6 +29,8 @@ type Values struct {
 	DeltaSnapshotLeaseName string
 	// FullSnapshotLeaseName is the name of the full snapshot lease object.
 	FullSnapshotLeaseName string
+	// ClusterRestoreLeaseName is the name of the lease object responsible for indicating restoration status of ETCD cluster
+	ClusterRestoreLeaseName string
 	// Replicas is the replica count of the etcd cluster.
 	Replicas int32
 }

--- a/pkg/component/etcd/lease/values_helper.go
+++ b/pkg/component/etcd/lease/values_helper.go
@@ -23,12 +23,13 @@ import (
 // GenerateValues generates `lease.Values` for the lease component with the given parameters.
 func GenerateValues(etcd *druidv1alpha1.Etcd) Values {
 	return Values{
-		BackupEnabled:          etcd.Spec.Backup.Store != nil,
-		EtcdName:               etcd.Name,
-		EtcdUID:                etcd.UID,
-		DeltaSnapshotLeaseName: GetDeltaSnapshotLeaseName(etcd),
-		FullSnapshotLeaseName:  GetFullSnapshotLeaseName(etcd),
-		Replicas:               etcd.Spec.Replicas,
+		BackupEnabled:           etcd.Spec.Backup.Store != nil,
+		EtcdName:                etcd.Name,
+		EtcdUID:                 etcd.UID,
+		DeltaSnapshotLeaseName:  GetDeltaSnapshotLeaseName(etcd),
+		FullSnapshotLeaseName:   GetFullSnapshotLeaseName(etcd),
+		ClusterRestoreLeaseName: GetClusterRestoreLeaseName(etcd),
+		Replicas:                etcd.Spec.Replicas,
 	}
 }
 
@@ -40,4 +41,9 @@ func GetDeltaSnapshotLeaseName(etcd *druidv1alpha1.Etcd) string {
 // GetFullSnapshotLeaseName returns the name of the full snapshot lease based on the given `etcd` object.
 func GetFullSnapshotLeaseName(etcd *druidv1alpha1.Etcd) string {
 	return fmt.Sprintf("%s-full-snap", etcd.Name)
+}
+
+// GetClusterRestoreLeaseName returns the name of the cluster restore indicator lease based on the given `etcd` object.
+func GetClusterRestoreLeaseName(etcd *druidv1alpha1.Etcd) string {
+	return fmt.Sprintf("%s-restoration-indicator", etcd.Name)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO

**What this PR does / why we need it**:
The druid controller now creates a lease that will indicate whether a multinode ETCD cluster is restored from backup bucket or not. This lease is not used for single node ETCD cluster.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
