### PR TITLE
Enhance BackupReady condition handling

### DIFF
--- a/pkg/health/condition/builder.go
+++ b/pkg/health/condition/builder.go
@@ -24,10 +24,10 @@ import (
 )
 
 //
-var skipMergeConditions = map[druidv1alpha1.ConditionType]bool{
-	druidv1alpha1.ConditionTypeReady:           true,
-	druidv1alpha1.ConditionTypeAllMembersReady: true,
-	druidv1alpha1.ConditionTypeBackupReady:     true,
+var skipMergeConditions = map[druidv1alpha1.ConditionType]struct{}{
+	druidv1alpha1.ConditionTypeReady:           struct{}{},
+	druidv1alpha1.ConditionTypeAllMembersReady: struct{}{},
+	druidv1alpha1.ConditionTypeBackupReady:     struct{}{},
 }
 
 // Builder is an interface for building conditions.
@@ -118,7 +118,7 @@ func (b *defaultBuilder) Build() []druidv1alpha1.Condition {
 
 	for _, condition := range b.old {
 		// Do not add conditions that are part of the skipMergeConditions list
-		ok := skipMergeConditions[condition.Type]
+		_, ok := skipMergeConditions[condition.Type]
 		if ok {
 			continue
 		}

--- a/pkg/health/condition/builder.go
+++ b/pkg/health/condition/builder.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
+// skipMergeConditions contain the list of conditions we dont want to add to the list if not recalculated
 var skipMergeConditions = map[druidv1alpha1.ConditionType]struct{}{
 	druidv1alpha1.ConditionTypeReady:           {},
 	druidv1alpha1.ConditionTypeAllMembersReady: {},
@@ -39,10 +39,9 @@ type Builder interface {
 }
 
 type defaultBuilder struct {
-	old      map[druidv1alpha1.ConditionType]druidv1alpha1.Condition
-	results  map[druidv1alpha1.ConditionType]Result
-	nowFunc  func() metav1.Time
-	replicas int32
+	old     map[druidv1alpha1.ConditionType]druidv1alpha1.Condition
+	results map[druidv1alpha1.ConditionType]Result
+	nowFunc func() metav1.Time
 }
 
 // NewBuilder returns a Builder for a specific condition.

--- a/pkg/health/condition/builder.go
+++ b/pkg/health/condition/builder.go
@@ -106,12 +106,6 @@ func (b *defaultBuilder) Build() []druidv1alpha1.Condition {
 		condition.Reason = res.Reason()
 
 		conditions = append(conditions, condition)
-		delete(b.old, condType)
-	}
-
-	for _, condition := range b.old {
-		// Add existing conditions as they were. This needs to be changed when SSA is used.
-		conditions = append(conditions, condition)
 	}
 
 	sort.Slice(conditions, func(i, j int) bool {

--- a/pkg/health/condition/builder_test.go
+++ b/pkg/health/condition/builder_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Builder", func() {
 				builder.WithOldConditions(oldConditions)
 			})
 
-			It("should correctly merge them", func() {
+			It("should not add old conditions", func() {
 				builder.WithResults([]Result{
 					&result{
 						ConType:    druidv1alpha1.ConditionTypeAllMembersReady,
@@ -116,14 +116,6 @@ var _ = Describe("Builder", func() {
 						"Status":             Equal(druidv1alpha1.ConditionTrue),
 						"Reason":             Equal("new reason"),
 						"Message":            Equal("new message"),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Type":               Equal(druidv1alpha1.ConditionTypeBackupReady),
-						"LastUpdateTime":     Equal(metav1.NewTime(oldConditionTime)),
-						"LastTransitionTime": Equal(metav1.NewTime(oldConditionTime)),
-						"Status":             Equal(druidv1alpha1.ConditionTrue),
-						"Reason":             Equal("foobar reason"),
-						"Message":            Equal("foobar message"),
 					}),
 				))
 			})

--- a/pkg/health/condition/builder_test.go
+++ b/pkg/health/condition/builder_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Builder", func() {
 					},
 				})
 
-				conditions := builder.Build()
+				conditions := builder.Build(1)
 
 				Expect(conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
@@ -138,7 +138,7 @@ var _ = Describe("Builder", func() {
 					},
 				})
 
-				conditions := builder.Build()
+				conditions := builder.Build(1)
 
 				Expect(conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{

--- a/pkg/health/condition/check_backup_ready.go
+++ b/pkg/health/condition/check_backup_ready.go
@@ -52,7 +52,7 @@ func (a *backupReadyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) R
 
 	// Special case of etcd not being configured to take snapshots
 	// Do not add the BackupReady condition if backup is not configured
-	if etcd.Spec.Backup.Store == nil || etcd.Spec.Backup.Store.Provider == nil {
+	if etcd.Spec.Backup.Store == nil || etcd.Spec.Backup.Store.Provider == nil || len(*etcd.Spec.Backup.Store.Provider) == 0 {
 		return nil
 	}
 

--- a/pkg/health/condition/check_backup_ready.go
+++ b/pkg/health/condition/check_backup_ready.go
@@ -56,28 +56,6 @@ func (a *backupReadyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) R
 		return nil
 	}
 
-	// Special case of etcd being scaled down
-	if etcd.Spec.Replicas == 0 {
-		etcdConditions := etcd.Status.Conditions
-		var bckpCond druidv1alpha1.Condition
-
-		for _, condition := range etcdConditions {
-			if condition.Type == druidv1alpha1.ConditionTypeBackupReady {
-				bckpCond = condition
-				break
-			}
-		}
-
-		if bckpCond.Status == "" {
-			result.status = druidv1alpha1.ConditionUnknown
-		} else {
-			result.status = bckpCond.Status
-		}
-		result.reason = ConditionNotChecked
-		result.message = "etcd cluster has been scaled down"
-		return result
-	}
-
 	//Fetch snapshot leases
 	var (
 		fullSnapErr, incrSnapErr error

--- a/pkg/health/condition/check_backup_ready.go
+++ b/pkg/health/condition/check_backup_ready.go
@@ -67,7 +67,11 @@ func (a *backupReadyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) R
 			}
 		}
 
-		result.status = bckpCond.Status
+		if bckpCond.Status == "" {
+			result.status = druidv1alpha1.ConditionUnknown
+		} else {
+			result.status = bckpCond.Status
+		}
 		result.reason = ConditionNotChecked
 		result.message = "Statefulset has been scaled down"
 		return result

--- a/pkg/health/condition/check_backup_ready.go
+++ b/pkg/health/condition/check_backup_ready.go
@@ -52,7 +52,7 @@ func (a *backupReadyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) R
 
 	// Special case of etcd not being configured to take snapshots
 	// Do not add the BackupReady condition if backup is not configured
-	if etcd.Spec.Backup.Store == nil {
+	if etcd.Spec.Backup.Store == nil || etcd.Spec.Backup.Store.Provider == nil {
 		return nil
 	}
 

--- a/pkg/health/condition/check_backup_ready.go
+++ b/pkg/health/condition/check_backup_ready.go
@@ -36,7 +36,8 @@ const (
 	// BackupFailed is a constant that means that etcd backup has failed
 	BackupFailed string = "BackupFailed"
 	// Unknown is a constant that means that the etcd backup status is currently not known
-	Unknown             string = "Unknown"
+	Unknown string = "Unknown"
+	// ConditionNotChecked is a constant that means that the etcd backup status has not been updated or rechecked
 	ConditionNotChecked string = "ConditionNotChecked"
 )
 
@@ -73,7 +74,7 @@ func (a *backupReadyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) R
 			result.status = bckpCond.Status
 		}
 		result.reason = ConditionNotChecked
-		result.message = "Statefulset has been scaled down"
+		result.message = "etcd cluster has been scaled down"
 		return result
 	}
 

--- a/pkg/health/condition/check_backup_ready_test.go
+++ b/pkg/health/condition/check_backup_ready_test.go
@@ -248,6 +248,7 @@ var _ = Describe("BackupReadyCheck", func() {
 
 					etcdObj := etcd
 					etcdObj.Spec.Replicas = 0
+					etcdObj.Status.Conditions = []druidv1alpha1.Condition{}
 					check := BackupReadyCheck(cl)
 					result := check.Check(context.TODO(), etcdObj)
 

--- a/pkg/health/condition/check_backup_ready_test.go
+++ b/pkg/health/condition/check_backup_ready_test.go
@@ -231,12 +231,15 @@ var _ = Describe("BackupReadyCheck", func() {
 					},
 				).AnyTimes()
 
-				etcdObj := etcd
-				etcdObj.Spec.Backup.Store = nil
+				etcd.Spec.Backup.Store = nil
 				check := BackupReadyCheck(cl)
-				result := check.Check(context.TODO(), etcdObj)
+				result := check.Check(context.TODO(), etcd)
 
 				Expect(result).To(BeNil())
+				etcd.Spec.Backup.Store = &druidv1alpha1.StoreSpec{
+					Prefix:   "test-prefix",
+					Provider: &storageProvider,
+				}
 			})
 		})
 		Context("With backup store is configured but provider is nil", func() {
@@ -247,12 +250,12 @@ var _ = Describe("BackupReadyCheck", func() {
 					},
 				).AnyTimes()
 
-				etcdObj := etcd
-				etcdObj.Spec.Backup.Store.Provider = nil
+				etcd.Spec.Backup.Store.Provider = nil
 				check := BackupReadyCheck(cl)
-				result := check.Check(context.TODO(), etcdObj)
+				result := check.Check(context.TODO(), etcd)
 
 				Expect(result).To(BeNil())
+				etcd.Spec.Backup.Store.Provider = &storageProvider
 			})
 		})
 	})

