### PR TITLE
Add missing service-endpoints to sts component

### DIFF
--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -72,7 +72,7 @@ func (c *component) Deploy(ctx context.Context) error {
 		sts = c.emptyStatefulset()
 	}
 
-	if sts.Generation > 1 && sts.Spec.ServiceName != c.values.ServiceName {
+	if sts.Generation > 1 && sts.Spec.ServiceName != c.values.PeerServiceName {
 		// Earlier clusters referred to the client service in `sts.Spec.ServiceName` which must be changed
 		// when a multi-node cluster is used, see https://github.com/gardener/etcd-druid/pull/293.
 		if clusterScaledUpToMultiNode(c.values) {
@@ -170,7 +170,7 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,
 		},
 		Replicas:    pointer.Int32(c.values.Replicas),
-		ServiceName: c.values.ServiceName,
+		ServiceName: c.values.PeerServiceName,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: getCommonLabels(&c.values),
 		},

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -552,6 +552,7 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 								fmt.Sprintf("--delta-snapshot-memory-limit=%d", values.DeltaSnapshotMemoryLimit.Value()):              Equal(fmt.Sprintf("--delta-snapshot-memory-limit=%d", values.DeltaSnapshotMemoryLimit.Value())),
 								fmt.Sprintf("--garbage-collection-policy=%s", *values.GarbageCollectionPolicy):                        Equal(fmt.Sprintf("--garbage-collection-policy=%s", *values.GarbageCollectionPolicy)),
 								fmt.Sprintf("--endpoints=https://%s-local:%d", values.Name, clientPort):                               Equal(fmt.Sprintf("--endpoints=https://%s-local:%d", values.Name, clientPort)),
+								fmt.Sprintf("--service-endpoints=https://%s:%d", values.ClientServiceName, clientPort):                Equal(fmt.Sprintf("--service-endpoints=https://%s:%d", values.ClientServiceName, clientPort)),
 								fmt.Sprintf("--embedded-etcd-quota-bytes=%d", int64(values.Quota.Value())):                            Equal(fmt.Sprintf("--embedded-etcd-quota-bytes=%d", int64(values.Quota.Value()))),
 								fmt.Sprintf("%s=%s", "--delta-snapshot-period", values.DeltaSnapshotPeriod.Duration.String()):         Equal(fmt.Sprintf("%s=%s", "--delta-snapshot-period", values.DeltaSnapshotPeriod.Duration.String())),
 								fmt.Sprintf("%s=%s", "--garbage-collection-period", values.GarbageCollectionPeriod.Duration.String()): Equal(fmt.Sprintf("%s=%s", "--garbage-collection-period", values.GarbageCollectionPeriod.Duration.String())),

--- a/pkg/component/etcd/statefulset/values.go
+++ b/pkg/component/etcd/statefulset/values.go
@@ -47,8 +47,6 @@ type Values struct {
 	EtcdImage string
 	// PriorityClassName is the Priority Class name.
 	PriorityClassName *string
-	// ServiceName is the name of the peer service.
-	ServiceName string
 	// ServiceAccountName is the service account name.
 	ServiceAccountName        string
 	Affinity                  *corev1.Affinity

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -64,7 +64,6 @@ func GenerateValues(
 		EtcdImage:                 etcdImage,
 		BackupImage:               backupImage,
 		PriorityClassName:         etcd.Spec.PriorityClassName,
-		ServiceName:               utils.GetPeerServiceName(etcd),
 		ServiceAccountName:        utils.GetServiceAccountName(etcd),
 		Affinity:                  etcd.Spec.SchedulingConstraints.Affinity,
 		TopologySpreadConstraints: etcd.Spec.SchedulingConstraints.TopologySpreadConstraints,
@@ -255,10 +254,13 @@ func getBackupRestoreCommand(val Values) []string {
 		command = append(command, "--insecure-transport=false")
 		command = append(command, "--insecure-skip-tls-verify=false")
 		command = append(command, fmt.Sprintf("--endpoints=https://%s-local:%d", val.Name, pointer.Int32Deref(val.ClientPort, defaultClientPort)))
+		command = append(command, fmt.Sprintf("--service-endpoints=https://%s:%d", val.ClientServiceName, pointer.Int32Deref(val.ClientPort, defaultClientPort)))
 	} else {
 		command = append(command, "--insecure-transport=true")
 		command = append(command, "--insecure-skip-tls-verify=true")
 		command = append(command, fmt.Sprintf("--endpoints=http://%s-local:%d", val.Name, pointer.Int32Deref(val.ClientPort, defaultClientPort)))
+		command = append(command, fmt.Sprintf("--service-endpoints=http://%s:%d", val.ClientServiceName, pointer.Int32Deref(val.ClientPort, defaultClientPort)))
+
 	}
 
 	if val.BackupTLS != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR is equivalent to https://github.com/gardener/etcd-druid/pull/388 but for  `pkg/component/etcd/statefulset` since the `etcd-statefulset.yaml` has been removed.

**Special notes for your reviewer**:
/invite @aaronfern

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
