### PR TITLE
Updated condition that adds the scale-up annotation to the sts

### DIFF
--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -283,10 +283,10 @@ func immutableFieldUpdate(sts *appsv1.StatefulSet, val Values) bool {
 }
 
 func clusterScaledUpToMultiNode(val *Values, sts *appsv1.StatefulSet) bool {
-	if sts.Spec.Replicas != nil {
+	if sts != nil && sts.Spec.Replicas != nil {
 		return val.Replicas > 1 && *sts.Spec.Replicas == 1
 	}
-	return false
+	return val.Replicas > 1 && val.StatusReplicas == 1
 }
 
 func (c *component) createOrPatch(ctx context.Context, sts *appsv1.StatefulSet, replicas int32) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area disaster-recovery
/area high-availability
/kind bug

**What this PR does / why we need it**:
`etcd-druid` contains a `scale-up` feature where a single member etcd can be scaled up to a multi member etcd cluster.

Ideally the `statefulset` has to be patched to update (increase) the number of replicas so that new members are added to the cluster. In addition, etcd cluster scale-up should also work when the `statefulset` is recreated rather than patched.

There was a bug where the etcd cluster would not scale up correctly if the `statefulset` was recreated and would lead to a broken cluster
This PR fixes a bug where the cluster would not scale up correctly for recreated `statefulsets`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The decision to add the scale-up annotation to the etcd sts now considers the etcd status if an existing sts is not present
```
