### PR TITLE
Add ETCD_ENDPOINT env var

### DIFF
--- a/charts/etcd/templates/etcd-role.yaml
+++ b/charts/etcd/templates/etcd-role.yaml
@@ -27,3 +27,13 @@ rules:
   - update
   - patch
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -266,6 +266,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: ETCD_ENDPOINT
+{{- if .Values.backup.enableTLS }}
+          value: https://{{ .Values.backup.etcdEndpoint }}
+{{ else }}
+          value: http://{{ .Values.backup.etcdEndpoint }}
+{{- end }}
 {{- if eq .Values.store.storageProvider "S3" }}
         - name: "AWS_APPLICATION_CREDENTIALS"
           value: "/root/etcd-backup"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         # Change the value of image field below to your controller image URL
-        - image: eu.gcr.io/gardener-project/gardener/etcd-druid:v0.9.0
+        - image: eu.gcr.io/gardener-project/gardener/etcd-druid:v0.10.0
           name: druid

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -988,6 +988,7 @@ func (r *EtcdReconciler) getMapFromEtcd(im imagevector.ImageVector, etcd *druidv
 		"snapstoreTempDir":         "/var/etcd/data/temp",
 		"deltaSnapshotMemoryLimit": deltaSnapshotMemoryLimit,
 		"enableProfiling":          enableProfiling,
+		"etcdEndpoint":             fmt.Sprintf("%s.%s.%s:%d", utils.GetPeerServiceName(etcd), etcd.Namespace, "svc", val.Service.ServerPort),
 	}
 
 	if etcd.Spec.Backup.Resources != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area disaster-recovery

**What this PR does / why we need it**:
Etcd druid now passes an `ETCD_ENDPOINT` env var that is to be used by individual `etcd-backup-restore` pods for member manipulation operations in the multi-node story

**Which issue(s) this PR fixes**:
Fixes Partially gardener/etcd-backup-restore#488

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`ETCD_ENDPOINT` env var now passed to `etcd-backup-restore` containers
```
