### PR TITLE
Fix storage class in statefulset

### DIFF
--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -256,11 +256,13 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 					AccessModes: []corev1.PersistentVolumeAccessMode{
 						corev1.ReadWriteOnce,
 					},
-					StorageClassName: c.values.StorageClass,
-					Resources:        getStorageReq(c.values),
+					Resources: getStorageReq(c.values),
 				},
 			},
 		},
+	}
+	if c.values.StorageClass != nil && *c.values.StorageClass != "" {
+		sts.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = c.values.StorageClass
 	}
 	if c.values.PriorityClassName != nil {
 		sts.Spec.Template.Spec.PriorityClassName = *c.values.PriorityClassName


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue with populating `storageClassName` for the `volumeClaimTemplate` in the etcd statefulset. It adds an extra layer of validation for storageClass value to ensure that if it is unset or empty, it should remain unset in the statefulset spec, rather than being set to empty string `""`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Co-author: @aaronfern 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix statefulset volumeClaimTemplate `StorageClassName` value population if etcd storageClass is an empty string.
```
