### PR TITLE
Removed unnecessary step from playbook to recover from quorum loss.

### DIFF
--- a/docs/operation/Recover_From_Etcd_Permanent_Quorum_Loss.md
+++ b/docs/operation/Recover_From_Etcd_Permanent_Quorum_Loss.md
@@ -69,7 +69,7 @@ There are two [ETCD clusters](https://github.com/gardener/etcd-druid/tree/master
       NAME          READY   STATUS    RESTARTS   AGE
       etcd-main-0   2/2     Running   0          1m
       ```
-   8. Remove the following annotation from the `Etcd` resource `etcd-main`: `kubectl annotate etcd etcd-main druid.gardener.cloud/ignore-reconciliation="true"`
+   8. Remove the following annotation from the `Etcd` resource `etcd-main`: `kubectl annotate etcd etcd-main druid.gardener.cloud/ignore-reconciliation-`
    9. Finally add the following annotation to the `Etcd` resource `etcd-main`: `kubectl annotate etcd etcd-main gardener.cloud/operation="reconcile"`
    10. Verify that the etcd cluster is formed correctly.
 

--- a/docs/operation/Recover_From_Etcd_Permanent_Quorum_Loss.md
+++ b/docs/operation/Recover_From_Etcd_Permanent_Quorum_Loss.md
@@ -69,10 +69,9 @@ There are two [ETCD clusters](https://github.com/gardener/etcd-druid/tree/master
       NAME          READY   STATUS    RESTARTS   AGE
       etcd-main-0   2/2     Running   0          1m
       ```
-   8. Add the following annotation to the `etcd-main` statefulset `kubectl annotate sts etcd-main gardener.cloud/scaled-to-multi-node="true"`
-   9. Remove the following annotation from the `Etcd` resource `etcd-main`: `kubectl annotate etcd etcd-main druid.gardener.cloud/ignore-reconciliation-`
-   10. Finally add the following annotation to the `Etcd` resource `etcd-main`: `kubectl annotate etcd etcd-main gardener.cloud/operation="reconcile"`
-   11. Verify that the etcd cluster is formed correctly.
+   8. Remove the following annotation from the `Etcd` resource `etcd-main`: `kubectl annotate etcd etcd-main druid.gardener.cloud/ignore-reconciliation="true"`
+   9. Finally add the following annotation to the `Etcd` resource `etcd-main`: `kubectl annotate etcd etcd-main gardener.cloud/operation="reconcile"`
+   10. Verify that the etcd cluster is formed correctly.
 
        All the `etcd-main` pods will have outputs similar to following:
        ```


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation
/kind enhancement

**What this PR does / why we need it**:
I found that there is no need to annotate the etcd-statefulset with annotation: `etcd-main gardener.cloud/scaled-to-multi-node="true"` as when we annotate the druid to reconcile, druid reconciliation will itself detect scale-up scenario and adds annotation `gardener.cloud/scaled-to-multi-node: ""` to `etcd statefulset`. Please check [here](https://github.com/gardener/etcd-druid/blob/ce59ba9d805ad1fac948b9ea3e41ec068f1ba522/pkg/component/etcd/statefulset/statefulset.go#L471-L483)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
None
```
