### PR TITLE
Update etcd custom image version to v3.4.13-bootstrap-9

### DIFF
--- a/api/v1alpha1/types_etcd_test.go
+++ b/api/v1alpha1/types_etcd_test.go
@@ -93,7 +93,7 @@ func getEtcd(name, namespace string) *Etcd {
 	deltaSnapshotPeriod := metav1.Duration{
 		Duration: 300 * time.Second,
 	}
-	imageEtcd := "eu.gcr.io/gardener-project/gardener/etcd:v3.4.13-bootstrap-8"
+	imageEtcd := "eu.gcr.io/gardener-project/gardener/etcd:v3.4.13-bootstrap-9"
 	imageBR := "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.20.2"
 	snapshotSchedule := "0 */24 * * *"
 	defragSchedule := "0 */24 * * *"

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,4 +6,4 @@ images:
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd
-  tag: "v3.4.13-bootstrap-8"
+  tag: "v3.4.13-bootstrap-9"

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -40,7 +40,7 @@ var (
 	clientPort              int32 = 2379
 	serverPort              int32 = 2380
 	backupPort              int32 = 8080
-	imageEtcd                     = "eu.gcr.io/gardener-project/gardener/etcd:v3.4.13-bootstrap-8"
+	imageEtcd                     = "eu.gcr.io/gardener-project/gardener/etcd:v3.4.13-bootstrap-9"
 	imageBR                       = "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.21.0"
 	snapshotSchedule              = "0 */24 * * *"
 	defragSchedule                = "0 */24 * * *"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updated the etcd image used from `v3.4.13-bootstrap-8` to `v3.4.13-bootstrap-9`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
etcd-custom-image updated from `v3.4.13-bootstrap-8` to `v3.4.13-bootstrap-9`
```
