### PR TITLE
Fix etcd resource limits for existing clusters

### DIFF
--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -629,7 +629,8 @@ func (r *EtcdReconciler) syncStatefulSetSpec(ctx context.Context, logger logr.Lo
 		if !ok {
 			return nil, fmt.Errorf("container with name %s could not be fetched from statefulset %s", c.Name, decoded.Name)
 		}
-		decoded.Spec.Template.Spec.Containers[i].Resources = container.Resources
+		// only copy requested resources from the existing stateful set to avoid copying already removed (from the etcd resource) resource limits
+		decoded.Spec.Template.Spec.Containers[i].Resources.Requests = container.Resources.Requests
 	}
 
 	ssCopy.Spec.Template = decoded.Spec.Template


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug

**What this PR does / why we need it**:

Makes sure that only that the resource limits of an existing etcd stateful set are not re-used when reconciling the etcd resource.
This makes sure that if the etcd resource specifies no resource limits, that etcd-druid does not add resource limits because the existing etcd statefulset has limits.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Do not re-used resource limits from an existing etcd  stateful set. This will cause a RESTART(!) of the etcd pod for existing clusters that currently have a resource limit set for the etcd stateful-set, but whose etcd resource does not specify a resource limit.
```
