### PR TITLE
Etcd controller shouldn't removes the scale-up annotation until scale-up succeeds

### DIFF
--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -476,6 +476,16 @@ func getStsAnnotations(val *Values, sts *appsv1.StatefulSet) map[string]string {
 		},
 		val.Annotations,
 	)
+
+	// If `scaleToMultiNodeAnnotationKey` annotation is already present in etcd statefulset
+	// then it is better to check scale-up was successful or not before removing `scaleToMultiNodeAnnotationKey` annotation.
+	if metav1.HasAnnotation(sts.ObjectMeta, scaleToMultiNodeAnnotationKey) {
+		if (sts.Spec.Replicas != nil && sts.Status.UpdatedReplicas < *sts.Spec.Replicas) || sts.Status.Replicas > sts.Status.UpdatedReplicas {
+			annotations[scaleToMultiNodeAnnotationKey] = ""
+			return annotations
+		}
+	}
+
 	if clusterScaledUpToMultiNode(val, sts) {
 		annotations[scaleToMultiNodeAnnotationKey] = ""
 	}

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -479,8 +479,8 @@ func getStsAnnotations(val *Values, sts *appsv1.StatefulSet) map[string]string {
 
 	// If `scaleToMultiNodeAnnotationKey` annotation is already present in etcd statefulset
 	// then it is better to check scale-up was successful or not before removing `scaleToMultiNodeAnnotationKey` annotation.
-	if metav1.HasAnnotation(sts.ObjectMeta, scaleToMultiNodeAnnotationKey) {
-		if (sts.Spec.Replicas != nil && sts.Status.UpdatedReplicas < *sts.Spec.Replicas) || sts.Status.Replicas > sts.Status.UpdatedReplicas {
+	if sts != nil && metav1.HasAnnotation(sts.ObjectMeta, scaleToMultiNodeAnnotationKey) {
+		if sts.Status.UpdatedReplicas < *sts.Spec.Replicas || sts.Status.Replicas > sts.Status.UpdatedReplicas {
 			annotations[scaleToMultiNodeAnnotationKey] = ""
 			return annotations
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Etcd controller shouldn't removes the scale-up annotation from etcd statefulset until scale-up succeeds.

**Which issue(s) this PR fixes**:
Fixes #582 

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Added check to ensure that the scale up annotation is removed from the etcd statefulset only when scale-up succeeds
```
