### PR TITLE
Run `make manifests`

### DIFF
--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -300,6 +300,17 @@ spec:
                   clientPort:
                     format: int32
                     type: integer
+                  clientService:
+                    description: ClientService defines the parameters of the client
+                      service that a user can specify
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations specify the annotations that should
+                          be added to the client service
+                        type: object
+                    type: object
                   clientUrlTls:
                     description: ClientUrlTLS contains the ca, server TLS and client
                       TLS secrets for client communication to ETCD cluster
@@ -1688,8 +1699,12 @@ spec:
                   for this resource.
                 format: int64
                 type: integer
+              peerUrlTLSEnabled:
+                description: PeerUrlTLSEnabled captures the state of peer url TLS
+                  being enabled for the etcd member(s)
+                type: boolean
               ready:
-                description: Ready represents the readiness of the etcd resource.
+                description: Ready is `true` if all etcd replicas are ready.
                 type: boolean
               readyReplicas:
                 description: ReadyReplicas is the count of replicas being ready in

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -284,14 +284,6 @@ spec:
               etcd:
                 description: EtcdConfig defines parameters associated etcd deployed
                 properties:
-                  clientService:
-                    description: ClientService defines properties that allow the client service to be manipulated from the etcd spec
-                    properties: 
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
                   authSecretRef:
                     description: SecretReference represents a Secret Reference. It
                       has enough information to retrieve secret in any namespace
@@ -308,6 +300,17 @@ spec:
                   clientPort:
                     format: int32
                     type: integer
+                  clientService:
+                    description: ClientService defines the parameters of the client
+                      service that a user can specify
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations specify the annotations that should
+                          be added to the client service
+                        type: object
+                    type: object
                   clientUrlTls:
                     description: ClientUrlTLS contains the ca, server TLS and client
                       TLS secrets for client communication to ETCD cluster
@@ -1696,6 +1699,10 @@ spec:
                   for this resource.
                 format: int64
                 type: integer
+              peerUrlTLSEnabled:
+                description: PeerUrlTLSEnabled captures the state of peer url TLS
+                  being enabled for the etcd member(s)
+                type: boolean
               ready:
                 description: Ready is `true` if all etcd replicas are ready.
                 type: boolean
@@ -1716,9 +1723,6 @@ spec:
                   etcd cluster.
                 format: int32
                 type: integer
-              peerUrlTLSEnabled:
-                description: PeerUrlTLSEnabled captures the state of the peer url TLS being enabled for the etcd member(s)
-                type: boolean
             type: object
         type: object
     served: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -6,152 +7,69 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - endpoints
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - roles
-  - rolebindings
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  - apps
-  resources:
-  - services
-  - configmaps
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-  - create
-  - delete
-- apiGroups:
   - batch
   resources:
   - jobs
   verbs:
+  - create
+  - delete
   - get
   - list
-  - watch
-  - create
-  - update
   - patch
-  - delete
-- apiGroups:
-  - batch
-  resources:
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-  - delete
-- apiGroups:
-  - druid.gardener.cloud
-  resources:
-  - etcds
-  - etcdcopybackupstasks
-  verbs:
-  - get
-  - list
-  - watch
-  - create
   - update
-  - patch
-  - delete
-- apiGroups:
-  - druid.gardener.cloud
-  resources:
-  - etcds/status
-  - etcds/finalizers
-  - etcdcopybackupstasks/status
-  - etcdcopybackupstasks/finalizers
-  verbs:
-  - get
-  - update
-  - patch
-  - create
+  - watch
 - apiGroups:
   - coordination.k8s.io
   resources:
   - leases
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
   - delete
   - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-  - ""
+  - druid.gardener.cloud
   resources:
-  - persistentvolumeclaims
+  - etcds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - etcds/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - druid.gardener.cloud
+  resources:
+  - secrets
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
   verbs:
+  - create
+  - delete
   - get
   - list
-  - watch
-  - create
-  - update
   - patch
-  - delete
+  - update
+  - watch


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind bug

**What this PR does / why we need it**:
While looking for a CRD version that includes the clientService annotations from https://github.com/gardener/etcd-druid/pull/438, I noticed that `charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml` does not include at all the corresponding fields.
Then I ran `make manifests` and it generated me the content from this PR.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `etcds.druid.gardener.cloud` CRD does now include the `spec.etcd.clientService` field.
```
