### PR TITLE
command is /etcd-druid

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - command:
-            - /bin/etcd-druid
+            - /etcd-druid
           args:
             - --enable-leader-election
           name: druid


### PR DESCRIPTION
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
kustomize uers want to directly reference the `/config/default` folder.
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

namespace: etcd-druid

resources:
  - https://github.com/gardener/etcd-druid/config/default?ref=vTAG
```

**Which issue(s) this PR fixes**:
Fixes the wrong command `/bin/etcd-druid`. Alternatively, the deployment could remove the command.
