### PR TITLE
[Cherry Pick] ci:component:github.com/gardener/etcd-backup-restore:v0.20.1->v0.20.2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.20.1"
+  tag: "v0.20.2"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry Pick of PR: https://github.com/gardener/etcd-druid/pull/439

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
``` improvement operator github.com/gardener/etcd-backup-restore #537 @ishan16696
Decreases the likelihood of potential race condition between the go-routines while closing the snapshotter.
```

``` improvement operator github.com/gardener/etcd-backup-restore #540 @aaronfern
[bug-fix] backup-restore does not return error when it fails to update PeerURL of member.
```