--- a/pkg/health/condition/check_backup_ready_test.go
+++ b/pkg/health/condition/check_backup_ready_test.go
@@ -237,52 +237,5 @@ var _ = Describe("BackupReadyCheck", func() {
 				Expect(result).To(BeNil())
 			})
 		})
-		Context("With etcd replicas set to 0", func() {
-			Context("With no prior BackupReady condition being set", func() {
-				It("Should return unknown status along with ConditionNotChecked reason", func() {
-					cl.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
-						func(_ context.Context, _ client.ObjectKey, er *coordinationv1.Lease) error {
-							return &noLeaseError
-						},
-					).AnyTimes()
-
-					etcdObj := etcd
-					etcdObj.Spec.Replicas = 0
-					etcdObj.Status.Conditions = []druidv1alpha1.Condition{}
-					check := BackupReadyCheck(cl)
-					result := check.Check(context.TODO(), etcdObj)
-
-					Expect(result).ToNot(BeNil())
-					Expect(result.Status()).To(Equal(druidv1alpha1.ConditionUnknown))
-					Expect(result.Reason()).To(Equal(ConditionNotChecked))
-					Expect(result.Message()).To(Equal("etcd cluster has been scaled down"))
-				})
-			})
-			Context("With a prior BackupReady condition being set", func() {
-				It("Should return the same status along with ConditionNotChecked reason", func() {
-					cl.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
-						func(_ context.Context, _ client.ObjectKey, er *coordinationv1.Lease) error {
-							return &noLeaseError
-						},
-					).AnyTimes()
-
-					etcdObj := etcd
-					etcdObj.Spec.Replicas = 0
-					etcdObj.Status.Conditions = []druidv1alpha1.Condition{
-						{
-							Type:   druidv1alpha1.ConditionTypeBackupReady,
-							Status: druidv1alpha1.ConditionTrue,
-						},
-					}
-					check := BackupReadyCheck(cl)
-					result := check.Check(context.TODO(), etcdObj)
-
-					Expect(result).ToNot(BeNil())
-					Expect(result.Status()).To(Equal(druidv1alpha1.ConditionTrue))
-					Expect(result.Reason()).To(Equal(ConditionNotChecked))
-					Expect(result.Message()).To(Equal("etcd cluster has been scaled down"))
-				})
-			})
-		})
 	})
 })

