### PR TITLE
Added support for compaction metrics in druid.

### DIFF
--- a/controllers/compaction/metrics.go
+++ b/controllers/compaction/metrics.go
@@ -1,0 +1,47 @@
+// Copyright 2023 SAP SE or an SAP affiliate company
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compaction
+
+import (
+	druidmetrics "github.com/gardener/etcd-druid/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func init() {
+	// CompactionJobCountTotal
+	CompactionJobCountTotalValues := map[string][]string{
+		druidmetrics.LabelSucceeded: druidmetrics.DruidLabels[druidmetrics.LabelSucceeded],
+	}
+	CompactionJobCounterCombinations := druidmetrics.GenerateLabelCombinations(CompactionJobCountTotalValues)
+	for _, combination := range CompactionJobCounterCombinations {
+		druidmetrics.CompactionJobCounterTotal.With(prometheus.Labels(combination))
+	}
+
+	// CompactionJobDurationSeconds
+	CompactionJobDurationSecondsValues := map[string][]string{
+		druidmetrics.LabelSucceeded: druidmetrics.DruidLabels[druidmetrics.LabelSucceeded],
+	}
+	CompactionJobDurationSecondsCombinations := druidmetrics.GenerateLabelCombinations(CompactionJobDurationSecondsValues)
+	for _, combination := range CompactionJobDurationSecondsCombinations {
+		druidmetrics.CompactionJobDurationSeconds.With(prometheus.Labels(combination))
+	}
+
+	// Metrics have to be registered to be exposed:
+	metrics.Registry.MustRegister(druidmetrics.CompactionJobCounterTotal)
+	metrics.Registry.MustRegister(druidmetrics.CompactionJobDurationSeconds)
+
+	metrics.Registry.MustRegister(druidmetrics.TotalNumberOfEvents)
+}

