### PR TITLE
Fix `make test-cov`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test: $(GINKGO) $(SETUP_ENVTEST) fmt check manifests
 
 .PHONY: test-cov
 test-cov: $(GINKGO) $(SETUP_ENVTEST)
-	@TEST_COV="true" "$(REPO_ROOT)/hack/test.sh"
+	@TEST_COV="true" "$(REPO_ROOT)/hack/test.sh" --skip-package=./test/e2e
 
 .PHONY: test-cov-clean
 test-cov-clean:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/area quality
/kind bug

**What this PR does / why we need it**:
This PR removes e2e tests from code-coverage tests, since e2e tests require a k8s cluster and object storage credentials to be setup. Ideally, e2e tests should not be used to check code coverage, since code coverage must be tested by unit tests and component-specific tests. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
