### PR TITLE
Block public access to S3 bucket as per standard compliance rules

### DIFF
--- a/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/controllers/etcdcopybackupstask/reconciler_test.go
@@ -536,7 +536,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 				Expect(*hostPathVolumeSource.Type).To(Equal(corev1.HostPathDirectory))
 			})
 
-			It("should create the correct volumes when store.SecretRef is not refered", func() {
+			It("should create the correct volumes when store.SecretRef is not referred", func() {
 				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
 				store.SecretRef = &corev1.SecretReference{Name: secret.Name}

--- a/hack/e2e-test/infrastructure/overlays/aws/common/files/common.sh
+++ b/hack/e2e-test/infrastructure/overlays/aws/common/files/common.sh
@@ -49,7 +49,8 @@ function create_s3_bucket() {
   result=$(aws ${ENDPOINT_URL} s3api get-bucket-location --bucket ${TEST_ID} 2>&1 || true)
   if [[ $result == *NoSuchBucket* ]]; then
     echo "Creating S3 bucket ${TEST_ID} in region ${AWS_REGION}"
-    aws ${ENDPOINT_URL} s3api create-bucket --bucket ${TEST_ID} --region ${AWS_REGION} --create-bucket-configuration LocationConstraint=${AWS_REGION}
+    aws ${ENDPOINT_URL} s3api create-bucket --bucket ${TEST_ID} --region ${AWS_REGION} --create-bucket-configuration LocationConstraint=${AWS_REGION} --acl private
+    aws ${ENDPOINT_URL} s3api put-public-access-block --bucket ${TEST_ID} --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
   else
     echo $result
     if [[ $result != *${AWS_REGION}* ]]; then

--- a/hack/e2e-test/infrastructure/overlays/aws/common/files/common.sh
+++ b/hack/e2e-test/infrastructure/overlays/aws/common/files/common.sh
@@ -17,7 +17,6 @@
 ENDPOINT_URL=""
 if [[ -n "${LOCALSTACK_HOST}" ]]; then
   ENDPOINT_URL=" --endpoint-url=http://${LOCALSTACK_HOST}"
-
 fi
 
 function setup_aws() {
@@ -50,7 +49,12 @@ function create_s3_bucket() {
   if [[ $result == *NoSuchBucket* ]]; then
     echo "Creating S3 bucket ${TEST_ID} in region ${AWS_REGION}"
     aws ${ENDPOINT_URL} s3api create-bucket --bucket ${TEST_ID} --region ${AWS_REGION} --create-bucket-configuration LocationConstraint=${AWS_REGION} --acl private
+    # Block public access to the S3 bucket
     aws ${ENDPOINT_URL} s3api put-public-access-block --bucket ${TEST_ID} --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+    # Deny non-HTTPS requests to the S3 bucket, except for localstack which is exposed on an HTTP endpoint
+    if [[ -z "${LOCALSTACK_HOST}" ]]; then
+      aws ${ENDPOINT_URL} s3api put-bucket-policy --bucket ${TEST_ID} --policy "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:*\",\"Resource\":[\"arn:aws:s3:::${TEST_ID}\",\"arn:aws:s3:::${TEST_ID}/*\"],\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"false\"},\"NumericLessThan\":{\"s3:TlsVersion\":\"1.2\"}}}]}"
+    fi
   else
     echo $result
     if [[ $result != *${AWS_REGION}* ]]; then

--- a/pkg/health/condition/check_backup_ready.go
+++ b/pkg/health/condition/check_backup_ready.go
@@ -31,7 +31,7 @@ type backupReadyCheck struct {
 }
 
 const (
-	// BackupSucceeded is a constant that means that etcd backup has been sucessfully taken
+	// BackupSucceeded is a constant that means that etcd backup has been successfully taken
 	BackupSucceeded string = "BackupSucceeded"
 	// BackupFailed is a constant that means that etcd backup has failed
 	BackupFailed string = "BackupFailed"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/area security
/area compliance
/kind task
/kind test
/platform aws

**What this PR does / why we need it**:
This PR configures the S3 buckets created by e2e tests to be blocked from public access as per standard practices. This is achieved by putting a public-access-block on the created bucket, as per [AWS documentation](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-public-access-block.html).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement developer
Block public access for S3 buckets created by e2e tests.
```
