### PR TITLE
Update golangci-lint version and bump golang to `v1.19`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,11 +24,11 @@ etcd-druid:
                 build: ~
     steps:
       check:
-        image: 'golang:1.19.2'
+        image: 'golang:1.19.3'
       test:
-        image: 'golang:1.19.2'
+        image: 'golang:1.19.3'
       build:
-        image: 'golang:1.19.2'
+        image: 'golang:1.19.3'
         output_dir: 'binary'
 
   jobs:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,7 @@
 run:
   concurrency: 4
   deadline: 10m
-  # some of the linters don't work correctly with 1.18, ref https://github.com/golangci/golangci-lint/issues/2649
-  # we are not using generics, so let's pin this to 1.17 until 1.18 is fully supported
-  go: "1.17"
+  go: "1.19"
 
 linters:
   disable:

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ IMAGE_BUILD_TAG     := $(VERSION)
 BUILD_DIR           := build
 PROVIDERS           := ""
 
-# TODO(timuthy): Remove this as soon as vendored to new gardener/gardener version.
-GOLANGCI_LINT_VERSION := v1.45.2
+GOLANGCI_LINT_VERSION := v1.50.1
 
 IMG ?= ${IMAGE_REPOSITORY}:${IMAGE_BUILD_TAG}
 

--- a/controllers/compaction_lease_controller_test.go
+++ b/controllers/compaction_lease_controller_test.go
@@ -1,16 +1,17 @@
-// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package controllers
 
 import (

--- a/controllers/controller_ref_manager.go
+++ b/controllers/controller_ref_manager.go
@@ -1,23 +1,16 @@
-/*
-Copyright 2016 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-This file was copied and modified from the kubernetes/kubernetes project
-https://github.com/kubernetes/kubernetes/release-1.8/pkg/controller/controller_ref_manager.go
-
-Modifications Copyright (c) 2017 SAP SE or an SAP affiliate company. All rights reserved.
-*/
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Package controllers is used to provide the core functionalities of hvpa-controller
 package controllers
@@ -71,8 +64,8 @@ func (m *BaseControllerRefManager) CanAdopt() error {
 // claimObject tries to take ownership of an object for this controller.
 //
 // It will reconcile the following:
-//   * Adopt orphans if the match function returns true.
-//   * Release owned objects if the match function returns false.
+//   - Adopt orphans if the match function returns true.
+//   - Release owned objects if the match function returns false.
 //
 // A non-nil error is returned if some form of reconciliation was attempted and
 // failed. Usually, controllers should try again later in case reconciliation

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/etcd-druid
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -66,7 +66,7 @@ const (
 	Local = "Local"
 	// ECS is a constant for the EMC storage provider.
 	ECS = "ECS"
-	// OSC is a constant for the OpenShift storage provider.
+	// OCS is a constant for the OpenShift storage provider.
 	OCS = "OCS"
 )
 
@@ -154,9 +154,10 @@ func nameAndNamespace(namespaceOrName string, nameOpt ...string) (namespace, nam
 
 // Key creates a new client.ObjectKey from the given parameters.
 // There are only two ways to call this function:
-// - If only namespaceOrName is set, then a client.ObjectKey with name set to namespaceOrName is returned.
-// - If namespaceOrName and one nameOpt is given, then a client.ObjectKey with namespace set to namespaceOrName
-//   and name set to nameOpt[0] is returned.
+//   - If only namespaceOrName is set, then a client.ObjectKey with name set to namespaceOrName is returned.
+//   - If namespaceOrName and one nameOpt is given, then a client.ObjectKey with namespace set to namespaceOrName
+//     and name set to nameOpt[0] is returned.
+//
 // For all other cases, this method panics.
 func Key(namespaceOrName string, nameOpt ...string) client.ObjectKey {
 	namespace, name := nameAndNamespace(namespaceOrName, nameOpt...)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Fix failing tests due to golang linting issue for go `v1.18`. Also bumps golang version to `v1.19`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @abdasgupta @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
