### PR TITLE
Fix CI pipeline cleanup

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -13,9 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -eo pipefail
 
-source .ci/common.sh
+# For all steps, concourse will set the following environment variables:
+# SOURCE_PATH - path to component repository root directory.
+if [[ -z "${SOURCE_PATH}" ]]; then
+  SOURCE_PATH="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/..")"
+else
+  SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
+fi
+export SOURCE_PATH
 
 # For the build step concourse will additionally set the following environment variable:
 # BINARY_PATH - path to an existing (empty) directory to place build results into.
@@ -25,6 +32,8 @@ else
   BINARY_PATH="$(readlink -f "${BINARY_PATH}")/bin"
 fi
 export BINARY_PATH
+
+source "${SOURCE_PATH}/.ci/common.sh"
 
 ###############################################################################
 

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -12,16 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
-# For all steps, concourse will set the following environment variables:
-# SOURCE_PATH - path to component repository root directory.
-if [[ -z "${SOURCE_PATH}" ]]; then
-  SOURCE_PATH="$(readlink -f "$(dirname "${0}")/..")"
-else
-  SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
-fi
-export SOURCE_PATH
+set -eo pipefail
 
 VCS="github.com"
 ORGANIZATION="gardener"
@@ -31,6 +22,11 @@ REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
 # The `go <cmd>` commands requires to see the target repository to be part of a
 # Go workspace. Thus, if we are not yet in a Go workspace, let's create one
 # temporarily by using symbolic links.
+if [[ -z "$SOURCE_PATH" ]]; then
+    echo "Environment variable SOURCE_PATH must be provided"
+    exit 1
+fi
+
 if [[ "${SOURCE_PATH}" != *"src/${REPOSITORY}" ]]; then
   SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/src/${REPOSITORY}"
   if [[ -d "${SOURCE_PATH}/tmp" ]]; then

--- a/.ci/test
+++ b/.ci/test
@@ -12,9 +12,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -e
 
-source .ci/common.sh
+set -eo pipefail
+
+# For all steps, concourse will set the following environment variables:
+# SOURCE_PATH - path to component repository root directory.
+if [[ -z "${SOURCE_PATH}" ]]; then
+  SOURCE_PATH="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")/..")"
+else
+  SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
+fi
+export SOURCE_PATH
+
+source "${SOURCE_PATH}/.ci/common.sh"
 
 ###############################################################################
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
Fixes bug introduced in https://github.com/gardener/etcd-druid/pull/517 during cleanup of CI scripts. Pipeline job for etcd-druid head-update is failing for `build` and `test` steps due to incorrect path provided to the `source` command in the scripts (pwd is set to the parent of the repo root dir by default in each CICD step). This PR fixes this by correctly setting the `SOURCE_PATH` before sourcing the `common.sh` script.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @unmarshall @seshachalam-yv 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
