### PR TITLE
Enhance test cases to scale single-node `etcd` to multi-node `etcd` cluster

### DIFF
--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Etcd", func() {
 
 			By("Scaling up cluster (from 0 to 1)")
 			Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
-			etcd.Spec.Replicas = multiNodeEtcdReplicas
+			etcd.Spec.Replicas = 1
 			updateAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 
 			By("Scaling up a healthy cluster (from 1 to 3)")

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Etcd", func() {
 			deleteAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 		})
 
-		It("should scale down a single-node etcd and then scale up to a multi-node etcd cluster", func() {
+		It("should scale down a single-node etcd to 0, then scale from 0->1 and then from 1->3", func() {
 			ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
 			defer cancelFunc()
 

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Etcd", func() {
 			deleteAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 		})
 
-		It("should scale down a single-node etcd to 0, then scale from 0->1 and then from 1->3", func() {
+		It("should scale down a single-node etcd to 0, then scale up from 0->1 replicas and then from 1->3 replicas", func() {
 			ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
 			defer cancelFunc()
 
@@ -165,17 +165,17 @@ var _ = Describe("Etcd", func() {
 			By("Creating a single-node etcd")
 			createAndCheckEtcd(ctx, cl, objLogger, etcd, singleNodeEtcdTimeout)
 
-			By("Scaling down a healthy cluster (from 1 to 0)")
+			By("Scaling down a healthy cluster (from 1 to 0 replica)")
 			Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
 			etcd.Spec.Replicas = 0
 			updateAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 
-			By("Scaling up cluster (from 0 to 1)")
+			By("Scaling up cluster (from 0 to 1 replica)")
 			Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
 			etcd.Spec.Replicas = 1
 			updateAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 
-			By("Scaling up a healthy cluster (from 1 to 3)")
+			By("Scaling up a healthy cluster (from 1 to 3 replica)")
 			Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
 			etcd.Spec.Replicas = 3
 			updateAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -183,30 +183,6 @@ var _ = Describe("Etcd", func() {
 			By("Deleting the single-node etcd")
 			deleteAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 		})
-
-		It("should scale down a single-node etcd and scale up to a multi-node etcd cluster without intermediate scaling", func() {
-			ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
-			defer cancelFunc()
-
-			etcd := getDefaultEtcd(etcdName, namespace, storageContainer, storePrefix, provider)
-			objLogger := logger.WithValues("etcd-multi-node", client.ObjectKeyFromObject(etcd))
-
-			By("Creating a single-node etcd")
-			createAndCheckEtcd(ctx, cl, objLogger, etcd, singleNodeEtcdTimeout)
-
-			By("Scaling down a healthy cluster (from 1 to 0)")
-			Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
-			etcd.Spec.Replicas = 0
-			updateAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
-
-			By("Scaling up cluster (from 0 to 3)")
-			Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
-			etcd.Spec.Replicas = multiNodeEtcdReplicas
-			updateAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
-
-			By("Deleting the single-node etcd")
-			deleteAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
-		})
 	})
 })
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing high-availability
/kind enhancement test

**What this PR does / why we need it**:

This PR enhances the existing test cases by adding various scenarios for scaling a single-node `etcd` cluster to a multi-node `etcd` cluster. The new test cases cover the following scenarios:

1. Scaling a single-node `etcd` directly to a multi-node `etcd` cluster.
2. Scaling down a single-node `etcd` to zero nodes and then scaling up to a multi-node `etcd` cluster.


These additional test cases will help ensure the robustness of our `etcd` scaling implementation and increase confidence in the stability of the system.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
