### PR TITLE
[CI] Release Improvements

### DIFF
--- a/.ci/bump_tag
+++ b/.ci/bump_tag
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+version=$(cat ../VERSION)
+sed -i "s/v[0-9]*.[0-9]*\.[0-9]*/${version}/g" ../config/default/manager_image_patch.yaml

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -48,6 +48,7 @@ etcd-druid:
           nextversion: 'bump_minor'
           git_tags:
           - ref_template: 'refs/tags/{VERSION}'
+          release_callback: $REPO_DIR/.ci/bump_tag
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         # Change the value of image field below to your controller image URL
-        - image: eu.gcr.io/gardener-project/gardener/etcd-druid:v0.10.0
+        - image: eu.gcr.io/gardener-project/gardener/etcd-druid:v0.11.0
           name: druid


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR adjusts the tag in `manager_image_patch.yaml` to the current release. It also adds another release step which bumps the version automatically.

**Special notes for your reviewer**:
Follow up for https://github.com/gardener/etcd-druid/pull/373.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The correct image version has been set in `config/default/manager_image_patch.yaml` to match the current release.
```
