### PR TITLE
[rel-v0.12] Fix podManagementPolicy for scale-up scenario

### DIFF
--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -72,19 +72,20 @@ func (c *component) Deploy(ctx context.Context) error {
 		sts = c.emptyStatefulset()
 	}
 
-	if sts.Generation > 1 && sts.Spec.ServiceName != c.values.PeerServiceName {
-		// Earlier clusters referred to the client service in `sts.Spec.ServiceName` which must be changed
-		// when a multi-node cluster is used, see https://github.com/gardener/etcd-druid/pull/293.
-		if clusterScaledUpToMultiNode(c.values) {
-			deleteAndWait := gardenercomponent.OpDestroyAndWait(c)
-			if err := deleteAndWait.Destroy(ctx); err != nil {
-				return err
-			}
-			sts = c.emptyStatefulset()
+	if sts.Generation > 1 && clusterScaledUpToMultiNode(c.values) && immutableFieldUpdate(sts, c.values) {
+		// Several immutable fields must be reset for the multi-node use-case.
+		deleteAndWait := gardenercomponent.OpDestroyAndWait(c)
+		if err := deleteAndWait.Destroy(ctx); err != nil {
+			return err
 		}
+		sts = c.emptyStatefulset()
 	}
 
 	return c.syncStatefulset(ctx, sts)
+}
+
+func immutableFieldUpdate(sts *appsv1.StatefulSet, val Values) bool {
+	return sts.Spec.ServiceName != val.PeerServiceName || sts.Spec.PodManagementPolicy != appsv1.ParallelPodManagement
 }
 
 func (c *component) Destroy(ctx context.Context) error {
@@ -165,6 +166,7 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 
 	sts.ObjectMeta = getObjectMeta(&c.values)
 	sts.Spec = appsv1.StatefulSetSpec{
+		PodManagementPolicy: appsv1.ParallelPodManagement,
 		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 			Type: appsv1.RollingUpdateStatefulSetStrategyType,
 		},
@@ -261,16 +263,6 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 		},
 	}
 
-	// TODO(shreyas-s-rao): relook at sts claim/recreation logic, since old shoots were created with
-	// default podManagementPolicy of OrderedReady, and trying to update it to Parallel leads to error,
-	// as updates to PodManagementPolicy in an existing statefulset is forbidden.
-	// This is important for bootstrapping and shoot unhibernation cases.
-	if stsOriginal.Spec.PodManagementPolicy == appsv1.OrderedReadyPodManagement {
-		sts.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
-	} else {
-		sts.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
-	}
-
 	if c.values.StorageClass != nil && *c.values.StorageClass != "" {
 		sts.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = c.values.StorageClass
 	}
@@ -279,8 +271,10 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 	}
 
 	if stsOriginal.Generation > 0 {
-		// TODO(shreyas-s-rao): replace with sts recreation logic, since Spec.ServiceName updation is forbidden
+		// Keep immutable fields
+		sts.Spec.PodManagementPolicy = stsOriginal.Spec.PodManagementPolicy
 		sts.Spec.ServiceName = stsOriginal.Spec.ServiceName
+
 		return c.client.Patch(ctx, sts, patch)
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug which caused a scaled-up etcd (`etcd.spec.replicas: 1 -> 3`) cluster having the wrong `sts.spec.podManamgentPolicy`.
This field must be set to `Parallel`, esp. if the cluster is afterwards scaled down (`etcd.spec.replicas: 0`) and scaled up (`etcd.spec.replicas: 3`) again. This is a common case when Gardener hibernates and wakes up shoot clusters.

**Special notes for your reviewer**:
/cc @shreyas-s-rao @aaronfern

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
This PR fixes an issue which caused the `sts.spec.podManagementPolicy` not to be updated to `Parallel` if an existing etcd cluster is scaled-up from `1 -> x`. This can cause an issue if the cluster is afterwards completely scaled-down (aka hibernation) and scaled-up again.
```
