### PR TITLE
[hotfix-v0.13] Remove BackupReady condition from PDB calculation (#441)

### DIFF
--- a/controllers/etcd_custodian_controller.go
+++ b/controllers/etcd_custodian_controller.go
@@ -193,18 +193,11 @@ func calculatePDBminAvailable(etcd *druidv1alpha1.Etcd) int {
 	}
 
 	allMembersReady := false
-	backupReady := false
 	for _, condition := range etcd.Status.Conditions {
 		if condition.Type == druidv1alpha1.ConditionTypeAllMembersReady &&
 			condition.Status == druidv1alpha1.ConditionTrue {
 			allMembersReady = true
-			continue
-		}
-
-		if condition.Type == druidv1alpha1.ConditionTypeBackupReady &&
-			condition.Status == druidv1alpha1.ConditionTrue {
-			backupReady = true
-			continue
+			break
 		}
 	}
 
@@ -220,10 +213,6 @@ func calculatePDBminAvailable(etcd *druidv1alpha1.Etcd) int {
 			}
 		}
 		values = append(values, readyMembers)
-	}
-
-	if backupReady {
-		values = append(values, clusterSize)
 	}
 
 	// calculate max value

--- a/controllers/etcd_custodian_controller_test.go
+++ b/controllers/etcd_custodian_controller_test.go
@@ -70,27 +70,12 @@ var _ = Describe("Custodian Controller", func() {
 
 			etcd.Status.Conditions = []druidv1alpha1.Condition{
 				{Type: druidv1alpha1.ConditionTypeAllMembersReady, Status: druidv1alpha1.ConditionFalse},
-				{Type: druidv1alpha1.ConditionTypeBackupReady, Status: druidv1alpha1.ConditionFalse},
 			}
 
 			It("should use all ready members if not all members are ready", func() {
 				Expect(calculatePDBminAvailable(etcd)).To(BeEquivalentTo(4))
 			})
 		})
-
-		When("having a multi node cluster", func() {
-			etcd := getEtcdWithStatus(5)
-
-			etcd.Status.Conditions = []druidv1alpha1.Condition{
-				{Type: druidv1alpha1.ConditionTypeAllMembersReady, Status: druidv1alpha1.ConditionTrue},
-				{Type: druidv1alpha1.ConditionTypeBackupReady, Status: druidv1alpha1.ConditionTrue},
-			}
-
-			It("should use clusterSize if backup is ready", func() {
-				Expect(calculatePDBminAvailable(etcd)).To(BeEquivalentTo(5))
-			})
-		})
-
 	})
 })
 
@@ -112,7 +97,6 @@ func getEtcdStatus(replicas int) druidv1alpha1.EtcdStatus {
 		Members:     members,
 		Conditions: []druidv1alpha1.Condition{
 			{Type: druidv1alpha1.ConditionTypeAllMembersReady, Status: druidv1alpha1.ConditionTrue},
-			{Type: druidv1alpha1.ConditionTypeBackupReady, Status: druidv1alpha1.ConditionFalse},
 		},
 	}
 }

--- a/docs/proposals/multi-node/README.md
+++ b/docs/proposals/multi-node/README.md
@@ -1345,9 +1345,6 @@ Hence, it is better to keep `etcd-druid` altogether agnostic of issues related t
 
 This proposal recommends that `etcd-druid` should deploy [`PodDisruptionBudget`](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) (`minAvailable` set to `floor(<cluster size>/2) + 1`) for multi-node etcd clusters (if `AllMembersReady` [condition](#conditions) is `true`) to ensure that any planned disruptive operation can try and honour the disruption budget to ensure high availability of the etcd cluster while making potentially disrupting maintenance operations.
 
-In addition, it is recommended to toggle the `minAvailable ` field between `floor(<cluster size>/2) + 1` and `<cluster size>` whenever the `BackupReady` condition toggles between `true` and `false`.
-This is to disable eviction of member pods when backups are not healthy.
-
 Also, it is recommended to toggle the `minAvailable` field between `floor(<cluster size>/2)` and `<number of members with status Ready true>` whenever the `AllMembersReady` condition toggles between `true` and `false`.
 This is to disable eviction of any member pods when not all members are `Ready`.
 


### PR DESCRIPTION
Earlier failing backups resulted in PDBs not tolerating any disruptions. This becomes esp. critical if such failures need to be fixed through rolling updates which are then blocked by the PDB configuration.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind bug

**What this PR does / why we need it**:
Cherry pick [`270797`](https://github.com/gardener/etcd-druid/commit/27079789a878132aea185a069376f4a0e1047f26)


**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator github.com/gardener/etcd-backup-restore #441 @timuthy 
A bug has been fixed that caused the wrong `minAvailable` configuration being calculated for multi-node etcd `PodDisruptionBudget`.
```
```other operator github.com/gardener/etcd-backup-restore #441 @timuthy 
The `BackupReady` condition is not considered anymore when the `PodDisruptionBudget` configuration is calculated. This earlier blocked rolling out fixes that potentially solved problems with backup procedures.
```
