### PR TITLE
Harmonize kustomizations

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: garden
+namespace: etcd-druid-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
@@ -17,7 +17,7 @@ resources:
   - ../rbac
   - ../manager
 
-patches:
+patchesStrategicMerge:
   - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
 - manager.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: garden
+  name: system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -11,16 +11,16 @@ metadata:
   name: controller
   namespace: system
   labels:
-    control-plane: etcd-druid
+    control-plane: controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: etcd-druid
+      control-plane: controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: etcd-druid
+        control-plane: controller-manager
     spec:
       containers:
         - command:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,3 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: garden
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -31,3 +37,4 @@ spec:
               cpu: 100m
               memory: 20Mi
       terminationGracePeriodSeconds: 10
+      serviceAccountName: controller-manager

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -7,6 +7,6 @@ roleRef:
   kind: Role
   name: leader-election-role
 subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: test
+  - kind: ServiceAccount
+    namespace: garden
+    name: controller-manager

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
   - kind: ServiceAccount
-    namespace: garden
+    namespace: system
     name: controller-manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -11,6 +10,7 @@ rules:
   resources:
   - pods
   verbs:
+  - get
   - list
   - watch
   - delete

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -7,6 +7,6 @@ roleRef:
   kind: ClusterRole
   name: manager-role
 subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: test
+  - kind: ServiceAccount
+    namespace: garden
+    name: controller-manager

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
   - kind: ServiceAccount
-    namespace: garden
+    namespace: system
     name: controller-manager

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: garden

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: controller-manager
-  namespace: garden
+  namespace: system


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR add a missing `ServiceAccount` in the kustomization `/config` folder. Additionally the namespaces have been harmonised to use the same default namespace `etcd-druid-system`.

You can evaluate the output by running:

```shell
kustomize build config/default
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
