### PR TITLE
Fix backup ready health check

### DIFF
--- a/pkg/health/condition/check_backup_ready.go
+++ b/pkg/health/condition/check_backup_ready.go
@@ -86,7 +86,7 @@ func (a *backupReadyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) R
 	} else if deltaLeaseRenewTime == nil && fullLeaseRenewTime != nil {
 		//Most probable during a startup scenario for new clusters
 		//Special case. Return Unknown condition for some time to allow delta backups to start up
-		if time.Since(fullLeaseRenewTime.Time) < 5*etcd.Spec.Backup.DeltaSnapshotPeriod.Duration {
+		if time.Since(fullLeaseRenewTime.Time) > 5*etcd.Spec.Backup.DeltaSnapshotPeriod.Duration {
 			result.message = "Periodic delta snapshots not started yet"
 			return result
 		}

--- a/pkg/health/condition/check_backup_ready_test.go
+++ b/pkg/health/condition/check_backup_ready_test.go
@@ -46,6 +46,8 @@ var _ = Describe("BackupReadyCheck", func() {
 					Reason: v1.StatusReasonNotFound,
 				},
 			}
+			deltaSnapshotDuration = 2 * time.Minute
+
 			etcd = druidv1alpha1.Etcd{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "test-etcd",
@@ -55,7 +57,7 @@ var _ = Describe("BackupReadyCheck", func() {
 					Replicas: 1,
 					Backup: druidv1alpha1.BackupSpec{
 						DeltaSnapshotPeriod: &v1.Duration{
-							Duration: 2 * time.Minute,
+							Duration: deltaSnapshotDuration,
 						},
 						Store: &druidv1alpha1.StoreSpec{
 							Prefix:   "test-prefix",
@@ -77,13 +79,16 @@ var _ = Describe("BackupReadyCheck", func() {
 				},
 			}
 		)
+
 		BeforeEach(func() {
 			mockCtrl = gomock.NewController(GinkgoT())
 			cl = mockclient.NewMockClient(mockCtrl)
 		})
+
 		AfterEach(func() {
 			mockCtrl.Finish()
 		})
+
 		Context("With no snapshot leases present", func() {
 			It("Should return Unknown rediness", func() {
 				cl.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -119,6 +124,7 @@ var _ = Describe("BackupReadyCheck", func() {
 				Expect(result.Status()).To(Equal(druidv1alpha1.ConditionTrue))
 				Expect(result.Reason()).To(Equal(BackupSucceeded))
 			})
+
 			It("Should set status to BackupSucceeded if delta snap lease is recently created and empty full snap lease has been created in the last 24h", func() {
 				cl.EXPECT().Get(context.TODO(), types.NamespacedName{Name: "test-etcd-full-snap", Namespace: "default"}, gomock.Any()).DoAndReturn(
 					func(_ context.Context, _ client.ObjectKey, le *coordinationv1.Lease) error {
@@ -144,10 +150,12 @@ var _ = Describe("BackupReadyCheck", func() {
 				Expect(result.Status()).To(Equal(druidv1alpha1.ConditionTrue))
 				Expect(result.Reason()).To(Equal(BackupSucceeded))
 			})
+
 			It("Should set status to Unknown if empty delta snap lease is present but full snap lease is renewed recently", func() {
 				cl.EXPECT().Get(context.TODO(), types.NamespacedName{Name: "test-etcd-full-snap", Namespace: "default"}, gomock.Any()).DoAndReturn(
 					func(_ context.Context, _ client.ObjectKey, le *coordinationv1.Lease) error {
 						*le = lease
+						le.Spec.RenewTime = &v1.MicroTime{Time: lease.Spec.RenewTime.Time.Add(-5 * deltaSnapshotDuration)}
 						return nil
 					},
 				).AnyTimes()
@@ -167,7 +175,9 @@ var _ = Describe("BackupReadyCheck", func() {
 				Expect(result.ConditionType()).To(Equal(druidv1alpha1.ConditionTypeBackupReady))
 				Expect(result.Status()).To(Equal(druidv1alpha1.ConditionUnknown))
 				Expect(result.Reason()).To(Equal(Unknown))
+				Expect(result.Message()).To(Equal("Periodic delta snapshots not started yet"))
 			})
+
 			It("Should set status to Unknown if both leases are stale", func() {
 				cl.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, _ client.ObjectKey, le *coordinationv1.Lease) error {
@@ -195,6 +205,7 @@ var _ = Describe("BackupReadyCheck", func() {
 				Expect(result.Status()).To(Equal(druidv1alpha1.ConditionUnknown))
 				Expect(result.Reason()).To(Equal(Unknown))
 			})
+
 			It("Should set status to BackupFailed if both leases are stale and current condition is Unknown", func() {
 				cl.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, _ client.ObjectKey, le *coordinationv1.Lease) error {
@@ -223,6 +234,7 @@ var _ = Describe("BackupReadyCheck", func() {
 				Expect(result.Reason()).To(Equal(BackupFailed))
 			})
 		})
+
 		Context("With no backup store configured", func() {
 			It("Should return nil condition", func() {
 				cl.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -242,6 +254,7 @@ var _ = Describe("BackupReadyCheck", func() {
 				}
 			})
 		})
+
 		Context("With backup store is configured but provider is nil", func() {
 			It("Should return nil condition", func() {
 				cl.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue for the backup ready health check, when the full snapshot is already taken but delta is missing.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed that caused the `BackupReady` condition to show `Unknown` when the cluster is newly created.
``` 
