### PR TITLE
Fix liveness and readiness probes

### DIFF
--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -993,6 +993,7 @@ func validateEtcdWithDefaults(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSe
 								}),
 								"InitialDelaySeconds": Equal(int32(15)),
 								"PeriodSeconds":       Equal(int32(5)),
+								"FailureThreshold":    Equal(int32(5)),
 							})),
 							"LivenessProbe": PointTo(MatchFields(IgnoreExtras, Fields{
 								"Handler": MatchFields(IgnoreExtras, Fields{
@@ -1006,6 +1007,20 @@ func validateEtcdWithDefaults(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSe
 								}),
 								"InitialDelaySeconds": Equal(int32(15)),
 								"PeriodSeconds":       Equal(int32(5)),
+								"FailureThreshold":    Equal(int32(5)),
+							})),
+							"StartupProbe": PointTo(MatchFields(IgnoreExtras, Fields{
+								"Handler": MatchFields(IgnoreExtras, Fields{
+									"Exec": PointTo(MatchFields(IgnoreExtras, Fields{
+										"Command": MatchAllElements(cmdIterator, Elements{
+											"/bin/sh": Equal("/bin/sh"),
+											"-ec":     Equal("-ec"),
+											fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=http://%s-local:%d get foo --consistency=s", instance.Name, clientPort): Equal(fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=http://%s-local:%d get foo --consistency=s", instance.Name, clientPort)),
+										}),
+									})),
+								}),
+								"PeriodSeconds":    Equal(int32(5)),
+								"FailureThreshold": Equal(int32(24)),
 							})),
 							"VolumeMounts": MatchAllElements(volumeMountIterator, Elements{
 								instance.Name: MatchFields(IgnoreExtras, Fields{
@@ -1364,6 +1379,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								}),
 								"InitialDelaySeconds": Equal(int32(15)),
 								"PeriodSeconds":       Equal(int32(5)),
+								"FailureThreshold":    Equal(int32(5)),
 							})),
 							"LivenessProbe": PointTo(MatchFields(IgnoreExtras, Fields{
 								"Handler": MatchFields(IgnoreExtras, Fields{
@@ -1377,6 +1393,20 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								}),
 								"InitialDelaySeconds": Equal(int32(15)),
 								"PeriodSeconds":       Equal(int32(5)),
+								"FailureThreshold":    Equal(int32(5)),
+							})),
+							"StartupProbe": PointTo(MatchFields(IgnoreExtras, Fields{
+								"Handler": MatchFields(IgnoreExtras, Fields{
+									"Exec": PointTo(MatchFields(IgnoreExtras, Fields{
+										"Command": MatchAllElements(cmdIterator, Elements{
+											"/bin/sh": Equal("/bin/sh"),
+											"-ec":     Equal("-ec"),
+											fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", instance.Name, clientPort): Equal(fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", instance.Name, clientPort)),
+										}),
+									})),
+								}),
+								"PeriodSeconds":    Equal(int32(5)),
+								"FailureThreshold": Equal(int32(24)),
 							})),
 							"VolumeMounts": MatchAllElements(volumeMountIterator, Elements{
 								*instance.Spec.VolumeClaimTemplate: MatchFields(IgnoreExtras, Fields{

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -26,8 +26,15 @@ if ! command -v setup-envtest &> /dev/null ; then
   exit 1
 fi
 
+ARCH=
+# if using M1 macbook, use amd64 architecture build, as suggested in
+# https://github.com/kubernetes-sigs/controller-runtime/issues/1657#issuecomment-988484517
+if [[ $(uname) == 'Darwin' && $(uname -m) == 'arm64' ]]; then
+  ARCH='--arch=amd64'
+fi
+
 # --use-env allows overwriting the envtest tools path via the KUBEBUILDER_ASSETS env var just like it was before
-export KUBEBUILDER_ASSETS="$(setup-envtest use --use-env -p path ${ENVTEST_K8S_VERSION})"
+export KUBEBUILDER_ASSETS="$(setup-envtest ${ARCH} use --use-env -p path ${ENVTEST_K8S_VERSION})"
 echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
 
 echo "> Tests"

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -211,6 +211,15 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 							PeriodSeconds:       5,
 							FailureThreshold:    5,
 						},
+						StartupProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								Exec: &corev1.ExecAction{
+									Command: c.values.LivenessProbeCommand,
+								},
+							},
+							PeriodSeconds:    5,
+							FailureThreshold: 24,
+						},
 						Ports:        getEtcdPorts(c.values),
 						Resources:    getEtcdResources(c.values),
 						Env:          getEtcdEnvVars(c.values),

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -204,7 +204,7 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 						LivenessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								Exec: &corev1.ExecAction{
-									Command: c.values.LivenessProbCommand,
+									Command: c.values.LivenessProbeCommand,
 								},
 							},
 							InitialDelaySeconds: 15,

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -31,10 +31,10 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -174,13 +174,13 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 		Selector: &metav1.LabelSelector{
 			MatchLabels: getCommonLabels(&c.values),
 		},
