### PR TITLE
Added pod permissions in etcd-role

### DIFF
--- a/charts/etcd/templates/etcd-role.yaml
+++ b/charts/etcd/templates/etcd-role.yaml
@@ -37,3 +37,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -953,6 +953,19 @@ func validateRole(instance *druidv1alpha1.Etcd, role *rbac.Role) {
 					"watch":  Equal("watch"),
 				}),
 			}),
+			"": MatchFields(IgnoreExtras, Fields{
+				"APIGroups": MatchAllElements(stringArrayIterator, Elements{
+					"": Equal(""),
+				}),
+				"Resources": MatchAllElements(stringArrayIterator, Elements{
+					"pods": Equal("pods"),
+				}),
+				"Verbs": MatchAllElements(stringArrayIterator, Elements{
+					"list":  Equal("list"),
+					"get":   Equal("get"),
+					"watch": Equal("watch"),
+				}),
+			}),
 		}),
 	}))
 }


### PR DESCRIPTION
* Added pod permissions in etcd-role

* Updated unit tests

* Removed unneeded pod permissions

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

**What this PR does / why we need it**:
Cherry pick [`ea9c04`](https://github.com/gardener/etcd-druid/commit/ea9c0488c59d548a58c6979e02f5c81833bc16e6) onto `hotfix-v0.11` branch

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator github.com/gardener/etcd-druid #372 @aaronfern 
Added pod permission in etcd_role that now enable `etcd-backup-restore` to get/list/watch pods
```
