### PR TITLE
Fix ServiceName updation for etcd statefulset

### DIFF
--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -279,6 +279,8 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 	}
 
 	if stsOriginal.Generation > 0 {
+		// TODO(shreyas-s-rao): replace with sts recreation logic, since Spec.ServiceName updation is forbidden
+		sts.Spec.ServiceName = stsOriginal.Spec.ServiceName
 		return c.client.Patch(ctx, sts, patch)
 	}
 


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind bug

**What this PR does / why we need it**:
This PR temporarily fixes an issue where druid tries to set `spec.ServiceName` to `PeerServiceName` by default, although older single-node etcds would have this field set to `ClientServiceName`, and updation of statefulset `spec.ServiceName` field is forbidden.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The permanent solution to this is to introduce sts recreation logic for updating any fields for which updates are forbidden.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Temporarily fixes an issue where druid tries to set `spec.ServiceName` to `PeerServiceName` by default, although older single-node etcds would have this field set to `ClientServiceName`, and updation of statefulset `spec.ServiceName` field is forbidden.
```
