### PR TITLE
Fix accidental member lease deletion

### DIFF
--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -233,7 +233,7 @@ spec:
         - --snapstore-temp-directory={{ .Values.backup.snapstoreTempDir }}
         - --etcd-process-name=etcd
 {{- if .Values.etcd.heartbeatDuration }}
-        - --enable-member-lease-renewal=false
+        - --enable-member-lease-renewal=true
         - --k8s-heartbeat-duration={{ .Values.etcd.heartbeatDuration }}
 {{- end }}
 {{- if .Values.backup.leaderElection }}

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -1202,7 +1202,7 @@ func validateEtcdWithDefaults(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSe
 								"--etcd-connection-timeout=5m":                   Equal("--etcd-connection-timeout=5m"),
 								"--snapstore-temp-directory=/var/etcd/data/temp": Equal("--snapstore-temp-directory=/var/etcd/data/temp"),
 								"--etcd-process-name=etcd":                       Equal("--etcd-process-name=etcd"),
-								"--enable-member-lease-renewal=false":            Equal("--enable-member-lease-renewal=false"),
+								"--enable-member-lease-renewal=true":             Equal("--enable-member-lease-renewal=true"),
 								"--k8s-heartbeat-duration=10s":                   Equal("--k8s-heartbeat-duration=10s"),
 
 								fmt.Sprintf("--delta-snapshot-memory-limit=%d", deltaSnapShotMemLimit.Value()):                 Equal(fmt.Sprintf("--delta-snapshot-memory-limit=%d", deltaSnapShotMemLimit.Value())),
@@ -1617,7 +1617,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								"--etcd-process-name=etcd":                                                                                          Equal("--etcd-process-name=etcd"),
 								"--etcd-connection-timeout=5m":                                                                                      Equal("--etcd-connection-timeout=5m"),
 								"--enable-snapshot-lease-renewal=true":                                                                              Equal("--enable-snapshot-lease-renewal=true"),
-								"--enable-member-lease-renewal=false":                                                                               Equal("--enable-member-lease-renewal=false"),
+								"--enable-member-lease-renewal=true":                                                                                Equal("--enable-member-lease-renewal=true"),
 								"--k8s-heartbeat-duration=10s":                                                                                      Equal("--k8s-heartbeat-duration=10s"),
 								fmt.Sprintf("--defragmentation-schedule=%s", *instance.Spec.Etcd.DefragmentationSchedule):                           Equal(fmt.Sprintf("--defragmentation-schedule=%s", *instance.Spec.Etcd.DefragmentationSchedule)),
 								fmt.Sprintf("--schedule=%s", *instance.Spec.Backup.FullSnapshotSchedule):                                            Equal(fmt.Sprintf("--schedule=%s", *instance.Spec.Backup.FullSnapshotSchedule)),

--- a/pkg/component/etcd/lease/lease_member.go
+++ b/pkg/component/etcd/lease/lease_member.go
@@ -66,7 +66,7 @@ func (c *component) syncMemberLeases(ctx context.Context) error {
 	}
 
 	leaseList := &coordinationv1.LeaseList{}
-	if err := c.client.List(ctx, leaseList, client.MatchingLabels(labels)); err != nil {
+	if err := c.client.List(ctx, leaseList, client.InNamespace(c.namespace), client.MatchingLabels(labels)); err != nil {
 		return err
 	}
 

--- a/pkg/component/etcd/lease/lease_test.go
+++ b/pkg/component/etcd/lease/lease_test.go
@@ -271,7 +271,7 @@ func matchLeaseElement(leaseName, etcdName string, etcdUID types.UID) gomegatype
 }
 
 func memberLease(etcd *druidv1alpha1.Etcd, replica int, withOwnerRef bool) coordinationv1.Lease {
-	return coordinationv1.Lease{
+	lease := coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%d", etcd.Name, replica),
 			Namespace: etcd.Namespace,
@@ -279,16 +279,21 @@ func memberLease(etcd *druidv1alpha1.Etcd, replica int, withOwnerRef bool) coord
 				common.GardenerOwnedBy:           etcd.Name,
 				v1beta1constants.GardenerPurpose: "etcd-member-lease",
 			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         druidv1alpha1.GroupVersion.String(),
-					Kind:               "Etcd",
-					Name:               etcd.Name,
-					UID:                etcd.UID,
-					Controller:         pointer.Bool(true),
-					BlockOwnerDeletion: pointer.Bool(true),
-				},
-			},
 		},
 	}
+
+	if withOwnerRef {
+		lease.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         druidv1alpha1.GroupVersion.String(),
+				Kind:               "Etcd",
+				Name:               etcd.Name,
+				UID:                etcd.UID,
+				Controller:         pointer.Bool(true),
+				BlockOwnerDeletion: pointer.Bool(true),
+			},
+		}
+	}
+
+	return lease
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue with the member lease handling when leases are deleted by accident in unrelated namespaces. It also enables the member lease renewals again.

**Which issue(s) this PR fixes**:
Fixes #320
Fixes #332

**Special notes for your reviewer**:
/invite @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed that deleted member `lease` objects in all namespaces. With this release member lease renewals are enabled again.
```