--- a/controllers/compaction/metrics.go
+++ b/controllers/compaction/metrics.go
@@ -26,8 +26,8 @@ const (
 )
 
 var (
-	// CompactionJobCounterTotal is the metric used to count the total number of compaction jobs initiated by compaction controller.
-	CompactionJobCounterTotal = prometheus.NewCounterVec(
+	// metricJobsTotal is the metric used to count the total number of compaction jobs initiated by compaction controller.
+	metricJobsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespaceEtcdDruid,
 			Subsystem: subsystemCompaction,
@@ -37,8 +37,19 @@ var (
 		[]string{druidmetrics.LabelSucceeded},
 	)
 
-	// CompactionJobDurationSeconds is the metric used to expose the time taken to finish running a compaction job.
-	CompactionJobDurationSeconds = prometheus.NewGaugeVec(
+	// metricJobsCurrent is the metric used to expose currently running comapction job. This metric is important to get a sense of total number of compaction job running in a seed cluster..
+	metricJobsCurrent = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdDruid,
+			Subsystem: subsystemCompaction,
+			Name:      "jobs_current",
+			Help:      "Number of currently running comapction job.",
+		},
+		[]string{druidmetrics.ShootNamespace},
+	)
+
+	// metricJobDurationSeconds is the metric used to expose the time taken to finish running a compaction job.
+	metricJobDurationSeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespaceEtcdDruid,
 			Subsystem: subsystemCompaction,
@@ -48,8 +59,8 @@ var (
 		[]string{druidmetrics.LabelSucceeded},
 	)
 
-	// NumDeltaEvents is the metric used to expose the total number of etcd events to be compacted by a compaction job.
-	NumDeltaEvents = prometheus.NewGaugeVec(
+	// metricNumDeltaEvents is the metric used to expose the total number of etcd events to be compacted by a compaction job.
+	metricNumDeltaEvents = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespaceEtcdDruid,
 			Subsystem: subsystemCompaction,
@@ -61,27 +72,29 @@ var (
 )
 
 func init() {
-	// compactionJobCountTotal
-	compactionJobCountTotalValues := map[string][]string{
+	// metricJobsTotalValues
+	metricJobsTotalValues := map[string][]string{
 		druidmetrics.LabelSucceeded: druidmetrics.DruidLabels[druidmetrics.LabelSucceeded],
 	}
-	compactionJobCounterCombinations := druidmetrics.GenerateLabelCombinations(compactionJobCountTotalValues)
-	for _, combination := range compactionJobCounterCombinations {
-		CompactionJobCounterTotal.With(prometheus.Labels(combination))
+	metricJobsTotalCombinations := druidmetrics.GenerateLabelCombinations(metricJobsTotalValues)
+	for _, combination := range metricJobsTotalCombinations {
+		metricJobsTotal.With(prometheus.Labels(combination))
 	}
 
-	// compactionJobDurationSeconds
-	compactionJobDurationSecondsValues := map[string][]string{
+	// metricJobDurationSecondsValues
+	metricJobDurationSecondsValues := map[string][]string{
 		druidmetrics.LabelSucceeded: druidmetrics.DruidLabels[druidmetrics.LabelSucceeded],
 	}
-	compactionJobDurationSecondsCombinations := druidmetrics.GenerateLabelCombinations(compactionJobDurationSecondsValues)
+	compactionJobDurationSecondsCombinations := druidmetrics.GenerateLabelCombinations(metricJobDurationSecondsValues)
 	for _, combination := range compactionJobDurationSecondsCombinations {
-		CompactionJobDurationSeconds.With(prometheus.Labels(combination))
+		metricJobDurationSeconds.With(prometheus.Labels(combination))
 	}
 
 	// Metrics have to be registered to be exposed:
-	metrics.Registry.MustRegister(CompactionJobCounterTotal)
-	metrics.Registry.MustRegister(CompactionJobDurationSeconds)
+	metrics.Registry.MustRegister(metricJobsTotal)
+	metrics.Registry.MustRegister(metricJobDurationSeconds)
 
-	metrics.Registry.MustRegister(NumDeltaEvents)
+	metrics.Registry.MustRegister(metricJobsCurrent)
+
+	metrics.Registry.MustRegister(metricNumDeltaEvents)
 }

--- a/controllers/compaction/metrics.go
+++ b/controllers/compaction/metrics.go
@@ -45,7 +45,7 @@ var (
 			Name:      "jobs_current",
 			Help:      "Number of currently running comapction job.",
 		},
-		[]string{druidmetrics.ShootNamespace},
+		[]string{druidmetrics.EtcdNamespace},
 	)
 
 	// metricJobDurationSeconds is the metric used to expose the time taken to finish running a compaction job.

--- a/controllers/compaction/metrics.go
+++ b/controllers/compaction/metrics.go
@@ -34,7 +34,7 @@ var (
 			Name:      "jobs_total",
 			Help:      "Total number of compaction jobs initiated by compaction controller.",
 		},
-		[]string{druidmetrics.LabelSucceeded},
+		[]string{druidmetrics.LabelSucceeded, druidmetrics.EtcdNamespace},
 	)
 
 	// metricJobsCurrent is the metric used to expose currently running compaction job. This metric is important to get a sense of total number of compaction job running in a seed cluster.
@@ -56,7 +56,7 @@ var (
 			Name:      "job_duration_seconds",
 			Help:      "Total time taken in seconds to finish a running compaction job.",
 		},
-		[]string{druidmetrics.LabelSucceeded},
+		[]string{druidmetrics.LabelSucceeded, druidmetrics.EtcdNamespace},
 	)
 
 	// metricNumDeltaEvents is the metric used to expose the total number of etcd events to be compacted by a compaction job.
@@ -67,7 +67,7 @@ var (
 			Name:      "num_delta_events",
 			Help:      "Total number of etcd events to be compacted by a compaction job.",
 		},
-		[]string{},
+		[]string{druidmetrics.EtcdNamespace},
 	)
 )
 
