### PR TITLE
Cleanup CI scripts

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -20,19 +20,16 @@ source .ci/common.sh
 # For the build step concourse will additionally set the following environment variable:
 # BINARY_PATH - path to an existing (empty) directory to place build results into.
 if [[ -z "${BINARY_PATH}" ]]; then
-  export BINARY_PATH="${SOURCE_PATH}/bin"
+  BINARY_PATH="${SOURCE_PATH}/bin"
 else
-  export BINARY_PATH="$(readlink -f "${BINARY_PATH}")/bin"
+  BINARY_PATH="$(readlink -f "${BINARY_PATH}")/bin"
 fi
+export BINARY_PATH
 
 ###############################################################################
-
-VERSION_FILE="$(readlink  -f "${SOURCE_PATH}/VERSION")"
-VERSION="$(cat "${VERSION_FILE}")"
-GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 
 CGO_ENABLED=0 GO111MODULE=on go build \
   -mod vendor \
   -v \
-  -o ${BINARY_PATH}/etcd-druid \
+  -o "${BINARY_PATH}"/etcd-druid \
   main.go

--- a/.ci/build
+++ b/.ci/build
@@ -15,41 +15,14 @@
 
 set -e
 
-# For the build step concourse will set the following environment variables:
-# SOURCE_PATH - path to component repository root directory.
-# BINARY_PATH - path to an existing (empty) directory to place build results into.
-if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f $(dirname ${0})/..)"
-else
-  export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
-fi
+source .ci/common.sh
 
+# For the build step concourse will additionally set the following environment variable:
+# BINARY_PATH - path to an existing (empty) directory to place build results into.
 if [[ -z "${BINARY_PATH}" ]]; then
   export BINARY_PATH="${SOURCE_PATH}/bin"
 else
   export BINARY_PATH="$(readlink -f "${BINARY_PATH}")/bin"
-fi
-
-VCS="github.com"
-ORGANIZATION="gardener"
-PROJECT="etcd-druid"
-REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
-
-# The `go <cmd>` commands requires to see the target repository to be part of a
-# Go workspace. Thus, if we are not yet in a Go workspace, let's create one
-# temporarily by using symbolic links.
-if [[ "${SOURCE_PATH}" != *"src/${REPOSITORY}" ]]; then
-  SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/src/${REPOSITORY}"
-  if [[ -d "${SOURCE_PATH}/tmp" ]]; then
-    rm -rf "${SOURCE_PATH}/tmp"
-  fi
-  mkdir -p "${SOURCE_PATH}/tmp/src/${VCS}/${ORGANIZATION}"
-  ln -s "${SOURCE_PATH}" "${SOURCE_SYMLINK_PATH}"
-  cd "${SOURCE_SYMLINK_PATH}"
-
-  export GOPATH="${SOURCE_PATH}/tmp"
-  export GOBIN="${SOURCE_PATH}/tmp/bin"
-  export PATH="${GOBIN}:${PATH}"
 fi
 
 ###############################################################################
@@ -58,8 +31,7 @@ VERSION_FILE="$(readlink  -f "${SOURCE_PATH}/VERSION")"
 VERSION="$(cat "${VERSION_FILE}")"
 GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 
-
-CGO_ENABLED=0  GO111MODULE=on go build \
+CGO_ENABLED=0 GO111MODULE=on go build \
   -mod vendor \
   -v \
   -o ${BINARY_PATH}/etcd-druid \

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 # For all steps, concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
 if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+  SOURCE_PATH="$(readlink -f "$(dirname "${0}")/..")"
 else
-  export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
+  SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
 fi
+export SOURCE_PATH
 
 VCS="github.com"
 ORGANIZATION="gardener"
@@ -41,7 +44,6 @@ if [[ "${SOURCE_PATH}" != *"src/${REPOSITORY}" ]]; then
   export GOBIN="${SOURCE_PATH}/tmp/bin"
   export PATH="${GOBIN}:${PATH}"
 fi
