### PR TITLE
Remove startup and liveness probes

### DIFF
--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -995,33 +995,6 @@ func validateEtcdWithDefaults(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSe
 								"PeriodSeconds":       Equal(int32(5)),
 								"FailureThreshold":    Equal(int32(5)),
 							})),
-							"LivenessProbe": PointTo(MatchFields(IgnoreExtras, Fields{
-								"Handler": MatchFields(IgnoreExtras, Fields{
-									"Exec": PointTo(MatchFields(IgnoreExtras, Fields{
-										"Command": MatchAllElements(cmdIterator, Elements{
-											"/bin/sh": Equal("/bin/sh"),
-											"-ec":     Equal("-ec"),
-											fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=http://%s-local:%d get foo --consistency=s", instance.Name, clientPort): Equal(fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=http://%s-local:%d get foo --consistency=s", instance.Name, clientPort)),
-										}),
-									})),
-								}),
-								"InitialDelaySeconds": Equal(int32(15)),
-								"PeriodSeconds":       Equal(int32(5)),
-								"FailureThreshold":    Equal(int32(5)),
-							})),
-							"StartupProbe": PointTo(MatchFields(IgnoreExtras, Fields{
-								"Handler": MatchFields(IgnoreExtras, Fields{
-									"Exec": PointTo(MatchFields(IgnoreExtras, Fields{
-										"Command": MatchAllElements(cmdIterator, Elements{
-											"/bin/sh": Equal("/bin/sh"),
-											"-ec":     Equal("-ec"),
-											fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=http://%s-local:%d get foo --consistency=s", instance.Name, clientPort): Equal(fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=http://%s-local:%d get foo --consistency=s", instance.Name, clientPort)),
-										}),
-									})),
-								}),
-								"PeriodSeconds":    Equal(int32(5)),
-								"FailureThreshold": Equal(int32(24)),
-							})),
 							"VolumeMounts": MatchAllElements(volumeMountIterator, Elements{
 								instance.Name: MatchFields(IgnoreExtras, Fields{
 									"Name":      Equal(instance.Name),
@@ -1380,33 +1353,6 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								"InitialDelaySeconds": Equal(int32(15)),
 								"PeriodSeconds":       Equal(int32(5)),
 								"FailureThreshold":    Equal(int32(5)),
-							})),
-							"LivenessProbe": PointTo(MatchFields(IgnoreExtras, Fields{
-								"Handler": MatchFields(IgnoreExtras, Fields{
-									"Exec": PointTo(MatchFields(IgnoreExtras, Fields{
-										"Command": MatchAllElements(cmdIterator, Elements{
-											"/bin/sh": Equal("/bin/sh"),
-											"-ec":     Equal("-ec"),
-											fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", instance.Name, clientPort): Equal(fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", instance.Name, clientPort)),
-										}),
-									})),
-								}),
-								"InitialDelaySeconds": Equal(int32(15)),
-								"PeriodSeconds":       Equal(int32(5)),
-								"FailureThreshold":    Equal(int32(5)),
-							})),
-							"StartupProbe": PointTo(MatchFields(IgnoreExtras, Fields{
-								"Handler": MatchFields(IgnoreExtras, Fields{
-									"Exec": PointTo(MatchFields(IgnoreExtras, Fields{
-										"Command": MatchAllElements(cmdIterator, Elements{
-											"/bin/sh": Equal("/bin/sh"),
-											"-ec":     Equal("-ec"),
-											fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", instance.Name, clientPort): Equal(fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", instance.Name, clientPort)),
-										}),
-									})),
-								}),
-								"PeriodSeconds":    Equal(int32(5)),
-								"FailureThreshold": Equal(int32(24)),
 							})),
 							"VolumeMounts": MatchAllElements(volumeMountIterator, Elements{
 								*instance.Spec.VolumeClaimTemplate: MatchFields(IgnoreExtras, Fields{

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -202,25 +202,6 @@ func (c *component) syncStatefulset(ctx context.Context, sts *appsv1.StatefulSet
 							PeriodSeconds:       5,
 							FailureThreshold:    5,
 						},
-						LivenessProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								Exec: &corev1.ExecAction{
-									Command: c.values.LivenessProbeCommand,
-								},
-							},
-							InitialDelaySeconds: 15,
-							PeriodSeconds:       5,
-							FailureThreshold:    5,
-						},
-						StartupProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								Exec: &corev1.ExecAction{
-									Command: c.values.LivenessProbeCommand,
-								},
-							},
-							PeriodSeconds:    5,
-							FailureThreshold: 24,
-						},
 						Ports:        getEtcdPorts(c.values),
 						Resources:    getEtcdResources(c.values),
 						Env:          getEtcdEnvVars(c.values),

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -477,33 +477,6 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 								"PeriodSeconds":       Equal(int32(5)),
 								"FailureThreshold":    Equal(int32(5)),
 							})),