@@ -75,6 +75,7 @@ func init() {
 	// metricJobsTotalValues
 	metricJobsTotalValues := map[string][]string{
 		druidmetrics.LabelSucceeded: druidmetrics.DruidLabels[druidmetrics.LabelSucceeded],
+		druidmetrics.EtcdNamespace:  druidmetrics.DruidLabels[druidmetrics.EtcdNamespace],
 	}
 	metricJobsTotalCombinations := druidmetrics.GenerateLabelCombinations(metricJobsTotalValues)
 	for _, combination := range metricJobsTotalCombinations {
@@ -84,6 +85,7 @@ func init() {
 	// metricJobDurationSecondsValues
 	metricJobDurationSecondsValues := map[string][]string{
 		druidmetrics.LabelSucceeded: druidmetrics.DruidLabels[druidmetrics.LabelSucceeded],
+		druidmetrics.EtcdNamespace:  druidmetrics.DruidLabels[druidmetrics.EtcdNamespace],
 	}
 	compactionJobDurationSecondsCombinations := druidmetrics.GenerateLabelCombinations(metricJobDurationSecondsValues)
 	for _, combination := range compactionJobDurationSecondsCombinations {

--- a/controllers/compaction/metrics.go
+++ b/controllers/compaction/metrics.go
@@ -37,7 +37,7 @@ var (
 		[]string{druidmetrics.LabelSucceeded},
 	)
 
-	// metricJobsCurrent is the metric used to expose currently running comapction job. This metric is important to get a sense of total number of compaction job running in a seed cluster..
+	// metricJobsCurrent is the metric used to expose currently running compaction job. This metric is important to get a sense of total number of compaction job running in a seed cluster.
 	metricJobsCurrent = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespaceEtcdDruid,
@@ -48,13 +48,13 @@ var (
 		[]string{druidmetrics.EtcdNamespace},
 	)
 
-	// metricJobDurationSeconds is the metric used to expose the time taken to finish running a compaction job.
-	metricJobDurationSeconds = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
+	// metricJobDurationSeconds is the metric used to expose the time taken to finish a compaction job.
+	metricJobDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Namespace: namespaceEtcdDruid,
 			Subsystem: subsystemCompaction,
 			Name:      "job_duration_seconds",
-			Help:      "Total time taken in seconds to finish running a compaction job.",
+			Help:      "Total time taken in seconds to finish a running compaction job.",
 		},
 		[]string{druidmetrics.LabelSucceeded},
 	)

--- a/controllers/compaction/metrics.go
+++ b/controllers/compaction/metrics.go
@@ -20,28 +20,68 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+const (
+	namespaceEtcdDruid  = "etcddruid"
+	subsystemCompaction = "compaction"
+)
+
+var (
+	// CompactionJobCounterTotal is the metric used to count the total number of compaction jobs initiated by compaction controller.
+	CompactionJobCounterTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespaceEtcdDruid,
+			Subsystem: subsystemCompaction,
+			Name:      "jobs_total",
+			Help:      "Total number of compaction jobs initiated by compaction controller.",
+		},
+		[]string{druidmetrics.LabelSucceeded},
+	)
+
+	// CompactionJobDurationSeconds is the metric used to expose the time taken to finish running a compaction job.
+	CompactionJobDurationSeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdDruid,
+			Subsystem: subsystemCompaction,
+			Name:      "job_duration_seconds",
+			Help:      "Total time taken in seconds to finish running a compaction job.",
+		},
+		[]string{druidmetrics.LabelSucceeded},
+	)
+
+	// NumDeltaEvents is the metric used to expose the total number of etcd events to be compacted by a compaction job.
+	NumDeltaEvents = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdDruid,
+			Subsystem: subsystemCompaction,
+			Name:      "num_delta_events",
+			Help:      "Total number of etcd events to be compacted by a compaction job.",
+		},
+		[]string{},
+	)
+)
+
 func init() {
-	// CompactionJobCountTotal
-	CompactionJobCountTotalValues := map[string][]string{
+	// compactionJobCountTotal
+	compactionJobCountTotalValues := map[string][]string{
 		druidmetrics.LabelSucceeded: druidmetrics.DruidLabels[druidmetrics.LabelSucceeded],
 	}
-	CompactionJobCounterCombinations := druidmetrics.GenerateLabelCombinations(CompactionJobCountTotalValues)
-	for _, combination := range CompactionJobCounterCombinations {
-		druidmetrics.CompactionJobCounterTotal.With(prometheus.Labels(combination))
+	compactionJobCounterCombinations := druidmetrics.GenerateLabelCombinations(compactionJobCountTotalValues)
+	for _, combination := range compactionJobCounterCombinations {
+		CompactionJobCounterTotal.With(prometheus.Labels(combination))
 	}
 
-	// CompactionJobDurationSeconds
-	CompactionJobDurationSecondsValues := map[string][]string{
+	// compactionJobDurationSeconds
+	compactionJobDurationSecondsValues := map[string][]string{
 		druidmetrics.LabelSucceeded: druidmetrics.DruidLabels[druidmetrics.LabelSucceeded],
 	}
-	CompactionJobDurationSecondsCombinations := druidmetrics.GenerateLabelCombinations(CompactionJobDurationSecondsValues)
-	for _, combination := range CompactionJobDurationSecondsCombinations {
-		druidmetrics.CompactionJobDurationSeconds.With(prometheus.Labels(combination))
+	compactionJobDurationSecondsCombinations := druidmetrics.GenerateLabelCombinations(compactionJobDurationSecondsValues)
+	for _, combination := range compactionJobDurationSecondsCombinations {
+		CompactionJobDurationSeconds.With(prometheus.Labels(combination))
 	}
 
 	// Metrics have to be registered to be exposed:
-	metrics.Registry.MustRegister(druidmetrics.CompactionJobCounterTotal)
-	metrics.Registry.MustRegister(druidmetrics.CompactionJobDurationSeconds)
+	metrics.Registry.MustRegister(CompactionJobCounterTotal)
+	metrics.Registry.MustRegister(CompactionJobDurationSeconds)
 
-	metrics.Registry.MustRegister(druidmetrics.TotalNumberOfEvents)
+	metrics.Registry.MustRegister(NumDeltaEvents)
 }

--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -201,7 +201,7 @@ func (r *Reconciler) reconcileJob(ctx context.Context, logger logr.Logger, etcd 
 	if job.Status.Failed > 0 {
 		metricJobsCurrent.With(prometheus.Labels{druidmetrics.EtcdNamespace: etcd.Namespace}).Set(0)
 		if job.Status.StartTime != nil {
-			metricJobDurationSeconds.With(prometheus.Labels{druidmetrics.LabelSucceeded: druidmetrics.ValueSucceededFalse}).Set(time.Since(job.Status.StartTime.Time).Seconds())
+			metricJobDurationSeconds.With(prometheus.Labels{druidmetrics.LabelSucceeded: druidmetrics.ValueSucceededFalse}).Observe(time.Since(job.Status.StartTime.Time).Seconds())
 		}
 		err = r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationForeground))
 		if err != nil {
@@ -220,7 +220,7 @@ func (r *Reconciler) reconcileJob(ctx context.Context, logger logr.Logger, etcd 
 		metricJobsTotal.With(prometheus.Labels{druidmetrics.LabelSucceeded: druidmetrics.ValueSucceededTrue}).Inc()
 		metricJobsCurrent.With(prometheus.Labels{druidmetrics.EtcdNamespace: etcd.Namespace}).Set(0)
 		if job.Status.CompletionTime != nil {
-			metricJobDurationSeconds.With(prometheus.Labels{druidmetrics.LabelSucceeded: druidmetrics.ValueSucceededTrue}).Set(job.Status.CompletionTime.Time.Sub(job.Status.StartTime.Time).Seconds())
+			metricJobDurationSeconds.With(prometheus.Labels{druidmetrics.LabelSucceeded: druidmetrics.ValueSucceededTrue}).Observe(job.Status.CompletionTime.Time.Sub(job.Status.StartTime.Time).Seconds())
 		}
 		return r.delete(ctx, logger, etcd)
 	}

--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -182,7 +182,7 @@ func (r *Reconciler) reconcileJob(ctx context.Context, logger logr.Logger, etcd 
 					RequeueAfter: 10 * time.Second,
 				}, fmt.Errorf("error during compaction job creation: %v", err)
 			}
-			metricJobsCurrent.With(prometheus.Labels{druidmetrics.ShootNamespace: etcd.Namespace}).Set(1)
+			metricJobsCurrent.With(prometheus.Labels{druidmetrics.EtcdNamespace: etcd.Namespace}).Set(1)
 		}
 	}
 
@@ -199,7 +199,7 @@ func (r *Reconciler) reconcileJob(ctx context.Context, logger logr.Logger, etcd 
 
 	// Delete job and requeue if the job failed
 	if job.Status.Failed > 0 {
-		metricJobsCurrent.With(prometheus.Labels{druidmetrics.ShootNamespace: etcd.Namespace}).Set(0)
+		metricJobsCurrent.With(prometheus.Labels{druidmetrics.EtcdNamespace: etcd.Namespace}).Set(0)
 		if job.Status.StartTime != nil {
 			metricJobDurationSeconds.With(prometheus.Labels{druidmetrics.LabelSucceeded: druidmetrics.ValueSucceededFalse}).Set(time.Since(job.Status.StartTime.Time).Seconds())
 		}
@@ -218,7 +218,7 @@ func (r *Reconciler) reconcileJob(ctx context.Context, logger logr.Logger, etcd 
 	// Delete job and return if the job succeeded
 	if job.Status.Succeeded > 0 {
 		metricJobsTotal.With(prometheus.Labels{druidmetrics.LabelSucceeded: druidmetrics.ValueSucceededTrue}).Inc()
-		metricJobsCurrent.With(prometheus.Labels{druidmetrics.ShootNamespace: etcd.Namespace}).Set(0)
+		metricJobsCurrent.With(prometheus.Labels{druidmetrics.EtcdNamespace: etcd.Namespace}).Set(0)
 		if job.Status.CompletionTime != nil {
 			metricJobDurationSeconds.With(prometheus.Labels{druidmetrics.LabelSucceeded: druidmetrics.ValueSucceededTrue}).Set(job.Status.CompletionTime.Time.Sub(job.Status.StartTime.Time).Seconds())
 		}

--- a/docs/development/metrics.md
+++ b/docs/development/metrics.md
@@ -15,8 +15,8 @@ These metrics give an idea about the compaction jobs that run after some interva
 | Name | Description | Type |
 |------|-------------|------|
 | etcddruid_compaction_jobs_total | Total number of compaction jobs initiated by compaction controller. | Counter |
-| etcddruid_compaction_jobs_current | Number of currently running comapction job. | Gauge |
-| etcddruid_compaction_job_duration_seconds | Total time taken in seconds to finish running a compaction job. | Gauge |
+| etcddruid_compaction_jobs_current | Number of currently running compaction job. | Gauge |
+| etcddruid_compaction_job_duration_seconds | Total time taken in seconds to finish a running compaction job. | Histogram |
 | etcddruid_compaction_num_delta_events | Total number of etcd events to be compacted by a compaction job. | Gauge |
 
 There are two labels for `etcddruid_compaction_jobs_total` metrics. The label `succeeded` shows how many of the compaction jobs are succeeded and label `failed` shows how many of compaction jobs are failed.

--- a/docs/development/metrics.md
+++ b/docs/development/metrics.md
@@ -1,0 +1,36 @@
+# Monitoring
+
+etcd-druid uses [Prometheus][prometheus] for metrics reporting. The metrics can be used for real-time monitoring and debugging of compaction jobs.
+
+The simplest way to see the available metrics is to cURL the metrics endpoint `/metrics`. The format is described [here](http://prometheus.io/docs/instrumenting/exposition_formats/).
+
+Follow the [Prometheus getting started doc][prometheus-getting-started] to spin up a Prometheus server to collect etcd metrics.
+
+The naming of metrics follows the suggested [Prometheus best practices][prometheus-naming]. All compaction related metrics are put under namespace `etcddruid` and subsystem `compaction`.
+
+### Compaction
+
+These metrics give an idea about the compaction jobs that run after some interval in shoot control planes. Studying the metrices, we can deduce how many compaction job ran successfully, how many failed, how many delta events compacted etc.
+
+| Name | Description | Type |
+|------|-------------|------|
+| jobs_total | Total number of compaction jobs initiated by compaction controller. | Counter |
+| jobs_current | Number of currently running comapction job. | Gauge |
+| job_duration_seconds | Total time taken in seconds to finish running a compaction job. | Gauge |
+| num_delta_events | Total number of etcd events to be compacted by a compaction job. | Gauge |
+
+There are two labels for `jobs_total` metrics. The label `succeeded` shows how many of the compaction jobs are succeeded and label `failed` shows how many of compaction jobs are failed.
+
+There are two labels for `job_duration_seconds` metrics. The label `succeeded` shows how much time taken by a successful job to complete and label `failed` shows how much time taken by a failed compaction job.
+
+`jobs_current` metric comes with label `shoot_namespace` that indicates the namespace of control plane of a shoot cluster.
+
+
+## Prometheus supplied metrics
+
+The Prometheus client library provides a number of metrics under the `go` and `process` namespaces.
+
+[glossary-proposal]: learning/glossary.md#proposal
+[prometheus]: http://prometheus.io/
+[prometheus-getting-started]: http://prometheus.io/docs/introduction/getting_started/
+[prometheus-naming]: http://prometheus.io/docs/practices/naming/

--- a/docs/development/metrics.md
+++ b/docs/development/metrics.md
@@ -14,16 +14,16 @@ These metrics give an idea about the compaction jobs that run after some interva
 
 | Name | Description | Type |
 |------|-------------|------|
-| jobs_total | Total number of compaction jobs initiated by compaction controller. | Counter |
-| jobs_current | Number of currently running comapction job. | Gauge |
-| job_duration_seconds | Total time taken in seconds to finish running a compaction job. | Gauge |
-| num_delta_events | Total number of etcd events to be compacted by a compaction job. | Gauge |
+| etcddruid_compaction_jobs_total | Total number of compaction jobs initiated by compaction controller. | Counter |
+| etcddruid_compaction_jobs_current | Number of currently running comapction job. | Gauge |
+| etcddruid_compaction_job_duration_seconds | Total time taken in seconds to finish running a compaction job. | Gauge |
+| etcddruid_compaction_num_delta_events | Total number of etcd events to be compacted by a compaction job. | Gauge |
 
-There are two labels for `jobs_total` metrics. The label `succeeded` shows how many of the compaction jobs are succeeded and label `failed` shows how many of compaction jobs are failed.
+There are two labels for `etcddruid_compaction_jobs_total` metrics. The label `succeeded` shows how many of the compaction jobs are succeeded and label `failed` shows how many of compaction jobs are failed.
 
-There are two labels for `job_duration_seconds` metrics. The label `succeeded` shows how much time taken by a successful job to complete and label `failed` shows how much time taken by a failed compaction job.
+There are two labels for `etcddruid_compaction_job_duration_seconds` metrics. The label `succeeded` shows how much time taken by a successful job to complete and label `failed` shows how much time taken by a failed compaction job.
 
-`jobs_current` metric comes with label `shoot_namespace` that indicates the namespace of control plane of a shoot cluster.
+`etcddruid_compaction_jobs_current` metric comes with label `etcd_namespace` that indicates the namespace of the ETCD running in the control plane of a shoot cluster..
 
 
 ## Prometheus supplied metrics

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/onsi/ginkgo/v2 v2.6.1
 	github.com/onsi/gomega v1.24.2
+	github.com/prometheus/client_golang v1.14.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	k8s.io/api v0.26.1
@@ -87,7 +88,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,163 @@
+// Copyright 2019 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sort"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// LabelSucceeded is a metric label indicating whether associated metric
+	// series is for success or failure.
+	LabelSucceeded = "succeeded"
+	// ValueSucceededTrue is value True for metric label succeeded.
+	ValueSucceededTrue = "true"
+	// ValueSucceededFalse is value False for metric label failed.
+	ValueSucceededFalse = "false"
+	// CompactionJobSubmitted is value for metric of total number of compaction jobs initiated by compaction controller.
+	CompactionJobSubmitted = "compaction_jobs"
+	// ValueRestoreSingleNode is value for metric of single node restoration.
+	ValueRestoreSingleNode = "single_node"
+	// LabelError is a metric error to indicate error occured.
+	LabelError = "error"
+
+	namespaceEtcdDruid  = "etcd_druid"
+	subsystemCompaction = "compaction"
+)
+
+var (
+	// DruidLabels are the labels for prometheus metrics
+	DruidLabels = map[string][]string{
+		LabelSucceeded: {
+			ValueSucceededFalse,
+			ValueSucceededTrue,
+		},
+	}
+
+	// CompactionJobCounterTotal is metric to count the total number of compaction jobs initiated by compaction controller.
+	CompactionJobCounterTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespaceEtcdDruid,
+			Subsystem: subsystemCompaction,
+			Name:      "compaction_job_total",
+			Help:      "Total number of compaction jobs initiated.",
+		},
+		[]string{LabelSucceeded},
+	)
+
+	// CompactionJobDurationSeconds is metric to expose duration to complete last compaction job.
+	CompactionJobDurationSeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdDruid,
+			Subsystem: subsystemCompaction,
+			Name:      "compaction_job_duration_seconds",
+			Help:      "Total time taken in seconds to complete last compaction job.",
+		},
+		[]string{LabelSucceeded},
+	)
+
+	// TotalNumberOfEvents is metric to expose the total number of events compacted by last compaction job.
+	TotalNumberOfEvents = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespaceEtcdDruid,
+			Subsystem: subsystemCompaction,
+			Name:      "total_number_of_events",
+			Help:      "Total number of events compacted by last compaction job.",
+		},
+		[]string{},
+	)
+)
+
+// GenerateLabelCombinations generates combinations of label values for metrics
+func GenerateLabelCombinations(labelValues map[string][]string) []map[string]string {
+	labels := make([]string, len(labelValues))
+	valuesList := make([][]string, len(labelValues))
+	valueCounts := make([]int, len(labelValues))
+	i := 0
+	for label := range labelValues {
+		labels[i] = label
+		i++
+	}
+	sort.Strings(labels)
+	for i, label := range labels {
+		values := make([]string, len(labelValues[label]))
+		copy(values, labelValues[label])
+		valuesList[i] = values
+		valueCounts[i] = len(values)
+	}
+	combinations := getCombinations(valuesList)
+
+	output := make([]map[string]string, len(combinations))
+	for i, combination := range combinations {
+		labelVals := make(map[string]string, len(labels))
+		for j := 0; j < len(labels); j++ {
+			labelVals[labels[j]] = combination[j]
+		}
+		output[i] = labelVals
+	}
+	return output
+}
+
+// getCombinations returns combinations of slice of string slices
+func getCombinations(valuesList [][]string) [][]string {
+	if len(valuesList) == 0 {
+		return [][]string{}
+	} else if len(valuesList) == 1 {
+		return wrapInSlice(valuesList[0])
+	}
+
+	return cartesianProduct(wrapInSlice(valuesList[0]), getCombinations(valuesList[1:]))
+}
+
+// cartesianProduct combines two slices of slice of strings while also
+// combining the sub-slices of strings into a single string
+// Ex:
+// a => [[p,q],[r,s]]
+// b => [[1,2],[3,4]]
+// Output => [[p,q,1,2],[p,q,3,4],[r,s,1,2],[r,s,3,4]]
+func cartesianProduct(a [][]string, b [][]string) [][]string {
+	output := make([][]string, len(a)*len(b))
+	for i := 0; i < len(a); i++ {
+		for j := 0; j < len(b); j++ {
+			arr := make([]string, len(a[i])+len(b[j]))
+			ctr := 0
+			for ii := 0; ii < len(a[i]); ii++ {
+				arr[ctr] = a[i][ii]
+				ctr++
+			}
+			for jj := 0; jj < len(b[j]); jj++ {
+				arr[ctr] = b[j][jj]
+				ctr++
+			}
+			output[(i*len(b))+j] = arr
+		}
+	}
+	return output
+}
+
+// wrapInSlice is a helper function to wrap a slice of strings within
+// a slice of slices of strings
+// Ex: [p,q,r] -> [[p],[q],[r]]
+func wrapInSlice(s []string) [][]string {
+	output := make([][]string, len(s))
+	for i := 0; i < len(output); i++ {
+		elem := make([]string, 1)
+		elem[0] = s[i]
+		output[i] = elem
+	}
+	return output
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,6 +24,9 @@ const (
 	ValueSucceededTrue = "true"
 	// ValueSucceededFalse is value False for metric label failed.
 	ValueSucceededFalse = "false"
+
+	// ShootNamespace is the label for prometheus metrics to indicate shoot namespace
+	ShootNamespace = "shoot_namespace"
 )
 
 var (

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -25,8 +25,8 @@ const (
 	// ValueSucceededFalse is value False for metric label failed.
 	ValueSucceededFalse = "false"
 
-	// ShootNamespace is the label for prometheus metrics to indicate shoot namespace
-	ShootNamespace = "shoot_namespace"
+	// EtcdNamespace is the label for prometheus metrics to indicate etcd namespace
+	EtcdNamespace = "etcd_namespace"
 )
 
 var (

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The etcd Authors
+// Copyright 2023 SAP SE or an SAP affiliate company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,11 +14,7 @@
 
 package metrics
 
-import (
-	"sort"
-
-	"github.com/prometheus/client_golang/prometheus"
-)
+import "sort"
 
 const (
 	// LabelSucceeded is a metric label indicating whether associated metric
@@ -28,15 +24,6 @@ const (
 	ValueSucceededTrue = "true"
 	// ValueSucceededFalse is value False for metric label failed.
 	ValueSucceededFalse = "false"
-	// CompactionJobSubmitted is value for metric of total number of compaction jobs initiated by compaction controller.
-	CompactionJobSubmitted = "compaction_jobs"
-	// ValueRestoreSingleNode is value for metric of single node restoration.
-	ValueRestoreSingleNode = "single_node"
-	// LabelError is a metric error to indicate error occured.
-	LabelError = "error"
-
-	namespaceEtcdDruid  = "etcd_druid"
-	subsystemCompaction = "compaction"
 )
 
 var (
@@ -47,39 +34,6 @@ var (
 			ValueSucceededTrue,
 		},
 	}
-
-	// CompactionJobCounterTotal is metric to count the total number of compaction jobs initiated by compaction controller.
-	CompactionJobCounterTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: namespaceEtcdDruid,
-			Subsystem: subsystemCompaction,
-			Name:      "compaction_job_total",
-			Help:      "Total number of compaction jobs initiated.",
-		},
-		[]string{LabelSucceeded},
-	)
-
-	// CompactionJobDurationSeconds is metric to expose duration to complete last compaction job.
-	CompactionJobDurationSeconds = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: namespaceEtcdDruid,
-			Subsystem: subsystemCompaction,
-			Name:      "compaction_job_duration_seconds",
-			Help:      "Total time taken in seconds to complete last compaction job.",
-		},
-		[]string{LabelSucceeded},
-	)
-
-	// TotalNumberOfEvents is metric to expose the total number of events compacted by last compaction job.
-	TotalNumberOfEvents = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: namespaceEtcdDruid,
-			Subsystem: subsystemCompaction,
-			Name:      "total_number_of_events",
-			Help:      "Total number of events compacted by last compaction job.",
-		},
-		[]string{},
-	)
 )
 
 // GenerateLabelCombinations generates combinations of label values for metrics