-
 
 # Turn colors in this script off by setting the NO_COLOR variable in your
 # environment to any value:

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,0 +1,61 @@
+# Copyright 2023 SAP SE or an SAP affiliate company
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For all steps, concourse will set the following environment variables:
+# SOURCE_PATH - path to component repository root directory.
+if [[ -z "${SOURCE_PATH}" ]]; then
+  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+else
+  export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
+fi
+
+VCS="github.com"
+ORGANIZATION="gardener"
+PROJECT="etcd-druid"
+REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
+
+# The `go <cmd>` commands requires to see the target repository to be part of a
+# Go workspace. Thus, if we are not yet in a Go workspace, let's create one
+# temporarily by using symbolic links.
+if [[ "${SOURCE_PATH}" != *"src/${REPOSITORY}" ]]; then
+  SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/src/${REPOSITORY}"
+  if [[ -d "${SOURCE_PATH}/tmp" ]]; then
+    rm -rf "${SOURCE_PATH}/tmp"
+  fi
+  mkdir -p "${SOURCE_PATH}/tmp/src/${VCS}/${ORGANIZATION}"
+  ln -s "${SOURCE_PATH}" "${SOURCE_SYMLINK_PATH}"
+  cd "${SOURCE_SYMLINK_PATH}"
+
+  export GOPATH="${SOURCE_PATH}/tmp"
+  export GOBIN="${SOURCE_PATH}/tmp/bin"
+  export PATH="${GOBIN}:${PATH}"
+fi
+
+
+# Turn colors in this script off by setting the NO_COLOR variable in your
+# environment to any value:
+#
+# $ NO_COLOR=1 test.sh
+NO_COLOR=${NO_COLOR:-""}
+if [ -z "$NO_COLOR" ]; then
+  header=$'\e[1;33m'
+  reset=$'\e[0m'
+else
+  header=''
+  reset=''
+fi
+
+function header_text {
+  echo "$header$*$reset"
+}

--- a/.ci/test
+++ b/.ci/test
@@ -14,52 +14,7 @@
 # limitations under the License.
 set -e
 
-# For the test step concourse will set the following environment variables:
-# SOURCE_PATH - path to component repository root directory.
-if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
-else
-  export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
-fi
-
-VCS="github.com"
-ORGANIZATION="gardener"
-PROJECT="etcd-druid"
-REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
-
-# The `go <cmd>` commands requires to see the target repository to be part of a
-# Go workspace. Thus, if we are not yet in a Go workspace, let's create one
-# temporarily by using symbolic links.
-if [[ "${SOURCE_PATH}" != *"src/${REPOSITORY}" ]]; then
-  SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/src/${REPOSITORY}"
-  if [[ -d "${SOURCE_PATH}/tmp" ]]; then
-    rm -rf "${SOURCE_PATH}/tmp"
-  fi
-  mkdir -p "${SOURCE_PATH}/tmp/src/${VCS}/${ORGANIZATION}"
-  ln -s "${SOURCE_PATH}" "${SOURCE_SYMLINK_PATH}"
-  cd "${SOURCE_SYMLINK_PATH}"
-
-  export GOPATH="${SOURCE_PATH}/tmp"
-  export GOBIN="${SOURCE_PATH}/tmp/bin"
-  export PATH="${GOBIN}:${PATH}"
-fi
-
-# Turn colors in this script off by setting the NO_COLOR variable in your
-# environment to any value:
-#
-# $ NO_COLOR=1 test.sh
-NO_COLOR=${NO_COLOR:-""}
-if [ -z "$NO_COLOR" ]; then
-  header=$'\e[1;33m'
-  reset=$'\e[0m'
-else
-  header=''
-  reset=''
-fi
-
-function header_text {
-  echo "$header$*$reset"
-}
+source .ci/common.sh
 
 ###############################################################################
 

--- a/.ci/test
+++ b/.ci/test
@@ -18,8 +18,7 @@ source .ci/common.sh
 
 ###############################################################################
 
-GINKGO_COMMON_FLAGS="-r -timeout=1h0m0s --randomize-all --randomize-suites --fail-on-pending --progress"
-if [ -z $COVER ] || [ "$COVER" = false ] ; then
+if [ -z "$COVER" ] || [ "$COVER" = false ] ; then
   echo "[INFO] Test coverage is disabled."
   make test
 else


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This cleans up the CI scripts by pulling common functionality into a separate script instead of duplication. It also helps when we have new CI steps coming in, like `test_integration`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR is required to be merged to master so that https://github.com/gardener/etcd-druid/pull/506/ CI steps `build` and `test` can pass. You will also notice that the steps `build` and `test` in this PR are failing, due to the concourse CI issue/design that the base `.ci` directory comes from the master branch rather than the PR branch. You will see that once this PR is merged, the head-update job on the master branch will run successfully.
/cc @unmarshall @seshachalam-yv 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
