### PR TITLE
Make `GetConfigmapName` consistent

### DIFF
--- a/pkg/utils/names.go
+++ b/pkg/utils/names.go
@@ -37,7 +37,7 @@ func GetServiceAccountName(etcd *druidv1alpha1.Etcd) string {
 
 // GetConfigmapName returns the name of the configmap based on the given `etcd` object.
 func GetConfigmapName(etcd *druidv1alpha1.Etcd) string {
-	return fmt.Sprintf("etcd-bootstrap-%s", string(etcd.UID[:6]))
+	return fmt.Sprintf("%s-bootstrap-%s", etcd.Name, string(etcd.UID[:6]))
 }
 
 // GetCronJobName returns the legacy compaction cron job name


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
All other resources are prefixed with the `etcd.Name` but the `ConfigMap` is not. This PR fixes this.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
