### PR TITLE
Added a design doc for single-member restoration in multi-node cluster.

### DIFF
--- a/docs/single_member_restoration.md
+++ b/docs/single_member_restoration.md
@@ -1,4 +1,4 @@
-## Restoration of a single member in multi-node etcd deployed by etcd-druid.
+# Restoration of a single member in multi-node etcd deployed by etcd-druid.
 
 **Note**:
 - For a cluster with n members, we are proposing the solution to only single member restoration within a etcd cluster not the quorum loss scenario (when majority of members within a cluster fail).
@@ -8,9 +8,9 @@
 If a single etcd member within a multi-node etcd cluster goes down due to DB corruption/PVC corruption/Invalid data-dir then it needs to be brought back. Unlike in the single-node case, a minority member of a multi-node cluster can't be restored from the snapshots present in storage container as you can't restore from the old snapshots as it contains the metadata information of cluster which leads to **memberID mismatch** that prevents the new member from coming up as new member is getting it's metadata information from db which got restore from old snapshots.
 
 ## Solution
-- Corresponding backup-restore sidecar if detects that its corresponding etcd is down due to [data-dir corruption](https://github.com/gardener/etcd-backup-restore/blob/7d27a47f5793b0949492d225ada5fd8344b6b6a2/pkg/initializer/validator/datavalidator.go#L177) or [Invalid data-dir](https://github.com/gardener/etcd-backup-restore/blob/7d27a47f5793b0949492d225ada5fd8344b6b6a2/pkg/initializer/validator/datavalidator.go#L204)
-- Then, if it's a cluster with cluster size `>1` then backup-restore will first remove the etcd failed member using the [MemberRemove API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L45-L46) call and clean the data-dir of failed etcd member.
+- If a corresponding backup-restore sidecar detects that its corresponding etcd is down due to [data-dir corruption](https://github.com/gardener/etcd-backup-restore/blob/7d27a47f5793b0949492d225ada5fd8344b6b6a2/pkg/initializer/validator/datavalidator.go#L177) or [Invalid data-dir](https://github.com/gardener/etcd-backup-restore/blob/7d27a47f5793b0949492d225ada5fd8344b6b6a2/pkg/initializer/validator/datavalidator.go#L204)
+- Then backup-restore will first remove the failing etcd member from the cluster using the [MemberRemove API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L45-L46) call and clean the data-dir of failed etcd member.
 - It won't affect the etcd cluster as quorum is still maintained.
-- After successfully removing failed member from the cluster, backup-restore sidecar will try to add a new member in a cluster to get the same cluster size as before.
-- Backup-restore firstly adds new member as a [Learner](https://etcd.io/docs/v3.3/learning/learner/) using the [MemberAddAsLearner API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L42-L43) call, once learner was added to the cluster and it's get in sync with leader and becomes up-to-date then promote the learner to a voting member using [MemberPromote API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L51-L52) call.
+- After successfully removing failed etcd member from the cluster, backup-restore sidecar will try to add a new etcd member to a cluster to get the same cluster size as before.
+- Backup-restore firstly adds new member as a [Learner](https://etcd.io/docs/v3.3/learning/learner/) using the [MemberAddAsLearner API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L42-L43) call, once learner is added to the cluster and it's get in sync with leader and becomes up-to-date then promote the learner(non-voting member) to a voting member using [MemberPromote API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L51-L52) call.
 - So, the failed member first needs to be removed from the cluster and then added as a new member.

--- a/docs/single_member_restoration.md
+++ b/docs/single_member_restoration.md
@@ -1,0 +1,15 @@
+## Restoration of a single member in multi-node etcd-backup-restore cluster.
+
+**Note**:
+Please note here we are proposing the solution to only single member restoration within a cluster not the quorum loss scenario(when majority of members within a cluster fail).
+
+### Motivation:
+If a single etcd member within a multi-node etcd cluster goes down due to PVC corruption(invalid data-dir) then it needs to be brought back. But it can't be restore from the snapshots present in storage container as you can't restore a part of whole cluster.
+
+### Solution
+- Corresponding backup-restore sidecar if detects that its corresponding etcd is down due to [data-dir corruption](https://github.com/gardener/etcd-backup-restore/blob/7d27a47f5793b0949492d225ada5fd8344b6b6a2/pkg/initializer/validator/datavalidator.go#L177) or [Invalid data-dir](https://github.com/gardener/etcd-backup-restore/blob/7d27a47f5793b0949492d225ada5fd8344b6b6a2/pkg/initializer/validator/datavalidator.go#L204)
+- Then, if its is a cluster with cluster size>1 then backup-restore will first remove the etcd failed member using the [MemberRemove API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L45-L46) call and clean the data-dir of failed etcd member.
+- It won't affect the etcd cluster as quorum is still maintained.
+- After successfully removing failed member from the cluster, backup-restore sidecar will try to add a new member in a cluster to get the same cluster size as before.
+- Backup-restore firstly add new member as a [Learner](https://etcd.io/docs/v3.3/learning/learner/) using the [MemberAddAsLearner API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L42-L43) call, once learner added to the cluster and its get in sync with leader and becomes up-to-date then promote the learner to a voting member using [MemberPromote API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L51-L52) call.
+- So, the failed member first needs to be removed removed from the cluster and then add a new member.

--- a/docs/single_member_restoration.md
+++ b/docs/single_member_restoration.md
@@ -1,15 +1,16 @@
 ## Restoration of a single member in multi-node etcd-backup-restore cluster.
 
 **Note**:
-Please note here we are proposing the solution to only single member restoration within a cluster not the quorum loss scenario(when majority of members within a cluster fail).
+- Here we are proposing the solution to only single member restoration within a cluster not the quorum loss scenario (when majority of members within a cluster fail).
+- In this proposal we are not targetting the recovery of single member which got separated from cluster due to [network partition](https://etcd.io/docs/v3.3/op-guide/failures/#network-partition).
 
-### Motivation:
-If a single etcd member within a multi-node etcd cluster goes down due to PVC corruption(invalid data-dir) then it needs to be brought back. But it can't be restore from the snapshots present in storage container as you can't restore a part of whole cluster.
+## Motivation
+If a single etcd member within a multi-node etcd cluster goes down due to PVC corruption(invalid data-dir) then it needs to be brought back. Unlike in the single-node case, a minority member of a multi-node cluster can't be restored from the snapshots present in storage container as you can't restore a part of whole cluster.
 
-### Solution
+## Solution
 - Corresponding backup-restore sidecar if detects that its corresponding etcd is down due to [data-dir corruption](https://github.com/gardener/etcd-backup-restore/blob/7d27a47f5793b0949492d225ada5fd8344b6b6a2/pkg/initializer/validator/datavalidator.go#L177) or [Invalid data-dir](https://github.com/gardener/etcd-backup-restore/blob/7d27a47f5793b0949492d225ada5fd8344b6b6a2/pkg/initializer/validator/datavalidator.go#L204)
-- Then, if its is a cluster with cluster size>1 then backup-restore will first remove the etcd failed member using the [MemberRemove API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L45-L46) call and clean the data-dir of failed etcd member.
+- Then, if it's a cluster with cluster size `>1` then backup-restore will first remove the etcd failed member using the [MemberRemove API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L45-L46) call and clean the data-dir of failed etcd member.
 - It won't affect the etcd cluster as quorum is still maintained.
 - After successfully removing failed member from the cluster, backup-restore sidecar will try to add a new member in a cluster to get the same cluster size as before.
-- Backup-restore firstly add new member as a [Learner](https://etcd.io/docs/v3.3/learning/learner/) using the [MemberAddAsLearner API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L42-L43) call, once learner added to the cluster and its get in sync with leader and becomes up-to-date then promote the learner to a voting member using [MemberPromote API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L51-L52) call.
-- So, the failed member first needs to be removed removed from the cluster and then add a new member.
+- Backup-restore firstly adds new member as a [Learner](https://etcd.io/docs/v3.3/learning/learner/) using the [MemberAddAsLearner API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L42-L43) call, once learner was added to the cluster and it's get in sync with leader and becomes up-to-date then promote the learner to a voting member using [MemberPromote API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L51-L52) call.
+- So, the failed member first needs to be removed from the cluster and then added as a new member.

--- a/docs/single_member_restoration.md
+++ b/docs/single_member_restoration.md
@@ -1,11 +1,11 @@
-## Restoration of a single member in multi-node etcd-backup-restore cluster.
+## Restoration of a single member in multi-node etcd deployed by etcd-druid.
 
 **Note**:
-- Here we are proposing the solution to only single member restoration within a cluster not the quorum loss scenario (when majority of members within a cluster fail).
+- For a cluster with n members, we are proposing the solution to only single member restoration within a etcd cluster not the quorum loss scenario (when majority of members within a cluster fail).
 - In this proposal we are not targetting the recovery of single member which got separated from cluster due to [network partition](https://etcd.io/docs/v3.3/op-guide/failures/#network-partition).
 
 ## Motivation
-If a single etcd member within a multi-node etcd cluster goes down due to PVC corruption(invalid data-dir) then it needs to be brought back. Unlike in the single-node case, a minority member of a multi-node cluster can't be restored from the snapshots present in storage container as you can't restore a part of whole cluster.
+If a single etcd member within a multi-node etcd cluster goes down due to DB corruption/PVC corruption/Invalid data-dir then it needs to be brought back. Unlike in the single-node case, a minority member of a multi-node cluster can't be restored from the snapshots present in storage container as you can't restore from the old snapshots as it contains the metadata information of cluster which leads to **memberID mismatch** that prevents the new member from coming up as new member is getting it's metadata information from db which got restore from old snapshots.
 
 ## Solution
 - Corresponding backup-restore sidecar if detects that its corresponding etcd is down due to [data-dir corruption](https://github.com/gardener/etcd-backup-restore/blob/7d27a47f5793b0949492d225ada5fd8344b6b6a2/pkg/initializer/validator/datavalidator.go#L177) or [Invalid data-dir](https://github.com/gardener/etcd-backup-restore/blob/7d27a47f5793b0949492d225ada5fd8344b6b6a2/pkg/initializer/validator/datavalidator.go#L204)

--- a/docs/single_member_restoration.md
+++ b/docs/single_member_restoration.md
@@ -14,3 +14,10 @@ If a single etcd member within a multi-node etcd cluster goes down due to DB cor
 - After successfully removing failed etcd member from the cluster, backup-restore sidecar will try to add a new etcd member to a cluster to get the same cluster size as before.
 - Backup-restore firstly adds new member as a [Learner](https://etcd.io/docs/v3.3/learning/learner/) using the [MemberAddAsLearner API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L42-L43) call, once learner is added to the cluster and it's get in sync with leader and becomes up-to-date then promote the learner(non-voting member) to a voting member using [MemberPromote API](https://github.com/etcd-io/etcd/blob/ae9734ed278b7a1a7dfc82e800471ebbf9fce56f/clientv3/cluster.go#L51-L52) call.
 - So, the failed member first needs to be removed from the cluster and then added as a new member.
+
+### Example: 
+1. If a `3` member etcd cluster has 1 downed member(due to invalid data-dir), the cluster can still make forward progress because the quorum is `2`.
+2. Backup-restore detects this downed member and then removed the downed member from cluster.
+3. The number of members in a cluster becomes `2` and the quorum remains at `2`, so it won't affect the etcd cluster.
+4. Clean the data-dir and add a member as a learner(non-voting member).
+5. As soon as learner gets in sync with leader, promote the learner to a voting member, hence increasing number of members in a cluster back to `3`.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a design document for single-member restoration in multi-node cluster.

**Which issue(s) this PR fixes**:
Fixes #371 

**Special notes for your reviewer**:

**Release note**:
```other operator
None
```
