### PR TITLE
Sort members in etcd status

### DIFF
--- a/pkg/health/etcdmember/builder.go
+++ b/pkg/health/etcdmember/builder.go
@@ -15,6 +15,7 @@
 package etcdmember
 
 import (
+	"sort"
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
@@ -105,6 +106,10 @@ func (b *defaultBuilder) Build() []druidv1alpha1.EtcdMemberStatus {
 
 		members = append(members, memberStatus)
 	}
+
+	sort.Slice(members, func(i, j int) bool {
+		return members[i].Name < members[j].Name
+	})
 
 	return members
 }

--- a/pkg/health/etcdmember/builder_test.go
+++ b/pkg/health/etcdmember/builder_test.go
@@ -116,15 +116,8 @@ var _ = Describe("Builder", func() {
 				memberRoleMember = druidv1alpha1.EtcdRoleMember
 			})
 
-			It("should not add any members", func() {
+			It("should not add any members but sort them", func() {
 				builder.WithResults([]Result{
-					&result{
-						MemberID:     pointer.StringPtr("1"),
-						MemberName:   "member1",
-						MemberRole:   &memberRoleLeader,
-						MemberStatus: druidv1alpha1.EtcdMemberStatusUnknown,
-						MemberReason: "unknown reason",
-					},
 					&result{
 						MemberID:     pointer.StringPtr("2"),
 						MemberName:   "member2",
@@ -132,28 +125,34 @@ var _ = Describe("Builder", func() {
 						MemberStatus: druidv1alpha1.EtcdMemberStatusReady,
 						MemberReason: "foo reason",
 					},
+					&result{
+						MemberID:     pointer.StringPtr("1"),
+						MemberName:   "member1",
+						MemberRole:   &memberRoleLeader,
+						MemberStatus: druidv1alpha1.EtcdMemberStatusUnknown,
+						MemberReason: "unknown reason",
+					},
 				})
 
 				conditions := builder.Build()
 
-				Expect(conditions).To(ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"Name":               Equal("member1"),
-						"ID":                 PointTo(Equal("1")),
-						"Role":               PointTo(Equal(druidv1alpha1.EtcdRoleLeader)),
-						"Status":             Equal(druidv1alpha1.EtcdMemberStatusUnknown),
-						"Reason":             Equal("unknown reason"),
-						"LastTransitionTime": Equal(metav1.NewTime(now)),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"Name":               Equal("member2"),
-						"ID":                 PointTo(Equal("2")),
-						"Role":               PointTo(Equal(druidv1alpha1.EtcdRoleMember)),
-						"Status":             Equal(druidv1alpha1.EtcdMemberStatusReady),
-						"Reason":             Equal("foo reason"),
-						"LastTransitionTime": Equal(metav1.NewTime(now)),
-					}),
-				))
+				Expect(conditions).To(HaveLen(2))
+				Expect(conditions[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Name":               Equal("member1"),
+					"ID":                 PointTo(Equal("1")),
+					"Role":               PointTo(Equal(druidv1alpha1.EtcdRoleLeader)),
+					"Status":             Equal(druidv1alpha1.EtcdMemberStatusUnknown),
+					"Reason":             Equal("unknown reason"),
+					"LastTransitionTime": Equal(metav1.NewTime(now)),
+				}))
+				Expect(conditions[1]).To(MatchFields(IgnoreExtras, Fields{
+					"Name":               Equal("member2"),
+					"ID":                 PointTo(Equal("2")),
+					"Role":               PointTo(Equal(druidv1alpha1.EtcdRoleMember)),
+					"Status":             Equal(druidv1alpha1.EtcdMemberStatusReady),
+					"Reason":             Equal("foo reason"),
+					"LastTransitionTime": Equal(metav1.NewTime(now)),
+				}))
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR makes the members check to sort the array before the `etcd` status is updated.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
