### PR TITLE
Fix setting `ownerReference` on copy backups `Job`

### DIFF
--- a/charts/etcd-copy-backups/templates/etcd-copy-backups-job.yaml
+++ b/charts/etcd-copy-backups/templates/etcd-copy-backups-job.yaml
@@ -13,13 +13,6 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
-  ownerReferences:
-  - apiVersion: druid.gardener.cloud/v1alpha1
-    kind: EtcdCopyBackupsTask
-    name: {{ .Values.ownerName }}
-    uid: {{ .Values.ownerUID }}
-    controller: true
-    blockOwnerDeletion: true
 spec:
   template:
     metadata:

--- a/charts/etcd-copy-backups/values.yaml
+++ b/charts/etcd-copy-backups/values.yaml
@@ -1,6 +1,4 @@
 name: test-worker
-ownerName: test
-ownerUID: test-uid
 
 annotations: {}
 labels: {}

--- a/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
@@ -50,7 +50,7 @@ var _ = Describe("EtcdCopyBackupsTask Controller", func() {
 
 	DescribeTable("when creating and deleting etcdcopybackupstask",
 		func(taskName string, provider druidv1alpha1.StorageProvider, withOptionalFields bool, jobStatus *batchv1.JobStatus) {
-			task := testutils.CreateEtcdCopyBackupsTask("foo01", namespace, "Local", true)
+			task := testutils.CreateEtcdCopyBackupsTask(taskName, namespace, "Local", true)
 
 			// Create secrets
 			errors := testutils.CreateSecrets(ctx, k8sClient, task.Namespace, task.Spec.SourceStore.SecretRef.Name, task.Spec.TargetStore.SecretRef.Name)
@@ -125,6 +125,9 @@ var _ = Describe("EtcdCopyBackupsTask Controller", func() {
 			"foo06", druidv1alpha1.StorageProvider("openstack"), false, getJobStatus(batchv1.JobComplete, "", "")),
 		Entry("should create the job, update the task status, and delete the job if the job completed, for alicloud",
 			"foo07", druidv1alpha1.StorageProvider("alicloud"), false, getJobStatus(batchv1.JobComplete, "", "")),
+		// ref https://github.com/gardener/etcd-druid/issues/532
+		Entry("should correctly handle ownerReferences for numeric names with leading 0",
+			"01234", druidv1alpha1.StorageProvider("Local"), true, getJobStatus(batchv1.JobComplete, "", "")),
 	)
 })
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:

Fix setting `ownerReference` on copy backups `Job`:
Instead of using helm for setting the `ownerReference`, use proper go code that won't mess up the leading `0` 😄 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-druid/issues/532

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug that caused control plane migrations to fail for shoots with numeric names and a leading `0` has been fixed.
```
