### PR TITLE
Revert "Upgrade Dockerfile and pipeline to use golang 1.19.2"

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,11 +24,11 @@ etcd-druid:
                 build: ~
     steps:
       check:
-        image: 'golang:1.19.2'
+        image: 'golang:1.18.6'
       test:
-        image: 'golang:1.19.2'
+        image: 'golang:1.18.6'
       build:
-        image: 'golang:1.19.2'
+        image: 'golang:1.18.6'
         output_dir: 'binary'
 
   jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.2 as builder
+FROM golang:1.18.6 as builder
 WORKDIR /go/src/github.com/gardener/etcd-druid
 COPY . .
 


### PR DESCRIPTION
Reverts gardener/etcd-druid#460

Golang 1.19.2 is not supported with golangci-lint  yet. So reverting back to 1.18