### PR TITLE
Fix e2e tests that failed due to changes made to condition handling

### DIFF
--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -217,9 +217,9 @@ func hibernateAndCheckEtcd(ctx context.Context, cl client.Client, logger logr.Lo
 		}
 
 		for _, c := range etcd.Status.Conditions {
-			if c.Status != v1alpha1.ConditionUnknown {
+			if c.Status != v1alpha1.ConditionTrue {
 				return fmt.Errorf("etcd %s status condition is %q, but expected to be %s ",
-					etcd.Name, c.Status, v1alpha1.ConditionUnknown)
+					etcd.Name, c.Status, v1alpha1.ConditionTrue)
 			}
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
With the inclusion of #415, some changes were made to the way etcd-druid maintains conditions in the etcd status. This has affected e2e tests introduced in #418 as these tests expect certain conditions that are now not the case with #415

This PR updates the tests so that they expect the correct conditions in line with the way etcd-druid now maintains the conditions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@seshachalam-yv 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
