### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,8 @@ RUN .ci/build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM alpine:3.12.3 AS druid
-RUN apk add --update bash \
-    && apk del curl
+FROM gcr.io/distroless/static-debian11:nonroot AS druid
 WORKDIR /
-COPY --from=builder /go/src/github.com/gardener/etcd-druid/bin/linux-amd64/etcd-druid bin/.
+COPY --from=builder /go/src/github.com/gardener/etcd-druid/bin/linux-amd64/etcd-druid /etcd-druid
 COPY charts charts
-ENTRYPOINT ["/bin/etcd-druid"]
+ENTRYPOINT ["/etcd-druid"]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source security
/kind enhancement

**What this PR does / why we need it**:
This PR changes the base image for `etcd-druid` from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The processes will now use a non root user for their execution. This will reduce the attack surface of the image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
As far as I saw there is no need to have `bash` installed in the `etcd-druid` container.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `etcd-druid` now uses `distroless` instead of `alpine` as a base image.
```
