### PR TITLE
etcd-backup-restore:v0.22.0->v0.22.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.22.0"
+  tag: "v0.22.1"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades the etcd-backup-restore from `v0.22.0` to `v0.22.1`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
``` bugfix operator github.com/gardener/etcd-backup-restore #602 @ishan16696
Fixes a bug in snapshotter loop when backup-restore fails to collect events or fails to apply watch if required etcd revision has been compacted.
```
