### PR TITLE
Enhance `kubectl` printer columns for etcd resource

### DIFF
--- a/api/v1alpha1/etcd_types.go
+++ b/api/v1alpha1/etcd_types.go
@@ -450,9 +450,15 @@ type EtcdStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
-// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
+// +kubebuilder:printcolumn:name="Quorate",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="All Members Ready",type=string,JSONPath=`.status.conditions[?(@.type=="AllMembersReady")].status`
+// +kubebuilder:printcolumn:name="Backup Ready",type=string,JSONPath=`.status.conditions[?(@.type=="BackupReady")].status`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Cluster Size",type=integer,JSONPath=`.spec.replicas`,priority=1
+// +kubebuilder:printcolumn:name="Current Replicas",type=integer,JSONPath=`.status.currentReplicas`,priority=1
+// +kubebuilder:printcolumn:name="Ready Replicas",type=integer,JSONPath=`.status.readyReplicas`,priority=1
 
 // Etcd is the Schema for the etcds API
 type Etcd struct {

--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -20,9 +20,30 @@ spec:
     - jsonPath: .status.ready
       name: Ready
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Quorate
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AllMembersReady")].status
+      name: All Members Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="BackupReady")].status
+      name: Backup Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.replicas
+      name: Cluster Size
+      priority: 1
+      type: integer
+    - jsonPath: .status.currentReplicas
+      name: Current Replicas
+      priority: 1
+      type: integer
+    - jsonPath: .status.readyReplicas
+      name: Ready Replicas
+      priority: 1
+      type: integer
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -20,9 +20,30 @@ spec:
     - jsonPath: .status.ready
       name: Ready
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Quorate
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AllMembersReady")].status
+      name: All Members Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="BackupReady")].status
+      name: Backup Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .spec.replicas
+      name: Cluster Size
+      priority: 1
+      type: integer
+    - jsonPath: .status.currentReplicas
+      name: Current Replicas
+      priority: 1
+      type: integer
+    - jsonPath: .status.readyReplicas
+      name: Ready Replicas
+      priority: 1
+      type: integer
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Enhances printer columns for `Etcd` resources when viewed using `kubectl get etcd`. The new fields displayed are as follows:
```
NAME        READY   QUORATE   ALL MEMBERS READY   BACKUP READY   AGE
etcd-test   true    True      True                True           99s
```

Columns displayed upon running `kubectl get etcd -o wide` are as follows:
```
NAME        READY   QUORATE   ALL MEMBERS READY   BACKUP READY   AGE   CLUSTER SIZE   CURRENT REPLICAS   READY REPLICAS
etcd-test   true    True      True                True           110s  3              3                  3
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-druid/issues/453

**Special notes for your reviewer**:
cc @vlerenc 
/cc @abdasgupta @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Enhance `kubectl` printer columns for `Etcd` resource.
```
