### PR TITLE
Upgrade to go 1.20.3

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,13 +24,13 @@ etcd-druid:
                 build: ~
     steps:
       check:
-        image: 'golang:1.20.1'
+        image: 'golang:1.20.3'
       test:
-        image: 'golang:1.20.1'
+        image: 'golang:1.20.3'
       test_integration:
-        image: 'golang:1.20.1'
+        image: 'golang:1.20.3'
       build:
-        image: 'golang:1.20.1'
+        image: 'golang:1.20.3'
         output_dir: 'binary'
 
   jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.1 as builder
+FROM golang:1.20.3 as builder
 WORKDIR /go/src/github.com/gardener/etcd-druid
 COPY . .
 

--- a/pkg/component/etcd/poddisruptionbudget/values.go
+++ b/pkg/component/etcd/poddisruptionbudget/values.go
@@ -17,11 +17,9 @@ package poddisruptionbudget
 import "k8s.io/apimachinery/pkg/types"
 
 const (
-	ownedByAnnotationKey   = "gardener.cloud/owned-by"
-	ownerTypeAnnotationKey = "gardener.cloud/owner-type"
-	instanceKey            = "instance"
-	nameKey                = "name"
-	appKey                 = "app"
+	instanceKey = "instance"
+	nameKey     = "name"
+	appKey      = "app"
 )
 
 // Values contains the values necessary for creating PodDisruptionBudget.

--- a/pkg/component/etcd/poddisruptionbudget/valueshelper.go
+++ b/pkg/component/etcd/poddisruptionbudget/valueshelper.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"github.com/gardener/etcd-druid/pkg/common"
 )
 
 // GenerateValues generates `poddisruptionbudget.Values` for the lease component with the given parameters.
@@ -33,8 +34,8 @@ func GenerateValues(etcd *druidv1alpha1.Etcd) Values {
 	}
 
 	annotations := map[string]string{
-		ownedByAnnotationKey:   fmt.Sprintf("%s/%s", etcd.Namespace, etcd.Name),
-		ownerTypeAnnotationKey: "etcd",
+		common.GardenerOwnedBy:   fmt.Sprintf("%s/%s", etcd.Namespace, etcd.Name),
+		common.GardenerOwnerType: "etcd",
 	}
 
 	return Values{

--- a/test/utils/etcdcopybackupstask.go
+++ b/test/utils/etcdcopybackupstask.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"github.com/gardener/etcd-druid/pkg/common"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,7 +116,7 @@ func CreateEtcdCopyBackupsJob(taskName, namespace string) *batchv1.Job {
 
 func createJobAnnotations(taskName, namespace string) map[string]string {
 	annotations := make(map[string]string, 2)
-	annotations["gardener.cloud/owned-by"] = fmt.Sprintf("%s/%s", namespace, taskName)
-	annotations["gardener.cloud/owner-type"] = "etcdcopybackupstask"
+	annotations[common.GardenerOwnedBy] = fmt.Sprintf("%s/%s", namespace, taskName)
+	annotations[common.GardenerOwnerType] = "etcdcopybackupstask"
 	return annotations
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR upgrades the golang runtime and build version to go `1.20`. Also makes minor fixes by reusing `gardener.cloud` annotations in the code.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Upgrade to go 1.20.3.
```
