### PR TITLE
Add e2e tests for multi-node etcd 

### DIFF
--- a/docs/development/local-e2e-tests.md
+++ b/docs/development/local-e2e-tests.md
@@ -58,7 +58,8 @@ make test-e2e
 
 The following environment variables influence how the flow described above is executed:
 
-- `PROVIDERS`:  Providers used for testing (`all`, `aws`, `azure`, `gcp`). Multiple entries must be comma separated.
+- `PROVIDERS`:  Providers used for testing (`all`, `aws`, `azure`, `gcp`). Multiple entries must be comma separated. 
+    > **Note**: Some tests will use very first entry from env `PROVIDERS` for e2e testing (ex: multi-node tests). So for multi-node tests to use specific provider, specify that provider as first entry in env `PROVIDERS`.
 - `KUBECONFIG`: Kubeconfig pointing to cluster where Etcd-Druid will be deployed (preferably [KinD](https://kind.sigs.k8s.io)).
 - `TEST_ID`:    Some ID which is used to create assets for and during testing.
 - `STEPS`:      Steps executed by `make` target (`setup`, `deploy`, `test`, `undeploy`, `cleanup` - default: all steps).

--- a/test/e2e/etcd_backup_test.go
+++ b/test/e2e/etcd_backup_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Etcd Backup", func() {
 
 					logger.Info("waiting for sts to become unready", "statefulSetName", etcdName)
 					Eventually(func() error {
-						ctx, cancelFunc := context.WithTimeout(context.TODO(), singleNodeEtcdTimeout)
+						ctx, cancelFunc := context.WithTimeout(context.Background(), singleNodeEtcdTimeout)
 						defer cancelFunc()
 
 						sts := &appsv1.StatefulSet{}
@@ -153,7 +153,7 @@ var _ = Describe("Etcd Backup", func() {
 
 					logger.Info("waiting for sts to become ready again", "statefulSetName", etcdName)
 					Eventually(func() error {
-						ctx, cancelFunc := context.WithTimeout(context.TODO(), singleNodeEtcdTimeout)
+						ctx, cancelFunc := context.WithTimeout(context.Background(), singleNodeEtcdTimeout)
 						defer cancelFunc()
 
 						sts := &appsv1.StatefulSet{}

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -1,0 +1,441 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/gardener/etcd-druid/api/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8s_labels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Etcd", func() {
+	Context("when multi-node is configured", func() {
+		var (
+			cl               client.Client
+			etcdName         string
+			storageContainer string
+			parentCtx        context.Context
+			provider         TestProvider
+			providers        []TestProvider
+			err              error
+		)
+
+		BeforeEach(func() {
+			parentCtx = context.Background()
+			providers, err = getProviders()
+			Expect(err).ToNot(HaveOccurred())
+			// take first provider
+			provider = providers[0]
+			cl, err = getKubernetesClient(kubeconfigPath)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			etcdName = fmt.Sprintf("etcd-%s", provider.Name)
+
+			storageContainer = getEnvAndExpectNoError(envStorageContainer)
+
+			snapstoreProvider := provider.Storage.Provider
+			store, err := getSnapstore(string(snapstoreProvider), storageContainer, storePrefix)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// purge any existing backups in bucket
+			Expect(purgeSnapstore(store)).To(Succeed())
+			Expect(deployBackupSecret(parentCtx, cl, logger, provider, etcdNamespace, storageContainer))
+
+		})
+
+		AfterEach(func() {
+			// remove etcd objects if any old etcd objects exists.
+			purgeEtcd(parentCtx, cl, providers)
+		})
+
+		It("should perform etcd operations", func() {
+			ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
+			defer cancelFunc()
+
+			etcd := getDefaultMultiNodeEtcd(etcdName, namespace, storageContainer, storePrefix, provider)
+			objLogger := logger.WithValues("etcd-multi-node", client.ObjectKeyFromObject(etcd))
+
+			By("Create etcd")
+			createAndCheckEtcd(ctx, cl, objLogger, etcd)
+
+			By("Hibernate etcd (Scale down from 3->0)")
+			hibernateAndCheckEtcd(ctx, cl, objLogger, etcd)
+
+			By("Wakeup etcd (Scale up from 0->3)")
+			wakeupEtcd(ctx, cl, objLogger, etcd)
+
+			By("Zero downtime rolling updates")
+			job := startEtcdZeroDownTimeValidatorJob(ctx, cl, etcd, "rolling-update")
+			// this defer ensures to remove the job, if test case breaks before deleting the job.
+			defer cleanUpTestHelperJob(ctx, cl, client.ObjectKeyFromObject(job))
+
+			ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+			// trigger rolling update by updating etcd quota
+			etcd.Spec.Etcd.Quota.Add(*resource.NewMilliQuantity(int64(10), resource.DecimalSI))
+			updateAndCheckEtcd(ctx, cl, objLogger, etcd)
+			checkEtcdZeroDownTimeValidatorJob(ctx, cl, client.ObjectKeyFromObject(job), objLogger)
+			cleanUpTestHelperJob(ctx, cl, client.ObjectKeyFromObject(job)) // remove job
+
+			By("Zero downtime maintenance operation: defragmentation")
+			job = startEtcdZeroDownTimeValidatorJob(ctx, cl, etcd, "defragmentation")
+			// this defer ensures to remove the job, if test case breaks before deleting the job.
+			defer cleanUpTestHelperJob(ctx, cl, client.ObjectKeyFromObject(job))
+
+			objLogger.Info("Configure defragmentation schedule for every 1 minute")
+			ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+			*etcd.Spec.Etcd.DefragmentationSchedule = "*/1 * * * *"
+			updateAndCheckEtcd(ctx, cl, objLogger, etcd)
+
+			checkDefragmentationFinished(ctx, cl, etcd, objLogger)
+
+			objLogger.Info("Checking any Etcd downtime")
+			// Checking Etcd cluster is healthy and there is no downtime while defragmentation.
+			// K8s job zeroDownTimeValidator will fail, if there is any downtime in Etcd cluster health.
+			checkEtcdZeroDownTimeValidatorJob(ctx, cl, client.ObjectKeyFromObject(job), objLogger)
+			cleanUpTestHelperJob(ctx, cl, client.ObjectKeyFromObject(job))
+
+			By("Delete etcd")
+			deleteAndCheckEtcd(ctx, cl, objLogger, etcd)
+		})
+	})
+
+	Context("when single-node is configured", func() {
+		var (
+			cl               client.Client
+			etcdName         string
+			storageContainer string
+			parentCtx        context.Context
+			provider         TestProvider
+			providers        []TestProvider
+			err              error
+		)
+
+		BeforeEach(func() {
+			parentCtx = context.Background()
+			providers, err = getProviders()
+			Expect(err).ToNot(HaveOccurred())
+			// take first provider
+			provider = providers[0]
+			provider.Storage = nil
+
+			cl, err = getKubernetesClient(kubeconfigPath)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			etcdName = fmt.Sprintf("etcd-%s", provider.Name)
+			typedClient, err = getKubernetesTypedClient(kubeconfigPath)
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		AfterEach(func() {
+			// remove etcd objects if any old etcd objects exist.
+			purgeEtcd(parentCtx, cl, providers)
+		})
+
+		It("should scale single-node etcd to multi-node etcd cluster", func() {
+			ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
+			defer cancelFunc()
+
+			etcd := getDefaultEtcd(etcdName, namespace, storageContainer, storePrefix, provider)
+			objLogger := logger.WithValues("etcd-multi-node", client.ObjectKeyFromObject(etcd))
+
+			By("Create single-node etcd")
+			createAndCheckEtcd(ctx, cl, objLogger, etcd)
+
+			By("Scale up of a healthy cluster (from 1->3)")
+			ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+			etcd.Spec.Replicas = multiNodeEtcdReplicas
+			updateAndCheckEtcd(ctx, cl, objLogger, etcd)
+
+			// TODO: Uncomment me once scale down replicas from 3 to 1 is supported.
+			// By("Scale down of a healthy cluster (from 3 to 1)")
+			// ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+			// etcd.Spec.Replicas = replicas
+			// updateAndCheckEtcd(ctx, cl, objLogger, etcd)
+
+			By("Delete single-node etcd")
+			deleteAndCheckEtcd(ctx, cl, objLogger, etcd)
+		})
+	})
+})
+
+// checkEventuallyEtcdRollingUpdateDone is a helper function, uses Gomega Eventually.
+// Returns the function until etcd rolling updates is done for given timeout and polling interval or
+// it raises assertion error.
+//
+// checkEventuallyEtcdRollingUpdateDone ensures rolling updates of etcd resources(etcd/sts) is done.
+func checkEventuallyEtcdRollingUpdateDone(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd,
+	oldStsObservedGeneration, oldEtcdObservedGeneration int64) {
+	Eventually(func() error {
+		sts := &appsv1.StatefulSet{}
+		ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), sts)).To(Succeed())
+
+		if sts.Status.ObservedGeneration <= oldStsObservedGeneration {
+			return fmt.Errorf("waiting for statefulset rolling update to complete %d pods at revision %s",
+				sts.Status.UpdatedReplicas, sts.Status.UpdateRevision)
+		}
+
+		if sts.Status.UpdatedReplicas != *sts.Spec.Replicas {
+			return fmt.Errorf("waiting for statefulset rolling update to complete, UpdatedReplicas is %d, but expected to be %d",
+				sts.Status.UpdatedReplicas, *sts.Spec.Replicas)
+		}
+
+		ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+		if *etcd.Status.ObservedGeneration <= oldEtcdObservedGeneration {
+			return fmt.Errorf("waiting for etcd %q rolling update to complete", etcd.Name)
+		}
+		return nil
+	}, timeout*3, pollingInterval).Should(BeNil())
+}
+
+// hibernateAndCheckEtcd scales down etcd replicas to zero and ensures
+func hibernateAndCheckEtcd(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd) {
+	ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+	etcd.Spec.Replicas = 0
+	etcd.SetAnnotations(
+		map[string]string{
+			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+		})
+	ExpectWithOffset(1, cl.Update(ctx, etcd)).ShouldNot(HaveOccurred())
+	logger.Info("Waiting to hibernate")
+
+	logger.Info("Checking statefulset")
+	Eventually(func() error {
+		sts := &appsv1.StatefulSet{}
+		ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), sts)).To(Succeed())
+
+		if sts.Status.ReadyReplicas != 0 {
+			return fmt.Errorf("sts %s not ready", etcd.Name)
+		}
+		return nil
+	}, timeout*3, pollingInterval).Should(BeNil())
+
+	logger.Info("Checking etcd")
+	Eventually(func() error {
+		etcd := getEmptyEtcd(etcd.Name, namespace)
+		err := cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)
+		if err != nil {
+			return err
+		}
+
+		if etcd != nil && etcd.Status.Ready != nil {
+			if *etcd.Status.Ready != true {
+				return fmt.Errorf("etcd %s is not ready", etcd.Name)
+			}
+		}
+
+		if etcd.Status.ClusterSize == nil {
+			return fmt.Errorf("etcd %s cluster size is empty", etcd.Name)
+		}
+		// TODO: uncomment me once scale down is supported,
+		// currently ClusterSize is not updated while scaling down.
+		// if *etcd.Status.ClusterSize != 0 {
+		// 	return fmt.Errorf("etcd %q cluster size is %d, but expected to be 0",
+		// 		etcdName, *etcd.Status.ClusterSize)
+		// }
+
+		for _, c := range etcd.Status.Conditions {
+			if c.Status != v1alpha1.ConditionUnknown {
+				return fmt.Errorf("etcd %s status condition is %q, but expected to be %s ",
+					etcd.Name, c.Status, v1alpha1.ConditionUnknown)
+			}
+		}
+
+		return nil
+	}, timeout*3, pollingInterval).Should(BeNil())
+	logger.Info("etcd is hibernated")
+}
+
+// wakeupEtcd scales up etcd replicas to 3 and ensures etcd cluster with 3 replicas is ready.
+func wakeupEtcd(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd) {
+	ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+	etcd.Spec.Replicas = multiNodeEtcdReplicas
+	updateAndCheckEtcd(ctx, cl, logger, etcd)
+}
+
+// updateAndCheckEtcd updates the given etcd obj in the Kubernetes cluster.
+func updateAndCheckEtcd(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd) {
+	sts := &appsv1.StatefulSet{}
+	ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), sts)).To(Succeed())
+	oldStsObservedGeneration, oldEtcdObservedGeneration := sts.Status.ObservedGeneration, *etcd.Status.ObservedGeneration
+
+	// update reconcile annotation, druid to reconcile and update the changes.
+	etcd.SetAnnotations(
+		map[string]string{
+			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+		})
+	ExpectWithOffset(1, cl.Update(ctx, etcd)).ShouldNot(HaveOccurred())
+
+	// Ensuring update is successful by verifying
+	// ObservedGeneration ID of sts, etcd before and after update done.
+	checkEventuallyEtcdRollingUpdateDone(ctx, cl, logger, etcd,
+		oldStsObservedGeneration, oldEtcdObservedGeneration)
+	checkEtcdReady(ctx, cl, logger, etcd)
+}
+
+// cleanUpTestHelperJob ensures to remove the given job in the kubernetes cluster if job exists.
+func cleanUpTestHelperJob(ctx context.Context, cl client.Client, jobKey types.NamespacedName) {
+	job := &batchv1.Job{}
+	if err := cl.Get(ctx, jobKey, job); err == nil {
+		ExpectWithOffset(1, kutil.DeleteObject(ctx, cl, job)).To(Succeed())
+	}
+}
+
+// checkJobReady checks k8s job associated pod is ready, up and running.
+// checkJobReady is a helper function, uses Gomega Eventually.
+func checkJobReady(ctx context.Context, cl client.Client, jobName string) {
+	r, _ := k8s_labels.NewRequirement("job-name", selection.Equals, []string{jobName})
+	opts := &client.ListOptions{
+		LabelSelector: k8s_labels.NewSelector().Add(*r),
+		Namespace:     namespace,
+	}
+
+	Eventually(func() error {
+		podList := &corev1.PodList{}
+		ExpectWithOffset(1, cl.List(ctx, podList, opts)).ShouldNot(HaveOccurred())
+		if len(podList.Items) == 0 {
+			return fmt.Errorf("job %s associated pod is not scheduled", jobName)
+		}
+
+		for _, c := range podList.Items[0].Status.Conditions {
+			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+				return nil
+			}
+
+		}
+		return fmt.Errorf("waiting for pod %v to be ready", podList.Items[0].Name)
+	}, timeout, pollingInterval).Should(BeNil())
+}
+
+// etcdZeroDownTimeValidatorJob returns k8s job which ensures
+// Etcd cluster zero down time by continuously checking etcd cluster health.
+// This job fails once health check fails and associated pod results in error status.
+func startEtcdZeroDownTimeValidatorJob(ctx context.Context, cl client.Client,
+	etcd *v1alpha1.Etcd, testName string) *batchv1.Job {
+	job := etcdZeroDownTimeValidatorJob(etcd.Name+"-client", testName, etcd.Spec.Etcd.ClientUrlTLS)
+
+	logger.Info(fmt.Sprintf("Creating job %s to ensure etcd zero downtime", job.Name))
+	ExpectWithOffset(1, cl.Create(ctx, job)).ShouldNot(HaveOccurred())
+
+	// Wait until zeroDownTimeValidator job is up and running.
+	checkJobReady(ctx, cl, job.Name)
+	logger.Info(fmt.Sprintf("Job %s is ready", job.Name))
+	return job
+}
+
+//getEtcdLeaderPodName returns the leader pod name by using lease
+func getEtcdLeaderPodName(ctx context.Context, cl client.Client, namespace string) (*types.NamespacedName, error) {
+	leaseList := &v1.LeaseList{}
+	opts := &client.ListOptions{Namespace: namespace}
+	ExpectWithOffset(1, cl.List(ctx, leaseList, opts)).ShouldNot(HaveOccurred())
+
+	for _, lease := range leaseList.Items {
+		if lease.Spec.HolderIdentity == nil {
+			return nil, fmt.Errorf("error occurred while finding leader, etcd lease %q spec.holderIdentity is nil", lease.Name)
+		}
+		if strings.Contains(*lease.Spec.HolderIdentity, "Leader") {
+			return &types.NamespacedName{Namespace: namespace, Name: lease.Name}, nil
+		}
+	}
+	return nil, fmt.Errorf("leader doesn't exist for namespace %q", namespace)
+}
+
+// getPodLogs returns logs for the given pod
+func getPodLogs(ctx context.Context, PodKey *types.NamespacedName, opts *corev1.PodLogOptions) (string, error) {
+	typedClient, err := getKubernetesTypedClient(kubeconfigPath)
+	if err != nil {
+		return "", err
+	}
+
+	req := typedClient.CoreV1().Pods(namespace).GetLogs(PodKey.Name, opts)
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// checkDefragmentationFinished checks defragmentation is finished or not for given etcd.
+func checkDefragmentationFinished(ctx context.Context, cl client.Client, etcd *v1alpha1.Etcd, logger logr.Logger) {
+	// Wait until etcd cluster defragmentation is finish.
+	logger.Info("Waiting for defragmentation to finish")
+	Eventually(func() error {
+		leaderPodKey, err := getEtcdLeaderPodName(ctx, cl, namespace)
+		if err != nil {
+			return err
+		}
+		// Get etcd leader pod logs to ensure etcd cluster defragmentation is finished or not.
+		logs, err := getPodLogs(ctx, leaderPodKey, &corev1.PodLogOptions{
+			Container:    "backup-restore",
+			SinceSeconds: pointer.Int64(60),
+		})
+
+		if err != nil {
+			return fmt.Errorf("error occurred while getting [%s] pod logs, error: %v ", leaderPodKey, err)
+		}
+
+		for i := 0; i < int(multiNodeEtcdReplicas); i++ {
+			if !strings.Contains(logs,
+				fmt.Sprintf("Finished defragmenting etcd member[https://%s-%d.%s-peer.%s.svc:2379]",
+					etcd.Name, i, etcd.Name, namespace)) {
+				return fmt.Errorf("etcd %q defragmentation is not finished for member %q-%d", etcd.Name, etcd.Name, i)
+			}
+		}
+
+		logger.Info("Defragmentation is finished")
+		return nil
+	}, time.Minute*6, pollingInterval).Should(BeNil())
+
+}
+
+// checkEtcdZeroDownTimeValidatorJob ensures etcd cluster health downtime,
+// there is no downtime if given job is active.
+func checkEtcdZeroDownTimeValidatorJob(ctx context.Context, cl client.Client, jobName types.NamespacedName,
+	logger logr.Logger) {
+
+	job := &batchv1.Job{}
+	ExpectWithOffset(1, cl.Get(ctx, jobName, job)).To(Succeed())
+	Expect(job.Status.Failed).Should(BeZero())
+	logger.Info("Etcd Cluster is healthy and there is no downtime")
+}
+
+func purgeEtcd(ctx context.Context, cl client.Client, providers []TestProvider) {
+	for _, p := range providers {
+		e := getEmptyEtcd(fmt.Sprintf("etcd-%s", p.Name), namespace)
+		if err := cl.Get(ctx, client.ObjectKeyFromObject(e), e); err == nil {
+			ExpectWithOffset(1, kutil.DeleteObject(ctx, cl, e)).To(Succeed())
+			Eventually(func() error {
+				ctx, cancelFunc := context.WithTimeout(ctx, timeout)
+				defer cancelFunc()
+				return cl.Get(ctx, client.ObjectKeyFromObject(e), e)
+			}, timeout*3, pollingInterval).Should(matchers.BeNotFoundError())
+			purgeEtcdPVCs(ctx, cl, e.Name)
+		}
+	}
+}

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Etcd", func() {
 
 			By("Wakeup etcd (Scale up from 0->3)")
 			// scale up etcd replicas to 3 and ensures etcd cluster with 3 replicas is ready.
-			ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
 			etcd.Spec.Replicas = multiNodeEtcdReplicas
 			updateAndCheckEtcd(ctx, cl, logger, etcd)
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -49,14 +49,17 @@ const (
 var (
 	logger         = zap.New(zap.WriteTo(GinkgoWriter))
 	typedClient    *kubernetes.Clientset
+	cl             client.Client
 	sourcePath     string
 	kubeconfigPath string
 
-	storePrefix             = "etcd-main"
-	etcdConfigMapVolumeName = "etcd-config-file"
+	storePrefix = "etcd-main"
 
 	etcdKeyPrefix   = "foo"
 	etcdValuePrefix = "bar"
+
+	providers []TestProvider
+	err       error
 )
 
 func TestIntegration(t *testing.T) {
@@ -67,7 +70,7 @@ func TestIntegration(t *testing.T) {
 var _ = BeforeSuite(func() {
 	ctx := context.Background()
 
-	providers, err := getProviders()
+	providers, err = getProviders()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(len(providers)).To(BeNumerically(">", 0))
 
@@ -78,8 +81,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	logger.V(1).Info("setting up k8s client", "KUBECONFIG", kubeconfigPath)
-	cl, err := getKubernetesClient(kubeconfigPath)
+	cl, err = getKubernetesClient(kubeconfigPath)
 	Expect(err).ShouldNot(HaveOccurred())
+
+	typedClient, err = getKubernetesTypedClient(kubeconfigPath)
+	Expect(err).NotTo(HaveOccurred())
 
 	logger.Info("creating namespace", "namespace", etcdNamespace)
 	err = cl.Create(ctx, &corev1.Namespace{

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -35,7 +35,9 @@ import (
 )
 
 const (
-	timeout           = time.Minute * 1
+	singleNodeEtcdTimeout = time.Minute
+	multiNodeEtcdTimeout  = time.Minute * 3
+
 	pollingInterval   = time.Second * 2
 	envSourcePath     = "SOURCE_PATH"
 	envKubeconfigPath = "KUBECONFIG"
@@ -126,5 +128,5 @@ var _ = AfterSuite(func() {
 
 	Eventually(func() error {
 		return cl.Get(ctx, client.ObjectKey{Name: etcdNamespace}, &corev1.Namespace{})
-	}, timeout*2, pollingInterval).Should(matchers.BeNotFoundError())
+	}, time.Minute*2, pollingInterval).Should(matchers.BeNotFoundError())
 })

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -32,7 +32,9 @@ import (
 	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -157,8 +159,12 @@ var (
 		AutoCompactionRetention: &autoCompactionRetention,
 	}
 
-	replicas        = 1
 	storageCapacity = resource.MustParse("10Gi")
+)
+
+const (
+	replicas              int32 = 1
+	multiNodeEtcdReplicas int32 = 3
 )
 
 func getEmptyEtcd(name, namespace string) *v1alpha1.Etcd {
@@ -230,6 +236,13 @@ func getDefaultEtcd(name, namespace, container, prefix string, provider TestProv
 		}
 	}
 
+	return etcd
+}
+
+func getDefaultMultiNodeEtcd(name, namespace, container, prefix string, provider TestProvider) *v1alpha1.Etcd {
+	etcd := getDefaultEtcd(name, namespace, container, prefix, provider)
+	etcd.Spec.Replicas = multiNodeEtcdReplicas
+	etcd.Spec.Backup = v1alpha1.BackupSpec{}
 	return etcd
 }
 
@@ -727,4 +740,121 @@ func getEnvAndExpectNoError(key string) string {
 	val, err := getEnvOrError(key)
 	utilruntime.Must(err)
 	return val
+}
+
+// newTestHelperJob returns the K8s Job for given commands to be executed inside k8s cluster.
+// This test helper job can be used to validate test cases from inside the k8s cluster by executing the bash scripts.
+func newTestHelperJob(jobName string, podSpec *corev1.PodSpec) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespace,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: *podSpec,
+			},
+			BackoffLimit: pointer.Int32(0),
+		},
+	}
+}
+
+// etcdZeroDownTimeValidatorJob returns k8s job which ensures
+// Etcd cluster zero down time by continuously checking etcd cluster health.
+// This job fails once health check fails and associated pod results in error status.
+func etcdZeroDownTimeValidatorJob(etcdSvc, testName string, tls *v1alpha1.TLSConfig) *batchv1.Job {
+	return newTestHelperJob(
+		"etcd-zero-down-time-validator-"+testName,
+		&corev1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "client-url-ca-etcd",
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{
+							SecretName:  tls.TLSCASecretRef.Name,
+							DefaultMode: pointer.Int32(420),
+						},
+					},
+				},
+				{
+					Name: "client-url-etcd-server-tls",
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{
+							SecretName:  tls.ClientTLSSecretRef.Name,
+							DefaultMode: pointer.Int32(420),
+						},
+					},
+				},
+				{
+					Name: "client-url-etcd-client-tls",
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{
+							SecretName:  tls.ServerTLSSecretRef.Name,
+							DefaultMode: pointer.Int32(420),
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "etcd-zero-down-time-validator-" + testName,
+					Image:   "alpine/curl",
+					Command: []string{"/bin/sh"},
+					//To avoid flakiness, consider downtime when curl fails consecutively back-to-back.
+					Args: []string{"-ec",
+						"echo '" +
+							"failed=0 ; threshold=2 ; " +
+							"while [ $failed -lt $threshold ] ; do  " +
+							"$(curl --cacert /var/etcd/ssl/client/ca/ca.crt --cert /var/etcd/ssl/client/client/tls.crt " + "--key /var/etcd/ssl/client/client/tls.key https://" + etcdSvc + ":2379/health -s -f  -o /dev/null ); " +
+							"if [ $? -gt 0 ] ; then let failed++; echo \"etcd is unhealthy and retrying\"; continue;  fi ; " +
+							"echo \"etcd is healthy\";  touch /tmp/healthy; let failed=0; " +
+							"sleep 1; done;  echo \"etcd is unhealthy\"; exit 1;" +
+							"' > test.sh && sh test.sh",
+					},
+					ReadinessProbe: &v1.Probe{
+						InitialDelaySeconds: int32(5),
+						FailureThreshold:    int32(1),
+						PeriodSeconds:       int32(1),
+						SuccessThreshold:    int32(3),
+						Handler: v1.Handler{
+							Exec: &v1.ExecAction{
+								Command: []string{
+									"cat",
+									"/tmp/healthy",
+								},
+							},
+						},
+					},
+					LivenessProbe: &v1.Probe{
+						InitialDelaySeconds: int32(5),
+						FailureThreshold:    int32(1),
+						PeriodSeconds:       int32(1),
+						Handler: v1.Handler{
+							Exec: &v1.ExecAction{
+								Command: []string{
+									"cat",
+									"/tmp/healthy",
+								},
+							},
+						},
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							MountPath: "/var/etcd/ssl/client/ca",
+							Name:      "client-url-ca-etcd",
+						},
+						{
+							MountPath: "/var/etcd/ssl/client/server",
+							Name:      "client-url-etcd-server-tls",
+						},
+						{
+							MountPath: "/var/etcd/ssl/client/client",
+							Name:      "client-url-etcd-client-tls",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+		})
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -805,7 +805,7 @@ func etcdZeroDownTimeValidatorJob(etcdSvc, testName string, tls *v1alpha1.TLSCon
 						"echo '" +
 							"failed=0 ; threshold=2 ; " +
 							"while [ $failed -lt $threshold ] ; do  " +
-							"$(curl --cacert /var/etcd/ssl/client/ca/ca.crt --cert /var/etcd/ssl/client/client/tls.crt " + "--key /var/etcd/ssl/client/client/tls.key https://" + etcdSvc + ":2379/health -s -f  -o /dev/null ); " +
+							"$(curl --cacert /var/etcd/ssl/client/ca/ca.crt --cert /var/etcd/ssl/client/client/tls.crt --key /var/etcd/ssl/client/client/tls.key https://" + etcdSvc + ":2379/health -s -f  -o /dev/null ); " +
 							"if [ $? -gt 0 ] ; then let failed++; echo \"etcd is unhealthy and retrying\"; continue;  fi ; " +
 							"echo \"etcd is healthy\";  touch /tmp/healthy; let failed=0; " +
 							"sleep 1; done;  echo \"etcd is unhealthy\"; exit 1;" +

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -760,7 +760,7 @@ func newTestHelperJob(jobName string, podSpec *corev1.PodSpec) *batchv1.Job {
 }
 
 // etcdZeroDownTimeValidatorJob returns k8s job which ensures
-// Etcd cluster zero down time by continuously checking etcd cluster health.
+// Etcd cluster(size>1) zero down time by continuously checking etcd cluster health.
 // This job fails once health check fails and associated pod results in error status.
 func etcdZeroDownTimeValidatorJob(etcdSvc, testName string, tls *v1alpha1.TLSConfig) *batchv1.Job {
 	return newTestHelperJob(

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -242,7 +242,6 @@ func getDefaultEtcd(name, namespace, container, prefix string, provider TestProv
 func getDefaultMultiNodeEtcd(name, namespace, container, prefix string, provider TestProvider) *v1alpha1.Etcd {
 	etcd := getDefaultEtcd(name, namespace, container, prefix, provider)
 	etcd.Spec.Replicas = multiNodeEtcdReplicas
-	etcd.Spec.Backup = v1alpha1.BackupSpec{}
 	return etcd
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR adds  e2e tests for multi-node etcd for below cases,

 **Etcd cluster operations:**
- [x] Creation of 3-member etcd cluster
- [x] Hibernation
    -  [x] Scale down from 3->0
    - [x] Scale up from 0->3
- [x] Zero downtime rolling updates 
- [x] Zero downtime maintenance operations - Defragmentation
- [x] Deletion of 3-member etcd cluster

 **Scaling**
- [x]  Scale up of a healthy cluster (from 1->3)
- [x]  Scale down of a healthy cluster (from 3->1) - (but commented, because this case not yet supported.)


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.
[](url)
Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
