### PR TITLE
Upgrade etcd-backup-restore:v0.15.2->v0.15.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.15.2"
+  tag: "v0.15.3"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade etcd-backup-restore from v0.15.2 to v0.15.3

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator github.com/gardener/etcd-backup-restore #476 @plkokanov 
Fixed retrieval of credentials during copy operation for backups stored in Swift snapstore.
```