### PR TITLE
Fix local provider

### DIFF
--- a/controllers/etcdcopybackupstask_controller.go
+++ b/controllers/etcdcopybackupstask_controller.go
@@ -290,11 +290,11 @@ func (r *EtcdCopyBackupsTaskReconciler) getChartValues(ctx context.Context, task
 		"ownerUID":  task.UID,
 	}
 
-	sourceStoreValues, err := utils.GetStoreValues(ctx, r.Client, &task.Spec.SourceStore, task.Namespace)
+	sourceStoreValues, err := utils.GetStoreValues(ctx, r.Client, r.logger, &task.Spec.SourceStore, task.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	targetStoreValues, err := utils.GetStoreValues(ctx, r.Client, &task.Spec.TargetStore, task.Namespace)
+	targetStoreValues, err := utils.GetStoreValues(ctx, r.Client, r.logger, &task.Spec.TargetStore, task.Namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/etcd-druid/pkg/client/kubernetes"
 	"github.com/gardener/etcd-druid/pkg/common"
 	. "github.com/gardener/etcd-druid/pkg/component/etcd/statefulset"
+	"github.com/gardener/etcd-druid/pkg/utils"
 	druidutils "github.com/gardener/etcd-druid/pkg/utils"
 
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -250,42 +251,56 @@ var _ = Describe("Statefulset", func() {
 			}
 
 			Context("with provider Local", func() {
+				var (
+					backupSecretData map[string][]byte
+					hostPath         string
+				)
+
 				BeforeEach(func() {
 					storageProvider = pointer.StringPtr(druidutils.Local)
 				})
 
-				It("should configure the correct provider values", func() {
-					Expect(stsDeployer.Deploy(ctx)).To(Succeed())
-					sts := &appsv1.StatefulSet{}
-					Expect(cl.Get(ctx, kutil.Key(namespace, values.Name), sts)).To(Succeed())
-
-					hpt := corev1.HostPathDirectory
-
-					// check volumes
-					Expect(sts.Spec.Template.Spec.Volumes).To(ContainElements(corev1.Volume{
-						Name: "host-storage",
-						VolumeSource: corev1.VolumeSource{
-							HostPath: &corev1.HostPathVolumeSource{
-								Path: "/etc/gardener/local-backupbuckets/" + container,
-								Type: &hpt,
-							},
+				JustBeforeEach(func() {
+					Expect(cl.Create(ctx, &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      etcdBackupSecretName,
+							Namespace: namespace,
 						},
-					}))
+						Data: backupSecretData,
+					})).To(Succeed())
+				})
 
-					backupRestoreContainer := sts.Spec.Template.Spec.Containers[1]
-					Expect(backupRestoreContainer.Name).To(Equal(backupRestore))
+				Context("when backup secret defines a hostPath", func() {
+					BeforeEach(func() {
+						hostPath = "/data"
+						backupSecretData = map[string][]byte{
+							utils.EtcdBackupSecretHostPath: []byte(hostPath),
+						}
+					})
 
-					// Check command
-					Expect(backupRestoreContainer.Command).To(ContainElements(
-						"--storage-provider="+string(*etcd.Spec.Backup.Store.Provider),
-						"--store-prefix="+prefix,
-					))
+					It("should configure the correct provider values", func() {
+						Expect(stsDeployer.Deploy(ctx)).To(Succeed())
+						sts := &appsv1.StatefulSet{}
+						Expect(cl.Get(ctx, kutil.Key(namespace, values.Name), sts)).To(Succeed())
 
-					// check volume mount
-					Expect(backupRestoreContainer.VolumeMounts).To(ContainElement(corev1.VolumeMount{
-						Name:      "host-storage",
-						MountPath: container,
-					}))
+						checkLocalProviderVaues(etcd, sts, hostPath)
+					})
+				})
+
+				Context("when backup secret doesn't define a hostPath", func() {
+					BeforeEach(func() {
+						backupSecretData = map[string][]byte{
+							"foo": []byte("bar"),
+						}
+					})
+
+					It("should configure the correct provider values", func() {
+						Expect(stsDeployer.Deploy(ctx)).To(Succeed())
+						sts := &appsv1.StatefulSet{}
+						Expect(cl.Get(ctx, kutil.Key(namespace, values.Name), sts)).To(Succeed())
+
+						checkLocalProviderVaues(etcd, sts, utils.LocalProviderDefaultMountPath)
+					})
 				})
 			})
 		})
@@ -827,6 +842,8 @@ func parseQuantity(q string) resource.Quantity {
 	return val
 }
 
+const etcdBackupSecretName = "etcd-backup"
+
 func getEtcdBackup(provider *string) *druidv1alpha1.StoreSpec {
 	storageProvider := pointer.StringDeref(provider, druidutils.ABS)
 
@@ -835,7 +852,7 @@ func getEtcdBackup(provider *string) *druidv1alpha1.StoreSpec {
 		Prefix:    prefix,
 		Provider:  (*druidv1alpha1.StorageProvider)(&storageProvider),
 		SecretRef: &corev1.SecretReference{
-			Name: "etcd-backup",
+			Name: etcdBackupSecretName,
 		},
 	}
 }
@@ -903,4 +920,34 @@ func getReadinessHandlerForMultiNode(val Values) gomegatypes.GomegaMatcher {
 			),
 		})),
 	})
