### PR TITLE
Installing `kustomize` dependency for `Etcd-druid`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ revendor: set-permissions
 all: druid
 
 # Build manager binary
-.PHONY: druid
+.PHONY: druid 
 druid: fmt check
 	@env GO111MODULE=on go build -o bin/druid main.go
 
@@ -65,7 +65,7 @@ install: manifests
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: deploy
-deploy: manifests
+deploy: manifests $(KUSTOMIZE)
 	kubectl apply -f config/crd/bases
 	kustomize build config/default | kubectl apply -f -
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ revendor: set-permissions
 all: druid
 
 # Build manager binary
-.PHONY: druid 
+.PHONY: druid
 druid: fmt check
 	@env GO111MODULE=on go build -o bin/druid main.go
 

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin
-GINKGO		               := $(TOOLS_BIN_DIR)/ginkgo
 SKAFFOLD                   := $(TOOLS_BIN_DIR)/skaffold
 GO_ADD_LICENSE             := $(TOOLS_BIN_DIR)/addlicense
+KUSTOMIZE                  := $(TOOLS_BIN_DIR)/kustomize
 
 # default tool versions
 SKAFFOLD_VERSION ?= v1.38.0
 GO_ADD_LICENSE_VERSION ?= latest
+KUSTOMIZE_VERSION ?= v5.0.0
 
 export TOOLS_BIN_DIR := $(TOOLS_BIN_DIR)
 export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
@@ -28,8 +29,8 @@ export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
 # Tools                                 #
 #########################################
 
-$(GINKGO): go.mod
-	go build -o $(GINKGO) github.com/onsi/ginkgo/v2/ginkgo
-
 $(GO_ADD_LICENSE):
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install github.com/google/addlicense@$(GO_ADD_LICENSE_VERSION)
+
+$(KUSTOMIZE):
+	@test -s $(TOOLS_BIN_DIR)/kustomize || GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity robustness
/kind enhancement

**What this PR does / why we need it**:
This PR installs the `kustomize` dependency for `Etcd-druid`, which is used by the `make deploy` command [here](https://github.com/gardener/etcd-druid/blob/master/Makefile#L60-L63).

One more thing has been fixed as part of this PR. 
- To address a make warning, the `GINKGO` target has been removed from `etcd-druid/hack/tools.mk`. 
  >**Warning**
  >etcd-druid/vendor/github.com/gardener/gardener/hack/tools.mk:110: warning: overriding commands for target `hack/tools/bin/ginkgo'
  >etcd-druid/hack/tools.mk:32: warning: ignoring old commands for target `hack/tools/bin/ginkgo'

- This is because the `GINKGO` target is always being overridden by `vendor/github.com/gardener/gardener/hack/tools.mk:110`, meaning that the `GINKGO` target from `etcd-druid/hack/tools.mk` is unnecessary

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