-		Template: v1.PodTemplateSpec{
+		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: c.values.Annotations,
 				Labels:      sts.GetLabels(),
 			},
-			Spec: v1.PodSpec{
-				HostAliases: []v1.HostAlias{
+			Spec: corev1.PodSpec{
+				HostAliases: []corev1.HostAlias{
 					{
 						IP:        "127.0.0.1",
 						Hostnames: []string{c.values.Name + "-local"},
@@ -189,25 +189,21 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 				ServiceAccountName:        c.values.ServiceAccountName,
 				Affinity:                  c.values.Affinity,
 				TopologySpreadConstraints: c.values.TopologySpreadConstraints,
-				Containers: []v1.Container{
+				Containers: []corev1.Container{
 					{
 						Name:            "etcd",
 						Image:           c.values.EtcdImage,
-						ImagePullPolicy: v1.PullIfNotPresent,
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						Command:         c.values.EtcdCommand,
-						ReadinessProbe: &v1.Probe{
-							Handler: v1.Handler{
-								Exec: &v1.ExecAction{
-									Command: c.values.ReadinessProbeCommand,
-								},
-							},
+						ReadinessProbe: &corev1.Probe{
+							Handler:             getReadinessHandler(c.values),
 							InitialDelaySeconds: 15,
 							PeriodSeconds:       5,
 							FailureThreshold:    5,
 						},
-						LivenessProbe: &v1.Probe{
-							Handler: v1.Handler{
-								Exec: &v1.ExecAction{
+						LivenessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								Exec: &corev1.ExecAction{
 									Command: c.values.LivenessProbCommand,
 								},
 							},
@@ -223,15 +219,15 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 					{
 						Name:            "backup-restore",
 						Image:           c.values.BackupImage,
-						ImagePullPolicy: v1.PullIfNotPresent,
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						Command:         c.values.EtcdBackupCommand,
 						Ports:           getBackupPorts(c.values),
 						Resources:       getBackupResources(c.values),
 						Env:             getBackupRestoreEnvVars(c.values),
 						VolumeMounts:    getBackupRestoreVolumeMounts(c.values),
-						SecurityContext: &v1.SecurityContext{
-							Capabilities: &v1.Capabilities{
-								Add: []v1.Capability{
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{
 									"SYS_PTRACE",
 								},
 							},
@@ -242,14 +238,14 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 				Volumes:               getVolumes(c.values),
 			},
 		},
-		VolumeClaimTemplates: []v1.PersistentVolumeClaim{
+		VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: c.values.VolumeClaimTemplateName,
 				},
-				Spec: v1.PersistentVolumeClaimSpec{
-					AccessModes: []v1.PersistentVolumeAccessMode{
-						v1.ReadWriteOnce,
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
 					},
 					StorageClassName: c.values.StorageClass,
 					Resources:        getStorageReq(c.values),
@@ -710,6 +706,38 @@ func getEnvVarFromSecrets(name, secretName, secretKey string) corev1.EnvVar {
 				},
 				Key: secretKey,
 			},
+		},
+	}
+}
+
+func getReadinessHandler(val Values) corev1.Handler {
+	if val.Replicas > 1 {
+		// TODO(timuthy): Special handling for multi-node etcd can be removed as soon as
+		// etcd-backup-restore supports `/healthz` for etcd followers, see https://github.com/gardener/etcd-backup-restore/pull/491.
+		return getReadinessHandlerForMultiNode(val)
+	}
+	return getReadinessHandlerForSingleNode(val)
+}
+
+func getReadinessHandlerForSingleNode(val Values) corev1.Handler {
+	scheme := corev1.URISchemeHTTPS
+	if val.BackupTLS == nil {
+		scheme = corev1.URISchemeHTTP
+	}
+
+	return corev1.Handler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path:   "/healthz",
+			Port:   intstr.FromInt(int(pointer.Int32Deref(val.BackupPort, defaultBackupPort))),
+			Scheme: scheme,
+		},
+	}
+}
+
+func getReadinessHandlerForMultiNode(val Values) corev1.Handler {
+	return corev1.Handler{
+		Exec: &corev1.ExecAction{
+			Command: val.ReadinessProbeCommand,
 		},
 	}
 }

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -458,6 +458,7 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 								"Handler":             getReadinessHandler(values),
 								"InitialDelaySeconds": Equal(int32(15)),
 								"PeriodSeconds":       Equal(int32(5)),
+								"FailureThreshold":    Equal(int32(5)),
 							})),
 							"LivenessProbe": PointTo(MatchFields(IgnoreExtras, Fields{
 								"Handler": MatchFields(IgnoreExtras, Fields{
@@ -471,6 +472,20 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 								}),
 								"InitialDelaySeconds": Equal(int32(15)),
 								"PeriodSeconds":       Equal(int32(5)),
+								"FailureThreshold":    Equal(int32(5)),
+							})),
+							"StartupProbe": PointTo(MatchFields(IgnoreExtras, Fields{
+								"Handler": MatchFields(IgnoreExtras, Fields{
+									"Exec": PointTo(MatchFields(IgnoreExtras, Fields{
+										"Command": MatchAllElements(cmdIterator, Elements{
+											"/bin/sh": Equal("/bin/sh"),
+											"-ec":     Equal("-ec"),
+											fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", values.Name, clientPort): Equal(fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", values.Name, clientPort)),
+										}),
+									})),
+								}),
+								"PeriodSeconds":    Equal(int32(5)),
+								"FailureThreshold": Equal(int32(24)),
 							})),
 							"Resources": Equal(etcdResources),
 							"VolumeMounts": MatchAllElements(volumeMountIterator, Elements{

--- a/pkg/component/etcd/statefulset/values.go
+++ b/pkg/component/etcd/statefulset/values.go
@@ -57,7 +57,7 @@ type Values struct {
 
 	EtcdCommand           []string
 	ReadinessProbeCommand []string
-	LivenessProbCommand   []string
+	LivenessProbeCommand  []string
 	EtcdBackupCommand     []string
 
 	EnableClientTLS string

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -128,7 +128,7 @@ func GenerateValues(
 	// Use serializability for liveness probe because we are only interested in the health of this particular member.
 	// Those read requests will especially succeed if quorum is lost. Usually it doesn't make sense to also restart
 	// members which are healthy in general, independent of the quorum situation.
-	values.LivenessProbCommand = getProbeCommand(values, serializable)
+	values.LivenessProbeCommand = getProbeCommand(values, serializable)
 
 	values.EtcdBackupCommand = getBackupRestoreCommand(values)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR fixes several issues for the currently used `liveness` and `readiness` checks and also adds a `startup` probe for single- and multi-node etcds.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Issue with current liveness probe:

* When passing multiple arguments to `/bin/sh -ec` then only the first argument is considered, i.e. `/bin/sh -ec ETCDCTL_API=3` is always successful.

```
            - /bin/sh
            - -ec
            - ETCDCTL_API=3
            - etcdctl
            - --cert=/var/etcd/ssl/client/client/tls.crt
            - --key=/var/etcd/ssl/client/client/tls.key
            - --cacert=/var/etcd/ssl/client/ca/ca.crt
            - --endpoints=https://etcd-aws-local:2379/
            - get
            - foo
            - --consistency=s
```

Issue with current readiness probe:

* The `exec` command did not evaluate the return code of the HTTP response and thus the container was considered `ready` even though the `/health(z)` endpoint returned `!= 200`.

```
            - /usr/bin/curl
            - --cert
            - /var/etcd/ssl/client/client/tls.crt
            - --key
            - /var/etcd/ssl/client/client/tls.key
            - --cacert
            - /var/etcd/ssl/client/ca/ca.crt
            - https://etcd-aws-local:8080/healthz
```

For single-node it's possible to switch to an [http probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes) to solve the explained issue.

For multi-node it's necessary to use an [exec probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes) because the `/health` endpoint of `etcd` is protected by mutual TLS (also see https://github.com/etcd-io/etcd/pull/12370) and providing a client cert is not supported via Kubernetes http probes.

The new liveness probe is now accurate, but still fails after few seconds due to the backup sidecar requiring a long time to promote its etcd member from learner. This leads to the etcd container being restarted, and the backup sidecar's initialization fails, and begins another initialization when the etcd container comes back up. This cycle continues, and the etcd pods never become ready. This problem is solved by using a startup probe of 2 minutes to allow the initialization to complete without interruptions due to etcd container restarts.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed that caused the `liveness` and `readiness` probes of `etcd` to always succeed even though an error was reported. This prevented defective etcd pods from being restarted automatically and caused unready candidates being considered as ready to serve traffic via the `etcd service`.
```
```bugfix operator
A `startup` probe has been added to `etcd` to allow 2 minutes of initialization time before checking for etcd liveness.
```
```feature developer
Add support for running envtest on M1 Macbooks.
```