### PR TITLE
Add etcd object labels to configmap

### DIFF
--- a/pkg/component/etcd/configmap/configmap.go
+++ b/pkg/component/etcd/configmap/configmap.go
@@ -229,6 +229,9 @@ func (c *component) emptyConfigmap(name string) *corev1.ConfigMap {
 
 func getObjectMeta(val *Values) metav1.ObjectMeta {
 	labels := map[string]string{"name": "etcd", "instance": val.EtcdName}
+	for key, value := range val.Labels {
+		labels[key] = value
+	}
 	return metav1.ObjectMeta{
 		Name:      val.ConfigMapName,
 		Namespace: val.EtcdNameSpace,

--- a/pkg/component/etcd/configmap/values.go
+++ b/pkg/component/etcd/configmap/values.go
@@ -59,4 +59,6 @@ type Values struct {
 	ConfigMapName string
 	// ConfigMapChecksum is the checksum of deployed configmap
 	ConfigMapChecksum string
+	// Labels is the labels from the etcd object spec
+	Labels map[string]string
 }

--- a/pkg/component/etcd/configmap/values_helper.go
+++ b/pkg/component/etcd/configmap/values_helper.go
@@ -43,6 +43,7 @@ func GenerateValues(etcd *druidv1alpha1.Etcd) *Values {
 		AutoCompactionMode:      etcd.Spec.Common.AutoCompactionMode,
 		AutoCompactionRetention: etcd.Spec.Common.AutoCompactionRetention,
 		ConfigMapName:           utils.GetConfigmapName(etcd),
+		Labels:                  etcd.Spec.Labels,
 	}
 	return values
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
Fixes a bug where etcd object labels are not added to the configmap
This is required in the event of a rollback to a previous `etcd-druid` version. In the current implementation, `conigmap` is created with 2 standard labels using the component concept. However in the event of a rollback to a previous `etcd-druid` version, the `claimConfigmap` func returns no matching cm found as it tries to list based on the etcd object labels. `etcd-druid` then assumes that the `configmap` does not exist and tries to create a new `configmap` which then fails (with the error shown below) as the `configmap` actually exists.
This can lead to a scenario where etcd reconciliation gets stuck

```
2022-05-06T19:33:36.023+0530	ERROR	controller.etcd	Reconciler error	{"reconciler group": "druid.gardener.cloud", "reconciler kind": "Etcd", "name": "etcd-main", "namespace": "default", "error": "configmaps \"etcd-bootstrap-cd7e2b\" already exists"}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