--- a/pkg/metrics/metrics_suite_test.go
+++ b/pkg/metrics/metrics_suite_test.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}

--- a/pkg/metrics/metrics_suite_test.go
+++ b/pkg/metrics/metrics_suite_test.go
@@ -1,5 +1,19 @@
 package metrics
 
+// Copyright 2023 SAP SE or an SAP affiliate company
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import (
 	"testing"
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 SAP SE or an SAP affiliate company
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package metrics
 
 import (

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,76 @@
+package metrics
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Metrics", func() {
+	Describe("Testing helper functions for metrics initialization", func() {
+		Context("Testing wrapInSlice with input", func() {
+			It("should return expected output", func() {
+				input := []string{"a", "b", "c"}
+				expectedOutput := [][]string{{"a"}, {"b"}, {"c"}}
+				output := wrapInSlice(input)
+				Expect(output).Should(Equal(expectedOutput))
+			})
+		})
+		Context("Testing cartesianProduct with inputs", func() {
+			It("should return expected output", func() {
+				input1 := [][]string{{"p", "q"}, {"r", "s"}}
+				input2 := [][]string{{"1", "2"}, {"3", "4"}}
+				expectedOutput := [][]string{
+					{"p", "q", "1", "2"},
+					{"p", "q", "3", "4"},
+					{"r", "s", "1", "2"},
+					{"r", "s", "3", "4"},
+				}
+				output := cartesianProduct(input1, input2)
+				Expect(output).Should(Equal(expectedOutput))
+			})
+		})
+		Context("Testing generateLabelCombinations with input of one label", func() {
+			It("should return expected output", func() {
+				input := map[string][]string{
+					"a": {
+						"1",
+						"2",
+						"3",
+					},
+				}
+				expectedOutput := []map[string]string{
+					{"a": "1"},
+					{"a": "2"},
+					{"a": "3"},
+				}
+				output := GenerateLabelCombinations(input)
+				Expect(output).Should(Equal(expectedOutput))
+			})
+		})
+		Context("Testing generateLabelCombinations with input of two labels", func() {
+			It("should return expected output", func() {
+				input := map[string][]string{
+					"a": {
+						"1",
+						"2",
+						"3",
+					},
+					"b": {
+						"4",
+						"5",
+					},
+				}
+				expectedOutput := []map[string]string{
+					{"a": "1", "b": "4"},
+					{"a": "1", "b": "5"},
+					{"a": "2", "b": "4"},
+					{"a": "2", "b": "5"},
+					{"a": "3", "b": "4"},
+					{"a": "3", "b": "5"},
+				}
+				output := GenerateLabelCombinations(input)
+				Expect(output).Should(Equal(expectedOutput))
+			})
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area disaster-recovery
/kind technical-debt

**What this PR does / why we need it**:
This PR exposes metrics related to compaction job initiated by druid.

**Which issue(s) this PR fixes**:
Fixes #515 

**Special notes for your reviewer**:
As per the issue description, this PR exposes metrices for number of successful jobs, number of failed jobs, time taken to complete last job, number of delta events compacted, but it does not expose CPU and Memory consumption by last successful job. Resource consumption is the gauge that can only be measured from inside the job. Druid doesn't have access to that.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Druid now exposes metrics related to snapshot compaction, on default port 8080. Please expose the desired metrics port via the etcd-druid service to allow metrics to be scraped by a Prometheus instance.
```
