### PR TITLE
Use JSON logger with ISO8601 time encoder for controller manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.0
+	go.uber.org/zap v1.21.0
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
@@ -99,7 +100,6 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"go.uber.org/zap/zapcore"
 	"os"
 	"time"
 
@@ -86,7 +87,10 @@ func main() {
 
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(func(options *zap.Options) {
+		options.Development = false
+		options.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}))
 
 	ctx := ctrl.SetupSignalHandler()
 

--- a/main.go
+++ b/main.go
@@ -87,10 +87,7 @@ func main() {
 
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(func(options *zap.Options) {
-		options.Development = false
-		options.TimeEncoder = zapcore.ISO8601TimeEncoder
-	}))
+	ctrl.SetLogger(zap.New(buildDefaultLoggerOpts()...))
 
 	ctx := ctrl.SetupSignalHandler()
 
@@ -177,4 +174,14 @@ func main() {
 		setupLog.Error(err, "Problem running manager")
 		os.Exit(1)
 	}
+}
+
+func buildDefaultLoggerOpts() []zap.Opts {
+	var opts []zap.Opts
+	opts = append(opts, zap.UseDevMode(false))
+	opts = append(opts, zap.JSONEncoder(func(encoderConfig *zapcore.EncoderConfig) {
+		encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+		encoderConfig.EncodeDuration = zapcore.StringDurationEncoder
+	}))
+	return opts
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/needs cherry-pick

**What this PR does / why we need it**:
Recently merged PR https://github.com/gardener/etcd-druid/pull/450 bumped controller-runtime version from `v0.10.2` to `v0.13.0`, which changed the default logging behavior for the logger provided for the controllers to print epoch timestamps in the logs which are not human-readable, as is pointed out by https://github.com/kubernetes-sigs/controller-runtime/issues/2024.

This PR explicitly sets the logger options to use ISO8601 timestamps for the controller logs, as well as switches the logger from dev mode to json mode, ie, structured logging, for better integration with logging stack in production environments.

**Which issue(s) this PR fixes**:
Fixes partially https://github.com/gardener/etcd-druid/issues/524

**Special notes for your reviewer**:
/cc @unmarshall @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Explicitly set logging options to use JSON logging and ISO8601 timestamp format.
```