-							"LivenessProbe": PointTo(MatchFields(IgnoreExtras, Fields{
-								"Handler": MatchFields(IgnoreExtras, Fields{
-									"Exec": PointTo(MatchFields(IgnoreExtras, Fields{
-										"Command": MatchAllElements(cmdIterator, Elements{
-											"/bin/sh": Equal("/bin/sh"),
-											"-ec":     Equal("-ec"),
-											fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", values.Name, clientPort): Equal(fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", values.Name, clientPort)),
-										}),
-									})),
-								}),
-								"InitialDelaySeconds": Equal(int32(15)),
-								"PeriodSeconds":       Equal(int32(5)),
-								"FailureThreshold":    Equal(int32(5)),
-							})),
-							"StartupProbe": PointTo(MatchFields(IgnoreExtras, Fields{
-								"Handler": MatchFields(IgnoreExtras, Fields{
-									"Exec": PointTo(MatchFields(IgnoreExtras, Fields{
-										"Command": MatchAllElements(cmdIterator, Elements{
-											"/bin/sh": Equal("/bin/sh"),
-											"-ec":     Equal("-ec"),
-											fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", values.Name, clientPort): Equal(fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/client/ca/ca.crt --cert=/var/etcd/ssl/client/client/tls.crt --key=/var/etcd/ssl/client/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=s", values.Name, clientPort)),
-										}),
-									})),
-								}),
-								"PeriodSeconds":    Equal(int32(5)),
-								"FailureThreshold": Equal(int32(24)),
-							})),
 							"Resources": Equal(etcdResources),
 							"VolumeMounts": MatchAllElements(volumeMountIterator, Elements{
 								values.VolumeClaimTemplateName: MatchFields(IgnoreExtras, Fields{

--- a/pkg/component/etcd/statefulset/values.go
+++ b/pkg/component/etcd/statefulset/values.go
@@ -58,7 +58,6 @@ type Values struct {
 
 	EtcdCommand           []string
 	ReadinessProbeCommand []string
-	LivenessProbeCommand  []string
 	EtcdBackupCommand     []string
 
 	EnableClientTLS string

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -125,11 +125,6 @@ func GenerateValues(
 	// when it has an active connection to the cluster and the cluster maintains a quorum.
 	values.ReadinessProbeCommand = getProbeCommand(values, linearizable)
 
-	// Use serializability for liveness probe because we are only interested in the health of this particular member.
-	// Those read requests will especially succeed if quorum is lost. Usually it doesn't make sense to also restart
-	// members which are healthy in general, independent of the quorum situation.
-	values.LivenessProbeCommand = getProbeCommand(values, serializable)
-
 	values.EtcdBackupCommand = getBackupRestoreCommand(values)
 
 	return values


### PR DESCRIPTION
The enablement of startup/liveness probes through https://github.com/gardener/etcd-druid/pull/396 showed that they cause more harm than good:
- The startup time of etcds can vary depending on the state and amount of data
- If startup does not happen in the expected time, the failing probes kill the container which does not help to solve the issue at all but will end in a endless loop of restarts
- Liveness probes had been disabled for a long time before which never caused issues in our experience.
- Other communities have come to a similar conclusion, see https://github.com/improbable-eng/etcd-cluster-operator/blob/master/docs/operations.md#why-arent-there-liveness-probes-for-the-etcd-pods

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Cherry pick of [`a8cb33`](https://github.com/gardener/etcd-druid/pull/423/commits/a8cb336d3d4dca9100f673b2baa96ad3e01b8bba)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator @timuthy 
Liveness and startup probes for etcd were removed. After activating them, we noticed that they cause more harm than good since the startup time for etcd clusters varies and isn't predicable. Killing the `etcd` container in such a case doesn't solve the situation and will rather end in an endless loop of restarts. This change will cause a restart of etcd clusters.
```
