### PR TITLE
Minor cosmetics and streamlining after controller-runtime refactoring

### DIFF
--- a/controllers/custodian/register.go
+++ b/controllers/custodian/register.go
@@ -34,15 +34,16 @@ const controllerName = "custodian-controller"
 
 // RegisterWithManager registers the Custodian Controller with the given controller manager.
 func (r *Reconciler) RegisterWithManager(ctx context.Context, mgr ctrl.Manager, ignoreOperationAnnotation bool) error {
-	builder := ctrl.NewControllerManagedBy(mgr).WithOptions(controller.Options{
-		MaxConcurrentReconciles: r.config.Workers,
-	})
-
-	c, err := builder.
+	c, err := ctrl.
+		NewControllerManagedBy(mgr).
 		Named(controllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: r.config.Workers,
+		}).
 		For(
 			&druidv1alpha1.Etcd{},
-			ctrlbuilder.WithPredicates(druidpredicates.EtcdReconciliationFinished(ignoreOperationAnnotation))).
+			ctrlbuilder.WithPredicates(druidpredicates.EtcdReconciliationFinished(ignoreOperationAnnotation)),
+		).
 		Owns(&coordinationv1.Lease{}).
 		Build(r)
 	if err != nil {

--- a/controllers/etcd/register.go
+++ b/controllers/etcd/register.go
@@ -29,18 +29,21 @@ const controllerName = "etcd-controller"
 
 // RegisterWithManager registers the Etcd Controller with the given controller manager.
 func (r *Reconciler) RegisterWithManager(mgr ctrl.Manager, ignoreOperationAnnotation bool) error {
-	builder := ctrl.NewControllerManagedBy(mgr).WithOptions(controller.Options{
-		MaxConcurrentReconciles: r.config.Workers,
-	})
-	builder = builder.
+	builder := ctrl.
+		NewControllerManagedBy(mgr).
 		Named(controllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: r.config.Workers,
+		}).
 		WithEventFilter(BuildPredicate(ignoreOperationAnnotation)).
 		For(&druidv1alpha1.Etcd{})
+
 	if ignoreOperationAnnotation {
 		builder = builder.Owns(&corev1.Service{}).
 			Owns(&corev1.ConfigMap{}).
 			Owns(&appsv1.StatefulSet{})
 	}
+
 	return builder.Complete(r)
 }
 

--- a/controllers/etcdcopybackupstask/register.go
+++ b/controllers/etcdcopybackupstask/register.go
@@ -19,7 +19,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -30,10 +30,13 @@ const controllerName = "etcdcopybackupstask-controller"
 func (r *Reconciler) RegisterWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(controllerName).
-		For(&druidv1alpha1.EtcdCopyBackupsTask{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Owns(&batchv1.Job{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.Config.Workers,
 		}).
+		For(
+			&druidv1alpha1.EtcdCopyBackupsTask{},
+			ctrlbuilder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Owns(&batchv1.Job{}).
 		Complete(r)
 }

--- a/controllers/secret/register.go
+++ b/controllers/secret/register.go
@@ -28,12 +28,12 @@ const controllerName = "secret-controller"
 
 // RegisterWithManager registers the Secret Controller with the given controller manager.
 func (r *Reconciler) RegisterWithManager(mgr ctrl.Manager) error {
-	builder := ctrl.NewControllerManagedBy(mgr).WithOptions(controller.Options{
-		MaxConcurrentReconciles: r.Config.Workers,
-	})
-
-	c, err := builder.
+	c, err := ctrl.
+		NewControllerManagedBy(mgr).
 		Named(controllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: r.Config.Workers,
+		}).
 		For(&corev1.Secret{}).
 		Build(r)
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality robustness
/kind enhancement

**What this PR does / why we need it**:
This PR does some minor cosmetics and streamlining after the major refactoring in https://github.com/gardener/etcd-druid/pull/506
Now we use builder wherever possible, and the builder functions are arranged consistently.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shreyas-s-rao 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
