### PR TITLE
component:github.com/gardener/etcd-backup-restore:v0.15.3->v0.15.4

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.15.3"
+  tag: "v0.15.4"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade etcd-backup-restore from v0.15.3 to v0.15.4

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator github.com/gardener/etcd-backup-restore #478 @plkokanov 
When the owner check fails, `etcd-backup-restore` will restart the `etcd` process right before attempting to take a final snapshot, if the owner check was previously successful.
```
