### PR TITLE
Build Multi-Arch Images 📦

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -58,21 +58,9 @@ VERSION_FILE="$(readlink  -f "${SOURCE_PATH}/VERSION")"
 VERSION="$(cat "${VERSION_FILE}")"
 GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 
-# If no LOCAL_BUILD environment variable is set, we configure the `go build` command
-# to build for linux OS, amd64 architectures and without CGO enablement.
-if [[ -z "$LOCAL_BUILD" ]]; then
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
-    -mod vendor \
-    -a \
-    -v \
-    -o ${BINARY_PATH}/linux-amd64/etcd-druid \
-    main.go
 
-# If the LOCAL_BUILD environment variable is set, we simply run `go build`.
-else
-  GO111MODULE=on go build \
-    -mod vendor \
-    -v \
-    -o ${BINARY_PATH}/etcd-druid \
-    main.go
-fi
+CGO_ENABLED=0  GO111MODULE=on go build \
+  -mod vendor \
+  -v \
+  -o ${BINARY_PATH}/etcd-druid \
+  main.go

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -8,7 +8,10 @@ etcd-druid:
           'inject-commit-hash'
         inject_effective_version: true
       publish:
-        oci-builder: 'kaniko'
+        oci-builder: 'docker-buildx'
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           etcd-druid:
             registry: 'gcr-readwrite'

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ RUN .ci/build
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static-debian11:nonroot AS druid
 WORKDIR /
-COPY --from=builder /go/src/github.com/gardener/etcd-druid/bin/linux-amd64/etcd-druid /etcd-druid
+COPY --from=builder /go/src/github.com/gardener/etcd-druid/bin/etcd-druid /etcd-druid
 COPY charts charts
 ENTRYPOINT ["/etcd-druid"]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR lets the CI pipeline build multi-arch images including `linux/amd64` and `linux/arm64` images.

**Which issue(s) this PR fixes**:
Fixes parts of https://github.com/gardener/gardener/issues/6258

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Published docker images for Etcd-Druid are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```
