### PR TITLE
Enabled e2e tests to read KUBECONFIG from in-cluster variables along with environment variable

### DIFF
--- a/test/e2e/etcd_backup_test.go
+++ b/test/e2e/etcd_backup_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Etcd Backup", func() {
 			provider := p
 			Context(fmt.Sprintf("with provider %s", provider.Name), func() {
 				BeforeEach(func() {
-					cl, err = getKubernetesClient(kubeconfigPath)
+					cl, err = GetKubernetesClientOrError()
 					Expect(err).ShouldNot(HaveOccurred())
 
 					etcdName = fmt.Sprintf("etcd-%s", provider.Name)

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -381,7 +381,7 @@ func getEtcdLeaderPodName(ctx context.Context, cl client.Client, namespace strin
 
 // getPodLogs returns logs for the given pod
 func getPodLogs(ctx context.Context, PodKey *types.NamespacedName, opts *corev1.PodLogOptions) (string, error) {
-	typedClient, err := getKubernetesTypedClient(kubeconfigPath)
+	typedClient, err := getKubernetesTypedClient()
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -38,10 +38,9 @@ const (
 	singleNodeEtcdTimeout = time.Minute
 	multiNodeEtcdTimeout  = time.Minute * 5
 
-	pollingInterval   = time.Second * 2
-	envSourcePath     = "SOURCE_PATH"
-	envKubeconfigPath = "KUBECONFIG"
-	etcdNamespace     = "shoot"
+	pollingInterval = time.Second * 2
+	envSourcePath   = "SOURCE_PATH"
+	etcdNamespace   = "shoot"
 
 	certsBasePath = "test/e2e/resources/tls"
 
@@ -77,16 +76,14 @@ var _ = BeforeSuite(func() {
 	Expect(len(providers)).To(BeNumerically(">", 0))
 
 	sourcePath = getEnvOrFallback(envSourcePath, ".")
-	kubeconfigPath = getEnvAndExpectNoError(envKubeconfigPath)
 
 	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	logger.V(1).Info("setting up k8s client", "KUBECONFIG", kubeconfigPath)
-	cl, err = getKubernetesClient(kubeconfigPath)
+	cl, err = GetKubernetesClientOrError()
 	Expect(err).ShouldNot(HaveOccurred())
 
-	typedClient, err = getKubernetesTypedClient(kubeconfigPath)
+	typedClient, err = getKubernetesTypedClient()
 	Expect(err).NotTo(HaveOccurred())
 
 	logger.Info("creating namespace", "namespace", etcdNamespace)
@@ -108,11 +105,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	ctx := context.Background()
 
-	kubeconfigPath, err := getEnvOrError(envKubeconfigPath)
-	Expect(err).NotTo(HaveOccurred())
-
-	logger.V(1).Info("setting up k8s client using", " KUBECONFIG", kubeconfigPath)
-	cl, err := getKubernetesClient(kubeconfigPath)
+	cl, err := GetKubernetesClientOrError()
 	Expect(err).ShouldNot(HaveOccurred())
 
 	namespaceLogger := logger.WithValues("namespace", etcdNamespace)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO

**What this PR does / why we need it**:
Currently, `make test-e2e` needs KUBECONFIG to be provided through environment variable. But the command can not construct KUBECONFIG from the in-cluster pod environment variables. But to enable running Druid e2e tests through Prow jobs, we need to run the e2e tests inside a pod (as a job) and the tests need to figure out kubeconfig from in-cluster variables. So, this is PR is raised which enables to run e2e tests with kubeconfigs provided by either environment variables or through in-cluster variables. 
**Which issue(s) this PR fixes**:
Fixes #465 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
KUBECONFIG variable is set by environment flag instead of options during the execution of command `make test-e2e`

```
