### PR TITLE
Added support for running e2e tests in local KIND cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ IMAGE_REPOSITORY    := $(REGISTRY)/etcd-druid
 IMAGE_BUILD_TAG     := $(VERSION)
 BUILD_DIR           := build
 PROVIDERS           := ""
+CLUSTER             := local
 
 GOLANGCI_LINT_VERSION := v1.50.1
 
@@ -122,7 +123,7 @@ test-cov-clean:
 
 .PHONY: test-e2e
 test-e2e: $(KUBECTL) $(HELM) $(SKAFFOLD)
-	@"$(REPO_ROOT)/hack/e2e-test/run-e2e-test.sh" $(PROVIDERS)
+	@"$(REPO_ROOT)/hack/e2e-test/run-e2e-test.sh" $(PROVIDERS) $(CLUSTER)
 
 .PHONY: update-dependencies
 update-dependencies:

--- a/docs/development/local-e2e-tests.md
+++ b/docs/development/local-e2e-tests.md
@@ -19,7 +19,7 @@ the e2e-tests are executed locally. Required binaries are automatically download
 as described in this document.
 
 It's expected that especially the `deploy` step is run against a Kubernetes cluster which doesn't contain an Druid deployment or any left-overs like `druid.gardener.cloud` CRDs.
-The `deploy` step will likely fail in such scenarios.
+Otherwise, `deploy` step will likely fail in such scenarios.
 
 > Tip: Create a fresh [KinD](https://kind.sigs.k8s.io/) cluster or a similar one with a small footprint before executing the tests. 
 
@@ -61,8 +61,10 @@ The following environment variables influence how the flow described above is ex
 - `PROVIDERS`:  Providers used for testing (`all`, `aws`, `azure`, `gcp`). Multiple entries must be comma separated. 
     > **Note**: Some tests will use very first entry from env `PROVIDERS` for e2e testing (ex: multi-node tests). So for multi-node tests to use specific provider, specify that provider as first entry in env `PROVIDERS`.
 - `KUBECONFIG`: Kubeconfig pointing to cluster where Etcd-Druid will be deployed (preferably [KinD](https://kind.sigs.k8s.io)).
-- `TEST_ID`:    Some ID which is used to create assets for and during testing.
+- `TEST_ID`:    Some ID which is used to create assets for and during testing. If not set, last git commit hash will be used to form a default `TEST_ID`
 - `STEPS`:      Steps executed by `make` target (`setup`, `deploy`, `test`, `undeploy`, `cleanup` - default: all steps).
+- `CLUSTER`:    If this environment variable is set with the value `local`, a KinD cluster is created and Etcd-Druid is deployed in the local KinD cluster. To deploy Etcd-Druid in a remote cluster, set this variable with the value `remote` and set `KUBECONFIG` variable as well. If not set, `CLUSTER` variable will be set with `local` by default.
+    > **Note**: No need to set KUBECONFIG environment variable if `CLUSTER` is set to `local`
 
 ### AWS Env Variables
 
@@ -72,12 +74,27 @@ The following environment variables influence how the flow described above is ex
 
 Example:
 
+While using a remote cluster:
 ```
 make \
   AWS_ACCESS_KEY_ID="abc" \
   AWS_SECRET_ACCESS_KEY="xyz" \
   AWS_REGION="eu-central-1" \
   KUBECONFIG="$HOME/.kube/config" \
+  CLUSTER="remote" \
+  PROVIDERS="aws" \
+  TEST_ID="some-test-id" \
+  STEPS="setup,deploy,test,undeploy,cleanup" \
+test-e2e
+```
+
+While using a local KIND cluster:
+```
+make \
+  AWS_ACCESS_KEY_ID="abc" \
+  AWS_SECRET_ACCESS_KEY="xyz" \
+  AWS_REGION="eu-central-1" \
+  CLUSTER="local" \
   PROVIDERS="aws" \
   TEST_ID="some-test-id" \
   STEPS="setup,deploy,test,undeploy,cleanup" \
@@ -91,11 +108,25 @@ test-e2e
 
 Example:
 
+While using a remote cluster:
 ```
 make \
   STORAGE_ACCOUNT="abc" \
   STORAGE_KEY="eHl6Cg==" \
   KUBECONFIG="$HOME/.kube/config" \
+  CLUSTER="remote" \
+  PROVIDERS="azure" \
+  TEST_ID="some-test-id" \
+  STEPS="setup,deploy,test,undeploy,cleanup" \
+test-e2e
+```
+
+While using a local cluster:
+```
+make \
+  STORAGE_ACCOUNT="abc" \
+  STORAGE_KEY="eHl6Cg==" \
+  CLUSTER="local" \
   PROVIDERS="azure" \
   TEST_ID="some-test-id" \
   STEPS="setup,deploy,test,undeploy,cleanup" \
@@ -109,11 +140,25 @@ test-e2e
 
 Example:
 
+While using a remote cluster:
 ```
 make \
   GCP_SERVICEACCOUNT_JSON_PATH="/var/lib/secrets/serviceaccount.json" \
   GCP_PROJECT_ID="xyz-project" \
   KUBECONFIG="$HOME/.kube/config" \
+  CLUSTER="remote" \
+  PROVIDERS="gcp" \
+  TEST_ID="some-test-id" \
+  STEPS="setup,deploy,test,undeploy,cleanup" \
+test-e2e
+```
+
+While using a local cluster:
+```
+make \
+  GCP_SERVICEACCOUNT_JSON_PATH="/var/lib/secrets/serviceaccount.json" \
+  GCP_PROJECT_ID="xyz-project" \
+  CLUSTER="local" \
   PROVIDERS="gcp" \
   TEST_ID="some-test-id" \
   STEPS="setup,deploy,test,undeploy,cleanup" \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Currently, ETCD Druid e2e tests do not deploy in a KinD cluster automatically through makefile. It is very much necessary to enable running druid e2e tests through Prow jobs. This PR enables user to run druid e2e tests locally through `make` command and creates local KinD cluster and deploys druid there.
**Which issue(s) this PR fixes**:
Fixes #465 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Run `make AWS_ACCESS_KEY_ID="abc" AWS_SECRET_ACCESS_KEY="xyz" AWS_REGION="eu-central-1" CLUSTER="local" PROVIDERS="aws"  STEPS="setup,deploy,test,undeploy,cleanup" test-e2e` to deploy druid e2e tests in local KinD cluster
```
