### PR TITLE
Added the logic for quorum loss scenario

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,151 +7,69 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-  - watch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - endpoints
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - roles
-  - rolebindings
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  - apps
-  resources:
-  - services
-  - configmaps
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-  - create
-  - delete
-- apiGroups:
   - batch
   resources:
   - jobs
   verbs:
+  - create
+  - delete
   - get
   - list
-  - watch
-  - create
-  - update
   - patch
-  - delete
-- apiGroups:
-  - batch
-  resources:
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-- apiGroups:
-  - druid.gardener.cloud
-  resources:
-  - etcds
-  - etcdcopybackupstasks
-  verbs:
-  - get
-  - list
-  - watch
-  - create
   - update
-  - patch
-  - delete
-- apiGroups:
-  - druid.gardener.cloud
-  resources:
-  - etcds/status
-  - etcds/finalizers
-  - etcdcopybackupstasks/status
-  - etcdcopybackupstasks/finalizers
-  verbs:
-  - get
-  - update
-  - patch
-  - create
+  - watch
 - apiGroups:
   - coordination.k8s.io
   resources:
   - leases
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
   - delete
   - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-  - ""
+  - druid.gardener.cloud
   resources:
-  - persistentvolumeclaims
+  - etcds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - etcds/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - secrets
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
   verbs:
+  - create
+  - delete
   - get
   - list
-  - watch
-  - create
-  - update
   - patch
-  - delete
+  - update
+  - watch

--- a/controllers/config/custodian.go
+++ b/controllers/config/custodian.go
@@ -22,6 +22,8 @@ type EtcdCustodianController struct {
 	EtcdMember EtcdMemberConfig
 	// SyncPeriod is the duration after which re-enqueuing happens.
 	SyncPeriod time.Duration
+	// EnableAutomaticQuorumLossHandling is the flag to enable automatic handling of quorum loss. Set it false by default.
+	EnableAutomaticQuorumLossHandling bool
 }
 
 type EtcdMemberConfig struct {

--- a/pkg/health/etcdmember/check_ready.go
+++ b/pkg/health/etcdmember/check_ready.go
@@ -73,7 +73,7 @@ func (r *readyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) []Resul
 		renew := lease.Spec.RenewTime
 		if renew == nil {
 			r.logger.Info("Member hasn't acquired lease yet, still in bootstrapping phase", "name", lease.Name)
-			continue
+			return []Result{}
 		}
 
 		// Check if member state must be considered as not ready

--- a/pkg/health/etcdmember/check_ready_test.go
+++ b/pkg/health/etcdmember/check_ready_test.go
@@ -389,17 +389,14 @@ var _ = Describe("ReadyCheck", func() {
 				}
 			})
 
-			It("should only contain members which acquired lease once", func() {
+			It("should not contain any member even if acquired lease once", func() {
 				defer test.WithVar(&TimeNow, func() time.Time {
 					return now
 				})()
 
 				results := check.Check(ctx, etcd)
 
-				Expect(results).To(HaveLen(1))
-				Expect(results[0].Status()).To(Equal(druidv1alpha1.EtcdMemberStatusReady))
-				Expect(results[0].ID()).To(Equal(member1ID))
-				Expect(results[0].Role()).To(gstruct.PointTo(Equal(druidv1alpha1.EtcdRoleLeader)))
+				Expect(results).To(HaveLen(0))
 			})
 		})
 	})

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -31,6 +31,10 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 )
 
+const (
+	QuorumLossAnnotation = "druid.gardener.cloud/quorum-loss"
+)
+
 func hasOperationAnnotation(obj client.Object) bool {
 	return obj.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile
 }
@@ -46,6 +50,33 @@ func HasOperationAnnotation() predicate.Predicate {
 		},
 		GenericFunc: func(event event.GenericEvent) bool {
 			return hasOperationAnnotation(event.Object)
+		},
+		DeleteFunc: func(event event.DeleteEvent) bool {
+			return true
+		},
+	}
+}
+
+func hasQuorumLossAnnotation(obj client.Object) bool {
+	etcd, ok := obj.(*druidv1alpha1.Etcd)
+	if !ok {
+		return false
+	}
+	_, ok = etcd.Annotations[QuorumLossAnnotation]
+	return ok
+}
+
+// HasQuorumLossAnnotation is a predicate for the operation annotation.
+func HasQuorumLossAnnotation() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			return hasQuorumLossAnnotation(event.Object)
+		},
+		UpdateFunc: func(event event.UpdateEvent) bool {
+			return hasQuorumLossAnnotation(event.ObjectNew)
+		},
+		GenericFunc: func(event event.GenericEvent) bool {
+			return hasQuorumLossAnnotation(event.Object)
 		},
 		DeleteFunc: func(event event.DeleteEvent) bool {
 			return true

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -31,6 +31,7 @@ import (
 const (
 	// LocalProviderDefaultMountPath is the default path where the buckets directory is mounted.
 	LocalProviderDefaultMountPath = "/etc/gardener/local-backupbuckets"
+	BootstrapAnnotation           = "druid.gardener.cloud/bootstrap"
 	// EtcdBackupSecretHostPath is the hostPath field in the etcd-backup secret.
 	EtcdBackupSecretHostPath = "hostPath"
 )


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR restores a multinode ETCD cluster after the quorum is lost. The steps are like following:
1. There is already provision for Health check of cluster in ETCD Druid code base. The health check is based on Member Lease renewal time. It also deduct the quorum loss case. This health check is used by Druid
2. Druid custodion controller monitors the cluster health at a regular interval
3. If quorum loss is detected, custodion controller will put an annotation on ETCD CR to indicate that ETCD controller needs to fix quorum loss.
4. ETCD controller scales down the ETCD statefulset to 0 and delete the PVCs
5. ETCD controller deploys the statefulset with replicas = 1
6. ETCD controller scales up the statefulset equal to the replicas mentioned in ETCD CR. ETCD scale up mechanism in ETCD BR makes sure that the first instance of the StatefulSet is up and then the rests are added.
**Which issue(s) this PR fixes**:
Fixes #362 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer 
1. A new annotation `gardener.cloud/quorum-loss=true` is used on ETCD CR to indicate the quorum loss happened in the ETCD multi node cluster. If there is no quorum loss, either `gardener.cloud/quorum-loss=false` is set or the annotation is not set at all.
```
```feature operator
1. ETCD multinode cluster can recover now during quorum loss case. If quorum is lost for multinode cluster and the lost nodes can't be scheduled for some period, then during that period, a temporary one node ETCD cluster will serve the requests and when the new nodes can be scheduled again, rest of the nodes will join the cluster without any manual intervention.
```
