### PR TITLE
Enable the member-lease renewal.

### DIFF
--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -233,7 +233,7 @@ spec:
         - --snapstore-temp-directory={{ .Values.backup.snapstoreTempDir }}
         - --etcd-process-name=etcd
 {{- if .Values.etcd.heartbeatDuration }}
-        - --enable-member-lease-renewal=false
+        - --enable-member-lease-renewal=true
         - --k8s-heartbeat-duration={{ .Values.etcd.heartbeatDuration }}
 {{- end }}
 {{- if .Values.backup.leaderElection }}

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -1202,7 +1202,7 @@ func validateEtcdWithDefaults(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSe
 								"--etcd-connection-timeout=5m":                   Equal("--etcd-connection-timeout=5m"),
 								"--snapstore-temp-directory=/var/etcd/data/temp": Equal("--snapstore-temp-directory=/var/etcd/data/temp"),
 								"--etcd-process-name=etcd":                       Equal("--etcd-process-name=etcd"),
-								"--enable-member-lease-renewal=false":            Equal("--enable-member-lease-renewal=false"),
+								"--enable-member-lease-renewal=true":             Equal("--enable-member-lease-renewal=true"),
 								"--k8s-heartbeat-duration=10s":                   Equal("--k8s-heartbeat-duration=10s"),
 
 								fmt.Sprintf("--delta-snapshot-memory-limit=%d", deltaSnapShotMemLimit.Value()):                 Equal(fmt.Sprintf("--delta-snapshot-memory-limit=%d", deltaSnapShotMemLimit.Value())),
@@ -1617,7 +1617,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								"--etcd-process-name=etcd":                                                                                          Equal("--etcd-process-name=etcd"),
 								"--etcd-connection-timeout=5m":                                                                                      Equal("--etcd-connection-timeout=5m"),
 								"--enable-snapshot-lease-renewal=true":                                                                              Equal("--enable-snapshot-lease-renewal=true"),
-								"--enable-member-lease-renewal=false":                                                                               Equal("--enable-member-lease-renewal=false"),
+								"--enable-member-lease-renewal=true":                                                                                Equal("--enable-member-lease-renewal=true"),
 								"--k8s-heartbeat-duration=10s":                                                                                      Equal("--k8s-heartbeat-duration=10s"),
 								fmt.Sprintf("--defragmentation-schedule=%s", *instance.Spec.Etcd.DefragmentationSchedule):                           Equal(fmt.Sprintf("--defragmentation-schedule=%s", *instance.Spec.Etcd.DefragmentationSchedule)),
 								fmt.Sprintf("--schedule=%s", *instance.Spec.Backup.FullSnapshotSchedule):                                            Equal(fmt.Sprintf("--schedule=%s", *instance.Spec.Backup.FullSnapshotSchedule)),


### PR DESCRIPTION
**What this PR does / why we need it**:
Member lease renewal has been disabled in #331 due to a bug where member leases are intermittently deleted. 
This PR re-enables the member-lease renewal.

**Which issue(s) this PR fixes**:
Fixes #332 

**Special notes for your reviewer**:


**Release note**:
```other operator
NONE
```