+}
+
+func checkLocalProviderVaues(etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet, hostPath string) {
+	hpt := corev1.HostPathDirectory
+
+	// check volumes
+	ExpectWithOffset(1, sts.Spec.Template.Spec.Volumes).To(ContainElements(corev1.Volume{
+		Name: "host-storage",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: hostPath + "/" + container,
+				Type: &hpt,
+			},
+		},
+	}))
+
+	backupRestoreContainer := sts.Spec.Template.Spec.Containers[1]
+	ExpectWithOffset(1, backupRestoreContainer.Name).To(Equal(backupRestore))
+
+	// Check command
+	ExpectWithOffset(1, backupRestoreContainer.Command).To(ContainElements(
+		"--storage-provider="+string(*etcd.Spec.Backup.Store.Provider),
+		"--store-prefix="+prefix,
+	))
+
+	// check volume mount
+	ExpectWithOffset(1, backupRestoreContainer.VolumeMounts).To(ContainElement(corev1.VolumeMount{
+		Name:      "host-storage",
+		MountPath: container,
+	}))
 }

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -37,7 +37,6 @@ const (
 	defaultEtcdDefragTimeout             = "15m"
 	defaultAutoCompactionMode            = "periodic"
 	defaultEtcdConnectionTimeout         = "5m"
-	defaultLocalPrefix                   = "/etc/gardener/local-backupbuckets"
 )
 
 var defaultStorageCapacity = resource.MustParse("16Gi")

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -172,7 +172,7 @@ func GetStoreValues(ctx context.Context, client client.Client, store *druidv1alp
 		"storageProvider": storageProvider,
 	}
 	if strings.EqualFold(string(*store.Provider), Local) {
-		mountPath, err := getHostMountPathFromSecretRef(ctx, client, store, namespace)
+		mountPath, err := GetHostMountPathFromSecretRef(ctx, client, store, namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -187,7 +187,8 @@ func GetStoreValues(ctx context.Context, client client.Client, store *druidv1alp
 	return storeValues, nil
 }
 
-func getHostMountPathFromSecretRef(ctx context.Context, client client.Client, store *druidv1alpha1.StoreSpec, namespace string) (string, error) {
+// GetHostMountPathFromSecretRef returns the hostPath configured for the given store.
+func GetHostMountPathFromSecretRef(ctx context.Context, client client.Client, store *druidv1alpha1.StoreSpec, namespace string) (string, error) {
 	secret := &corev1.Secret{}
 	if err := client.Get(ctx, Key(namespace, store.SecretRef.Name), secret); err != nil {
 		return "", err

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -162,7 +164,7 @@ func Key(namespaceOrName string, nameOpt ...string) client.ObjectKey {
 }
 
 // GetStoreValues converts the values in the StoreSpec to a map, or returns an error if the storage provider is unsupported.
-func GetStoreValues(ctx context.Context, client client.Client, store *druidv1alpha1.StoreSpec, namespace string) (map[string]interface{}, error) {
+func GetStoreValues(ctx context.Context, client client.Client, logger logr.Logger, store *druidv1alpha1.StoreSpec, namespace string) (map[string]interface{}, error) {
 	storageProvider, err := StorageProviderFromInfraProvider(store.Provider)
 	if err != nil {
 		return nil, err
@@ -172,7 +174,7 @@ func GetStoreValues(ctx context.Context, client client.Client, store *druidv1alp
 		"storageProvider": storageProvider,
 	}
 	if strings.EqualFold(string(*store.Provider), Local) {
-		mountPath, err := GetHostMountPathFromSecretRef(ctx, client, store, namespace)
+		mountPath, err := GetHostMountPathFromSecretRef(ctx, client, logger, store, namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -188,7 +190,12 @@ func GetStoreValues(ctx context.Context, client client.Client, store *druidv1alp
 }
 
 // GetHostMountPathFromSecretRef returns the hostPath configured for the given store.
-func GetHostMountPathFromSecretRef(ctx context.Context, client client.Client, store *druidv1alpha1.StoreSpec, namespace string) (string, error) {
+func GetHostMountPathFromSecretRef(ctx context.Context, client client.Client, logger logr.Logger, store *druidv1alpha1.StoreSpec, namespace string) (string, error) {
+	if store.SecretRef == nil {
+		logger.Info("secretRef is not defined for store, using default hostPath")
+		return LocalProviderDefaultMountPath, nil
+	}
+
 	secret := &corev1.Secret{}
 	if err := client.Get(ctx, Key(namespace, store.SecretRef.Name), secret); err != nil {
 		return "", err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes the hostPath configuration for the `Local` provider as explained in the linked issue. It also fixes some potential nil pointer dereferences along the way.

**Which issue(s) this PR fixes**:
Fixes #407 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed that caused Etcd-Druid to not consider the `hostPath` configuration in the referenced backup secret `etcd.spec.backup.store.secretRef`.
```
