### PR TITLE
fix serviceaccount name in chart

### DIFF
--- a/charts/druid/templates/service-account.yaml
+++ b/charts/druid/templates/service-account.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}
+  name: etcd-druid
   namespace: {{ .Release.Namespace }}
   labels:
     gardener.cloud/role: etcd-druid


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     control-plane
"/kind" identifiers:     bug

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
It fixes the helm chart which prevents installation

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-druid/issues/457

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
