### PR TITLE
Clarify `etcd.status.ready` field

### DIFF
--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -417,7 +417,7 @@ type EtcdStatus struct {
 	// ReadyReplicas is the count of replicas being ready in the etcd cluster.
 	// +optional
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
-	// Ready represents the readiness of the etcd resource.
+	// Ready is `true` if all etcd replicas are ready.
 	// +optional
 	Ready *bool `json:"ready,omitempty"`
 	// UpdatedReplicas is the count of updated replicas in the etcd cluster.

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -1689,7 +1689,7 @@ spec:
                 format: int64
                 type: integer
               ready:
-                description: Ready represents the readiness of the etcd resource.
+                description: Ready is `true` if all etcd replicas are ready.
                 type: boolean
               readyReplicas:
                 description: ReadyReplicas is the count of replicas being ready in


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR defines the meaning of `etcd.status.ready` more precisely. Earlier, when Etcd-Druid could only handle single-node etcds the meaning and implementation clearer because with only one replica the cluster was either ready or not ready but evaluating this count.

This semantic changed with multi-node (cluster is ready as long as quorum is maintained) which is at the same time rather covered by a dedicated condition (`type: Ready`). Thus, the `etcd.status.ready` field  became quite ambiguous. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The definition of the `etcd.status.ready` field was defined more precisely due to changed semantics of multi-node etcd clusters. `etcd.status.ready` is `true` whenever all underlying etcd replicas are ready. Please note, that the implementation for this check was not changed.
```
