### PR TITLE
fix deployment issue of etcd druid

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,8 +2,8 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-  - bases/druid.gardener.cloud_etcds.yaml
-  - based/druid.gardener.cloud_etcdcopybackupstasks.yaml
+  - bases/10-crd-druid.gardener.cloud_etcds.yaml
+  - bases/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         # Change the value of image field below to your controller image URL
-        - image: eu.gcr.io/gardener-project/gardener/etcd-druid:v0.7.0-dev
+        - image: eu.gcr.io/gardener-project/gardener/etcd-druid:v0.9.0
           name: druid

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - command:
-            - /bin/druid
+            - /bin/etcd-druid
           args:
             - --enable-leader-election
           name: druid

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,69 +7,151 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - batch
+  - ""
   resources:
-  - jobs
+  - pods
   verbs:
-  - create
+  - list
+  - watch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - endpoints
+  verbs:
   - get
   - list
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  - apps
+  resources:
+  - services
+  - configmaps
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - etcds
+  - etcdcopybackupstasks
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - etcds/status
+  - etcds/finalizers
+  - etcdcopybackupstasks/status
+  - etcdcopybackupstasks/finalizers
+  verbs:
+  - get
+  - update
+  - patch
+  - create
 - apiGroups:
   - coordination.k8s.io
   resources:
   - leases
   verbs:
+  - get
+  - list
+  - watch
   - create
+  - update
+  - patch
   - delete
   - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
-  - druid.gardener.cloud
+  - ""
   resources:
-  - etcds
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - druid.gardener.cloud
-  resources:
-  - etcds/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - druid.gardener.cloud
-  resources:
-  - secrets
+  - persistentvolumeclaims
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/samples/druid_v1alpha1_etcd.yaml
+++ b/config/samples/druid_v1alpha1_etcd.yaml
@@ -64,7 +64,13 @@ spec:
     autoCompactionRetention: "30m"
   schedulingConstraints:
     affinity: {}
-    topologySpreadConstraints: []
+    topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: etcd-statefulset
 
   replicas: 1
 # priorityClassName: foo


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
Fix issue that the etcd-druid-controller can't be deployed from the kustomize files which are located in /config folder.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
