### PR TITLE
Fix make manifest target

### DIFF
--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -300,6 +300,17 @@ spec:
                   clientPort:
                     format: int32
                     type: integer
+                  clientService:
+                    description: ClientService defines the parameters of the client
+                      service that a user can specify
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations specify the annotations that should
+                          be added to the client service
+                        type: object
+                    type: object
                   clientUrlTls:
                     description: ClientUrlTLS contains the ca, server TLS and client
                       TLS secrets for client communication to ETCD cluster
@@ -1688,8 +1699,12 @@ spec:
                   for this resource.
                 format: int64
                 type: integer
+              peerUrlTLSEnabled:
+                description: PeerUrlTLSEnabled captures the state of peer url TLS
+                  being enabled for the etcd member(s)
+                type: boolean
               ready:
-                description: Ready represents the readiness of the etcd resource.
+                description: Ready is `true` if all etcd replicas are ready.
                 type: boolean
               readyReplicas:
                 description: ReadyReplicas is the count of replicas being ready in

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -284,14 +284,6 @@ spec:
               etcd:
                 description: EtcdConfig defines parameters associated etcd deployed
                 properties:
-                  clientService:
-                    description: ClientService defines properties that allow the client service to be manipulated from the etcd spec
-                    properties: 
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
                   authSecretRef:
                     description: SecretReference represents a Secret Reference. It
                       has enough information to retrieve secret in any namespace
@@ -308,6 +300,17 @@ spec:
                   clientPort:
                     format: int32
                     type: integer
+                  clientService:
+                    description: ClientService defines the parameters of the client
+                      service that a user can specify
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations specify the annotations that should
+                          be added to the client service
+                        type: object
+                    type: object
                   clientUrlTls:
                     description: ClientUrlTLS contains the ca, server TLS and client
                       TLS secrets for client communication to ETCD cluster
@@ -1696,6 +1699,10 @@ spec:
                   for this resource.
                 format: int64
                 type: integer
+              peerUrlTLSEnabled:
+                description: PeerUrlTLSEnabled captures the state of peer url TLS
+                  being enabled for the etcd member(s)
+                type: boolean
               ready:
                 description: Ready is `true` if all etcd replicas are ready.
                 type: boolean
@@ -1716,9 +1723,6 @@ spec:
                   etcd cluster.
                 format: int32
                 type: integer
-              peerUrlTLSEnabled:
-                description: PeerUrlTLSEnabled captures the state of the peer url TLS being enabled for the etcd member(s)
-                type: boolean
             type: object
         type: object
     served: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -8,16 +9,20 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
+  - configmaps
+  - serviceaccounts
+  - services
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
-  - delete
 - apiGroups:
   - ""
   resources:
-  - secrets
   - endpoints
   verbs:
   - get
@@ -33,108 +38,9 @@ rules:
   - create
   - get
   - list
-  - watch
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - roles
-  - rolebindings
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  - apps
-  resources:
-  - services
-  - configmaps
-  - statefulsets
-  verbs:
-  - get
-  - list
   - patch
   - update
   - watch
-  - create
-  - delete
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - batch
-  resources:
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-- apiGroups:
-  - druid.gardener.cloud
-  resources:
-  - etcds
-  - etcdcopybackupstasks
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - druid.gardener.cloud
-  resources:
-  - etcds/status
-  - etcds/finalizers
-  - etcdcopybackupstasks/status
-  - etcdcopybackupstasks/finalizers
-  verbs:
-  - get
-  - update
-  - patch
-  - create
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
 - apiGroups:
   - ""
   resources:
@@ -144,14 +50,146 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - etcdcopybackupstasks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - etcdcopybackupstasks/finalizers
+  - etcdcopybackupstasks/status
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - etcds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - etcds/finalizers
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - etcds/status
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
   verbs:
+  - create
+  - delete
   - get
   - list
-  - watch
-  - create
-  - update
   - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
   - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/compaction_lease_controller.go
+++ b/controllers/compaction_lease_controller.go
@@ -88,6 +88,7 @@ func (lc *CompactionLeaseController) InitializeControllerWithImageVector() (*Com
 // +kubebuilder:rbac:groups=druid.gardener.cloud,resources=etcds,verbs=get;list;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;create;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=list;watch;delete;get
 
 // Reconcile reconciles the compaction job.
 func (lc *CompactionLeaseController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/etcd_controller.go
+++ b/controllers/etcd_controller.go
@@ -224,9 +224,16 @@ func buildPredicate(ignoreOperationAnnotation bool) predicate.Predicate {
 }
 
 // +kubebuilder:rbac:groups=druid.gardener.cloud,resources=etcds,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=druid.gardener.cloud,resources=etcds/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=druid.gardener.cloud,resources=etcds/finalizers,verbs=get;update;patch;create
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts;services;configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;get;list;watch;patch;update
 
 // Reconcile reconciles the etcd.
 func (r *EtcdReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/etcd_custodian_controller.go
+++ b/controllers/etcd_custodian_controller.go
@@ -70,7 +70,7 @@ func NewEtcdCustodian(mgr manager.Manager, config controllersconfig.EtcdCustodia
 }
 
 // +kubebuilder:rbac:groups=druid.gardener.cloud,resources=etcds,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=druid.gardener.cloud,resources=etcds/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=druid.gardener.cloud,resources=etcds/status,verbs=get;update;patch;create
 
 // Reconcile reconciles the etcd.
 func (ec *EtcdCustodian) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/etcdcopybackupstask_controller.go
+++ b/controllers/etcdcopybackupstask_controller.go
@@ -56,6 +56,9 @@ type EtcdCopyBackupsTaskReconciler struct {
 	logger       logr.Logger
 }
 
+// +kubebuilder:rbac:groups=druid.gardener.cloud,resources=etcdcopybackupstasks,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=druid.gardener.cloud,resources=etcdcopybackupstasks/status;etcdcopybackupstasks/finalizers,verbs=get;update;patch;create
+
 // NewEtcdCopyBackupsTaskReconciler creates a new EtcdCopyBackupsTaskReconciler.
 func NewEtcdCopyBackupsTaskReconciler(mgr manager.Manager) (*EtcdCopyBackupsTaskReconciler, error) {
 	return (&EtcdCopyBackupsTaskReconciler{

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -48,7 +48,7 @@ func NewSecret(mgr manager.Manager) *Secret {
 	}
 }
 
-// +kubebuilder:rbac:groups=druid.gardener.cloud,resources=secrets,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update;patch
 
 // Reconcile reconciles the secret.
 func (s *Secret) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind technical-debt

**What this PR does / why we need it**:
There is an issue where `config/rbac/role.yaml` gets incorrectly overwritten when `make manifests` is run. This is due to incorrect/incomplete kubebuilder RBACs 
This PR adds and corrects RBACs so that `make manifests` now generates the correct role file

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
