### PR TITLE
Remove etcd-process-name flag from statefulset

### DIFF
--- a/controllers/etcd_controller_test.go
+++ b/controllers/etcd_controller_test.go
@@ -908,7 +908,6 @@ func validateEtcdWithDefaults(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSe
 								"--insecure-skip-tls-verify=true":                Equal("--insecure-skip-tls-verify=true"),
 								"--etcd-connection-timeout=5m":                   Equal("--etcd-connection-timeout=5m"),
 								"--snapstore-temp-directory=/var/etcd/data/temp": Equal("--snapstore-temp-directory=/var/etcd/data/temp"),
-								"--etcd-process-name=etcd":                       Equal("--etcd-process-name=etcd"),
 								"--enable-member-lease-renewal=true":             Equal("--enable-member-lease-renewal=true"),
 								"--k8s-heartbeat-duration=10s":                   Equal("--k8s-heartbeat-duration=10s"),
 
@@ -1293,7 +1292,6 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								"--insecure-transport=false":                                                                                        Equal("--insecure-transport=false"),
 								"--insecure-skip-tls-verify=false":                                                                                  Equal("--insecure-skip-tls-verify=false"),
 								"--snapstore-temp-directory=/var/etcd/data/temp":                                                                    Equal("--snapstore-temp-directory=/var/etcd/data/temp"),
-								"--etcd-process-name=etcd":                                                                                          Equal("--etcd-process-name=etcd"),
 								"--etcd-connection-timeout=5m":                                                                                      Equal("--etcd-connection-timeout=5m"),
 								"--enable-snapshot-lease-renewal=true":                                                                              Equal("--enable-snapshot-lease-renewal=true"),
 								"--enable-member-lease-renewal=true":                                                                                Equal("--enable-member-lease-renewal=true"),

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -538,7 +538,6 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 								"--insecure-transport=false":                        Equal("--insecure-transport=false"),
 								"--insecure-skip-tls-verify=false":                  Equal("--insecure-skip-tls-verify=false"),
 								"--snapstore-temp-directory=/var/etcd/data/temp":    Equal("--snapstore-temp-directory=/var/etcd/data/temp"),
-								"--etcd-process-name=etcd":                          Equal("--etcd-process-name=etcd"),
 								fmt.Sprintf("%s=%s", "--etcd-connection-timeout-leader-election", etcdLeaderElectionConnectionTimeout.Duration.String()): Equal(fmt.Sprintf("%s=%s", "--etcd-connection-timeout-leader-election", values.LeaderElection.EtcdConnectionTimeout.Duration.String())),
 								"--etcd-connection-timeout=5m":                                                                        Equal("--etcd-connection-timeout=5m"),
 								"--enable-snapshot-lease-renewal=true":                                                                Equal("--enable-snapshot-lease-renewal=true"),

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -295,7 +295,6 @@ func getBackupRestoreCommand(val Values) []string {
 	command = append(command, "--etcd-defrag-timeout="+etcdDefragTimeout)
 
 	command = append(command, "--snapstore-temp-directory=/var/etcd/data/temp")
-	command = append(command, "--etcd-process-name=etcd")
 	command = append(command, "--enable-member-lease-renewal=true")
 
 	heartbeatDuration := defaultHeartbeatDuration


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind technical-debt

**What this PR does / why we need it**:
Removal of owner checks in https://github.com/gardener/etcd-backup-restore/pull/555 meant that we got rid of one flag `--etcd-process-name` in `etcd-backup-restore`
This PR makes changes to remove this flag from the `etcd` `statefulset` and corresponding tests as the presence of this flag will now cause an error

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`--etcd-process-name` has been deprecated and is now not added to the statefulset
```