--- a/pkg/health/condition/check_backup_ready_test.go
+++ b/pkg/health/condition/check_backup_ready_test.go
@@ -254,7 +254,7 @@ var _ = Describe("BackupReadyCheck", func() {
 					Expect(result).ToNot(BeNil())
 					Expect(result.Status()).To(Equal(druidv1alpha1.ConditionUnknown))
 					Expect(result.Reason()).To(Equal(ConditionNotChecked))
-					Expect(result.Message()).To(Equal("Statefulset has been scaled down"))
+					Expect(result.Message()).To(Equal("etcd cluster has been scaled down"))
 				})
 			})
 			Context("With a prior BackupReady condition being set", func() {
@@ -279,7 +279,7 @@ var _ = Describe("BackupReadyCheck", func() {
 					Expect(result).ToNot(BeNil())
 					Expect(result.Status()).To(Equal(druidv1alpha1.ConditionTrue))
 					Expect(result.Reason()).To(Equal(ConditionNotChecked))
-					Expect(result.Message()).To(Equal("Statefulset has been scaled down"))
+					Expect(result.Message()).To(Equal("etcd cluster has been scaled down"))
 				})
 			})
 		})

--- a/pkg/health/condition/check_backup_ready_test.go
+++ b/pkg/health/condition/check_backup_ready_test.go
@@ -51,9 +51,13 @@ var _ = Describe("BackupReadyCheck", func() {
 					Namespace: "default",
 				},
 				Spec: druidv1alpha1.EtcdSpec{
+					Replicas: 1,
 					Backup: druidv1alpha1.BackupSpec{
 						DeltaSnapshotPeriod: &v1.Duration{
 							Duration: 2 * time.Minute,
+						},
+						Store: &druidv1alpha1.StoreSpec{
+							Prefix: "test-prefix",
 						},
 					},
 				},
@@ -215,6 +219,68 @@ var _ = Describe("BackupReadyCheck", func() {
 				Expect(result.ConditionType()).To(Equal(druidv1alpha1.ConditionTypeBackupReady))
 				Expect(result.Status()).To(Equal(druidv1alpha1.ConditionFalse))
 				Expect(result.Reason()).To(Equal(BackupFailed))
+			})
+		})
+		Context("With no backup store configured", func() {
+			It("Should return nil condition", func() {
+				cl.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, er *coordinationv1.Lease) error {
+						return &noLeaseError
+					},
+				).AnyTimes()
+
+				etcdObj := etcd
+				etcdObj.Spec.Backup.Store = nil
+				check := BackupReadyCheck(cl)
+				result := check.Check(context.TODO(), etcdObj)
+
+				Expect(result).To(BeNil())
+			})
+		})
+		Context("With etcd replicas set to 0", func() {
+			Context("With no prior BackupReady condition being set", func() {
+				It("Should return unknown status along with ConditionNotChecked reason", func() {
+					cl.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ context.Context, _ client.ObjectKey, er *coordinationv1.Lease) error {
+							return &noLeaseError
+						},
+					).AnyTimes()
+
+					etcdObj := etcd
+					etcdObj.Spec.Replicas = 0
+					check := BackupReadyCheck(cl)
+					result := check.Check(context.TODO(), etcdObj)
+
+					Expect(result).ToNot(BeNil())
+					Expect(result.Status()).To(Equal(druidv1alpha1.ConditionUnknown))
+					Expect(result.Reason()).To(Equal(ConditionNotChecked))
+					Expect(result.Message()).To(Equal("Statefulset has been scaled down"))
+				})
+			})
+			Context("With a prior BackupReady condition being set", func() {
+				It("Should return the same status along with ConditionNotChecked reason", func() {
+					cl.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ context.Context, _ client.ObjectKey, er *coordinationv1.Lease) error {
+							return &noLeaseError
+						},
+					).AnyTimes()
+
+					etcdObj := etcd
+					etcdObj.Spec.Replicas = 0
+					etcdObj.Status.Conditions = []druidv1alpha1.Condition{
+						{
+							Type:   druidv1alpha1.ConditionTypeBackupReady,
+							Status: druidv1alpha1.ConditionTrue,
+						},
+					}
+					check := BackupReadyCheck(cl)
+					result := check.Check(context.TODO(), etcdObj)
+
+					Expect(result).ToNot(BeNil())
+					Expect(result.Status()).To(Equal(druidv1alpha1.ConditionTrue))
+					Expect(result.Reason()).To(Equal(ConditionNotChecked))
+					Expect(result.Message()).To(Equal("Statefulset has been scaled down"))
+				})
 			})
 		})
 	})

