### PR TITLE
[ci:component:github.com/gardener/etcd-backup-restore:v0.18.0->v0.18.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.18.0"
+  tag: "v0.18.1" 
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

**What this PR does / why we need it**:
Upgrade `etcd-backup-restore` image from `v0.18.0` to `v0.18.1`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator github.com/gardener/etcd-backup-restore #504 @aaronfern 
Fixed a bug where etcd calls related to multi node operation were used in single node operation
```
```bugfix operator github.com/gardener/etcd-backup-restore #501 @ishan16696 
Temp fix: skip the single member restoration if data-dir found to be invalid.
```
```bugfix operator github.com/gardener/etcd-backup-restore #501 @ishan16696 
Fixed a bug in Scaleup feature in func: `IsMemberInCluster()` which can cause Scaleup feature to get fail.
```
```improvement operator github.com/gardener/etcd-backup-restore #505 @ishan16696 
Assigned the correct Peer address to the Etcd after it restores from backup-bucket.
```
```improvement operator github.com/gardener/etcd-backup-restore #506 @aaronfern 
No attempt is made to update member Peer URL when trying to promote a member
```
