### PR TITLE
Disable member lease update

### DIFF
--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -211,7 +211,7 @@ spec:
         - --snapstore-temp-directory={{ .Values.backup.snapstoreTempDir }}
         - --etcd-process-name=etcd
 {{- if .Values.etcd.heartbeatDuration }}
-        - --enable-member-lease-renewal=true
+        - --enable-member-lease-renewal=false
         - --k8s-heartbeat-duration={{ .Values.etcd.heartbeatDuration }}
 {{- end }}
 {{- if .Values.backup.leaderElection }}

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -1059,7 +1059,7 @@ func validateEtcdWithDefaults(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSe
 								"--etcd-connection-timeout=5m":                   Equal("--etcd-connection-timeout=5m"),
 								"--snapstore-temp-directory=/var/etcd/data/temp": Equal("--snapstore-temp-directory=/var/etcd/data/temp"),
 								"--etcd-process-name=etcd":                       Equal("--etcd-process-name=etcd"),
-								"--enable-member-lease-renewal=true":             Equal("--enable-member-lease-renewal=true"),
+								"--enable-member-lease-renewal=false":            Equal("--enable-member-lease-renewal=false"),
 								"--k8s-heartbeat-duration=10s":                   Equal("--k8s-heartbeat-duration=10s"),
 
 								fmt.Sprintf("--delta-snapshot-memory-limit=%d", deltaSnapShotMemLimit.Value()):                 Equal(fmt.Sprintf("--delta-snapshot-memory-limit=%d", deltaSnapShotMemLimit.Value())),
@@ -1446,7 +1446,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								"--etcd-process-name=etcd":                       Equal("--etcd-process-name=etcd"),
 								"--etcd-connection-timeout=5m":                   Equal("--etcd-connection-timeout=5m"),
 								"--enable-snapshot-lease-renewal=true":           Equal("--enable-snapshot-lease-renewal=true"),
-								"--enable-member-lease-renewal=true":             Equal("--enable-member-lease-renewal=true"),
+								"--enable-member-lease-renewal=false":            Equal("--enable-member-lease-renewal=false"),
 								"--k8s-heartbeat-duration=10s":                   Equal("--k8s-heartbeat-duration=10s"),
 								fmt.Sprintf("--defragmentation-schedule=%s", *instance.Spec.Etcd.DefragmentationSchedule):                           Equal(fmt.Sprintf("--defragmentation-schedule=%s", *instance.Spec.Etcd.DefragmentationSchedule)),
 								fmt.Sprintf("--schedule=%s", *instance.Spec.Backup.FullSnapshotSchedule):                                            Equal(fmt.Sprintf("--schedule=%s", *instance.Spec.Backup.FullSnapshotSchedule)),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO

**What this PR does / why we need it**:
cherry pick [`8673df`](https://github.com/gardener/etcd-druid/pull/331/commits/8673df298e74a8bdfc063b8236e611e0b697587f) and [`9720c6`](https://github.com/gardener/etcd-druid/pull/331/commits/9720c6ff1ee0b1488b58e9ce964bc4a5f1aecbfe)

This PR disables member lease update due to pending investigation of [issues/320](https://github.com/gardener/etcd-druid/issues/320). 
There is a bug where the member lease is intermittently deleted which results in polluted logs in etcd-backup-restore with `lease not found` warnings

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