--- a/pkg/health/status/check.go
+++ b/pkg/health/status/check.go
@@ -111,7 +111,7 @@ func (c *checker) executeConditionChecks(ctx context.Context, etcd *druidv1alpha
 		WithNowFunc(func() metav1.Time { return metav1.NewTime(TimeNow()) }).
 		WithOldConditions(etcd.Status.Conditions).
 		WithResults(results).
-		Build()
+		Build(etcd.Spec.Replicas)
 
 	etcd.Status.Conditions = conditions
 	return nil

--- a/pkg/health/status/check_test.go
+++ b/pkg/health/status/check_test.go
@@ -102,6 +102,9 @@ var _ = Describe("Check", func() {
 			}
 
 			etcd := &druidv1alpha1.Etcd{
+				Spec: druidv1alpha1.EtcdSpec{
+					Replicas: 1,
+				},
 				Status: status,
 			}
 

--- a/pkg/health/status/check_test.go
+++ b/pkg/health/status/check_test.go
@@ -112,6 +112,9 @@ var _ = Describe("Check", func() {
 				func(client.Client) condition.Checker {
 					return createConditionCheck(druidv1alpha1.ConditionTypeAllMembersReady, druidv1alpha1.ConditionTrue, "bar reason", "bar message")
 				},
+				func(client.Client) condition.Checker {
+					return createConditionCheck(druidv1alpha1.ConditionTypeBackupReady, druidv1alpha1.ConditionUnknown, "foobar reason", "foobar message")
+				},
 			})()
 
 			defer test.WithVar(&EtcdMemberChecks, []EtcdMemberCheckFn{
@@ -151,7 +154,7 @@ var _ = Describe("Check", func() {
 					"Type":               Equal(druidv1alpha1.ConditionTypeBackupReady),
 					"Status":             Equal(druidv1alpha1.ConditionUnknown),
 					"LastTransitionTime": Equal(metav1.NewTime(timeBefore)),
-					"LastUpdateTime":     Equal(metav1.NewTime(timeBefore)),
+					"LastUpdateTime":     Equal(metav1.NewTime(timeNow)),
 					"Reason":             Equal("foobar reason"),
 					"Message":            Equal("foobar message"),
 				}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the `BackupReady` condition handling to take into account cases where the backup section is not defined and in cases where the etcd statefulset is scaled down

**Which issue(s) this PR fixes**:
Fixes #413 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enhance `BackupReady` condition to take into account statefulset being scaled down and the backup section not being defined
```
