### PR TITLE
Added e2e tests for single member restoration

### DIFF
--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -24,6 +24,7 @@ import (
 	k8s_labels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -62,7 +63,7 @@ var _ = Describe("Etcd", func() {
 
 	Context("when multi-node is configured", func() {
 		It("should perform etcd operations", func() {
-			ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
+			ctx, cancelFunc := context.WithTimeout(parentCtx, 15*time.Minute)
 			defer cancelFunc()
 
 			etcd := getDefaultMultiNodeEtcd(etcdName, namespace, storageContainer, storePrefix, provider)
@@ -105,6 +106,15 @@ var _ = Describe("Etcd", func() {
 			// K8s job zeroDownTimeValidator will fail, if there is any downtime in Etcd cluster health.
 			checkEtcdZeroDownTimeValidatorJob(ctx, cl, client.ObjectKeyFromObject(job), objLogger)
 
+			By("Single member restoration")
+			objLogger.Info("Delete one member pod")
+			deletePodAndCheckSts(ctx, cl, logger, etcd, "etcd-aws-2")
+			checkEtcdReady(ctx, cl, logger, etcd, multiNodeEtcdTimeout)
+
+			objLogger.Info("Delete member dir of one member pod")
+			deleteMemberDir(ctx, cl, logger, etcd, "etcd-aws-2")
+			checkEtcdReady(ctx, cl, logger, etcd, multiNodeEtcdTimeout)
+
 			By("Delete etcd")
 			deleteAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 		})
@@ -137,6 +147,50 @@ var _ = Describe("Etcd", func() {
 		})
 	})
 })
+
+func deleteMemberDir(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd, podName string) {
+	Expect(deleteDir(kubeconfigPath, namespace, podName, "backup-restore", "/var/etcd/data/new.etcd/member")).To(Succeed())
+	checkUnreadySts(ctx, cl, logger, etcd)
+	checkReadySts(ctx, cl, logger, etcd)
+}
+
+func deletePodAndCheckSts(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd, podName string) {
+	pod := &corev1.Pod{}
+	ExpectWithOffset(1, cl.Get(ctx, types.NamespacedName{Name: podName, Namespace: "shoot"}, pod)).To(Succeed())
+	ExpectWithOffset(1, cl.Delete(ctx, pod, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+	checkUnreadySts(ctx, cl, logger, etcd)
+	checkReadySts(ctx, cl, logger, etcd)
+}
+
+func checkUnreadySts(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd) {
+	logger.Info("waiting for sts to become unready", "statefulSetName", "etcd-aws")
+	Eventually(func() error {
+		sts := &appsv1.StatefulSet{}
+		if err := cl.Get(ctx, client.ObjectKeyFromObject(etcd), sts); err != nil {
+			return err
+		}
+		if sts.Status.ReadyReplicas == *sts.Spec.Replicas {
+			return fmt.Errorf("sts %s is still in ready state", "etcd-aws")
+		}
+		return nil
+	}, multiNodeEtcdTimeout, pollingInterval).Should(BeNil())
+	logger.Info("sts is unready", "statefulSetName", "etcd-aws")
+}
+
+func checkReadySts(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd) {
+	logger.Info("waiting for sts to become ready again", "statefulSetName", "etcd-aws")
+	Eventually(func() error {
+		sts := &appsv1.StatefulSet{}
+		if err := cl.Get(ctx, client.ObjectKeyFromObject(etcd), sts); err != nil {
+			return err
+		}
+		if sts.Status.ReadyReplicas != *sts.Spec.Replicas {
+			return fmt.Errorf("sts %s unready", "etcd-aws")
+		}
+		return nil
+	}, multiNodeEtcdTimeout, pollingInterval).Should(BeNil())
+	logger.Info("sts is ready", "statefulSetName", "etcd-aws")
+}
 
 // checkEventuallyEtcdRollingUpdateDone is a helper function, uses Gomega Eventually.
 // Returns the function until etcd rolling updates is done for given timeout and polling interval or
@@ -175,13 +229,15 @@ func checkEventuallyEtcdRollingUpdateDone(ctx context.Context, cl client.Client,
 
 // hibernateAndCheckEtcd scales down etcd replicas to zero and ensures
 func hibernateAndCheckEtcd(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd, timeout time.Duration) {
-	ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
-	etcd.Spec.Replicas = 0
-	etcd.SetAnnotations(
-		map[string]string{
-			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-		})
-	ExpectWithOffset(1, cl.Update(ctx, etcd)).ShouldNot(HaveOccurred())
+	ExpectWithOffset(1, retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		ExpectWithOffset(2, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+		etcd.SetAnnotations(
+			map[string]string{
+				v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+			})
+		etcd.Spec.Replicas = 0
+		return cl.Update(ctx, etcd)
+	})).ToNot(HaveOccurred())
 	logger.Info("Waiting to hibernate")
 
 	logger.Info("Checking etcd")
@@ -242,11 +298,16 @@ func updateAndCheckEtcd(ctx context.Context, cl client.Client, logger logr.Logge
 	oldStsObservedGeneration, oldEtcdObservedGeneration := sts.Status.ObservedGeneration, *etcd.Status.ObservedGeneration
 
 	// update reconcile annotation, druid to reconcile and update the changes.
-	etcd.SetAnnotations(
-		map[string]string{
-			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-		})
-	ExpectWithOffset(1, cl.Update(ctx, etcd)).ShouldNot(HaveOccurred())
+	ExpectWithOffset(1, retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		etcdObj := &v1alpha1.Etcd{}
+		ExpectWithOffset(1, cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcdObj)).To(Succeed())
+		etcdObj.SetAnnotations(
+			map[string]string{
+				v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+			})
+		etcdObj.Spec = etcd.Spec
+		return cl.Update(ctx, etcdObj)
+	})).ToNot(HaveOccurred())
 
 	// Ensuring update is successful by verifying
 	// ObservedGeneration ID of sts, etcd before and after update done.

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	singleNodeEtcdTimeout = time.Minute
-	multiNodeEtcdTimeout  = time.Minute * 3
+	multiNodeEtcdTimeout  = time.Minute * 5
 
 	pollingInterval   = time.Second * 2
 	envSourcePath     = "SOURCE_PATH"

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -735,6 +735,15 @@ func deleteDir(kubeconfigPath, namespace, podName, containerName string, dirPath
 	return nil
 }
 
+func corruptDBFile(kubeconfigPath, namespace, podName, containerName string, dirPath string) error {
+	cmd := fmt.Sprintf("echo destrory > %s", dirPath)
+	stdout, stderr, err := executeRemoteCommand(kubeconfigPath, namespace, podName, containerName, cmd)
+	if err != nil || stdout != "" {
+		return fmt.Errorf("failed to corrupt file %s for %s: stdout: %s; stderr: %s; err: %v", dirPath, podName, stdout, stderr, err)
+	}
+	return nil
+}
+
 func getEnvAndExpectNoError(key string) string {
 	val, err := getEnvOrError(key)
 	utilruntime.Must(err)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -739,7 +739,7 @@ func corruptDBFile(kubeconfigPath, namespace, podName, containerName string, dir
 	cmd := fmt.Sprintf("echo destrory > %s", dirPath)
 	stdout, stderr, err := executeRemoteCommand(kubeconfigPath, namespace, podName, containerName, cmd)
 	if err != nil || stdout != "" {
-		return fmt.Errorf("failed to corrupt file %s for %s: stdout: %s; stderr: %s; err: %v", dirPath, podName, stdout, stderr, err)
+		return fmt.Errorf("failed to corrupt db %s for %s: stdout: %s; stderr: %s; err: %v", dirPath, podName, stdout, stderr, err)
 	}
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR Adds a few e2e tests for the multi node scenario to test single node restoration.

It adds the following tests:
1. Deletion of one member pod
2. Deletion of member dir of one member
3. Corruption of DB file of one member

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Added e2e tests to check single member restoration in multi node setup
```
