### PR TITLE
Added etcd-druid-api content

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,3 +1,17 @@
 structure:
 - name: _index.md
   source: /README.md
+- name: etcd-druid-api
+  nodes:
+  - name: _index.md
+    properties:
+      frontmatter:
+        title: API Reference
+        weight: 1
+        aliases: "/api-reference"
+        categories:
+          - Developers
+    source: https://github.com/gardener/etcd-druid-api/blob/DEFAULT_BRANCH/README.md
+  - name: api-reference
+    nodesSelector:
+      path: https://github.com/gardener/etcd-druid-api/tree/DEFAULT_BRANCH/docs/api-reference


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR adds the contents of the [etcd-druid-api documentation](https://github.com/gardener/etcd-druid-api/tree/main/docs/api-reference) to the [etcd section](https://gardener.cloud/docs/other-components/etcd-druid/) of the public Gardener website.

**Which issue(s) this PR fixes**:
Fixes #561 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
