### PR TITLE
Fixes scaleup from single-node to multi-node etcd cluster

### DIFF
--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -361,7 +361,7 @@ func (r *Reconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, etcd
 		return reconcileResult{err: err}
 	}
 
-	peerTLSEnabled, err := leaseDeployer.GetPeerURLTLSEnabledStatus(ctx)
+	peerTLSEnabled, err := druidutils.IsPeerURLTLSEnabled(ctx, r.Client, etcd.Namespace, etcd.Name, logger)
 	if err != nil {
 		return reconcileResult{err: err}
 	}

--- a/pkg/component/etcd/lease/lease.go
+++ b/pkg/component/etcd/lease/lease.go
@@ -30,9 +30,6 @@ import (
 // Interface provides a facade for operations on leases.
 type Interface interface {
 	gardenercomponent.Deployer
-	// GetPeerURLTLSEnabledStatus checks the Peer URL TLS enabled status by inspecting all the lease objects and returns
-	// a result after applying value captured in the lease object for each member in conjunction.
-	GetPeerURLTLSEnabledStatus(context.Context) (bool, error)
 }
 type component struct {
 	client    client.Client
@@ -81,18 +78,6 @@ func (c *component) Destroy(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (c *component) GetPeerURLTLSEnabledStatus(ctx context.Context) (bool, error) {
-	tlsEnabledValues, err := c.getTLSEnabledAnnotationValues(ctx, c.values.EtcdName)
-	if err != nil {
-		return false, err
-	}
-	tlsEnabled := true
-	for _, v := range tlsEnabledValues {
-		tlsEnabled = tlsEnabled && v
-	}
-	return tlsEnabled, nil
 }
 
 // New creates a new lease deployer instance.

--- a/pkg/component/etcd/lease/lease_member.go
+++ b/pkg/component/etcd/lease/lease_member.go
@@ -17,11 +17,9 @@ package lease
 import (
 	"context"
 	"fmt"
-	"strconv"
 
-	"github.com/gardener/etcd-druid/pkg/common"
+	"github.com/gardener/etcd-druid/pkg/utils"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -30,7 +28,7 @@ import (
 )
 
 func (c *component) deleteAllMemberLeases(ctx context.Context) error {
-	labels := getMemberLeaseLabels(c.values.EtcdName)
+	labels := utils.GetMemberLeaseLabels(c.values.EtcdName)
 
 	return c.client.DeleteAllOf(ctx, &coordinationv1.Lease{}, client.InNamespace(c.namespace), client.MatchingLabels(labels))
 }
@@ -39,7 +37,7 @@ func (c *component) syncMemberLeases(ctx context.Context) error {
 	var (
 		fns []flow.TaskFn
 
-		labels     = getMemberLeaseLabels(c.values.EtcdName)
+		labels     = utils.GetMemberLeaseLabels(c.values.EtcdName)
 		prefix     = c.values.EtcdName
 		leaseNames = sets.NewString()
 	)
@@ -86,48 +84,6 @@ func (c *component) syncMemberLeases(ctx context.Context) error {
 	}
 
 	return flow.Parallel(fns...)(ctx)
-}
-
-func (c *component) getTLSEnabledAnnotationValues(ctx context.Context, etcdName string) ([]bool, error) {
-	var tlsEnabledValues []bool
-	labels := getMemberLeaseLabels(etcdName)
-	leaseList := &coordinationv1.LeaseList{}
-	if err := c.client.List(ctx, leaseList, client.InNamespace(c.namespace), client.MatchingLabels(labels)); err != nil {
-		return nil, err
-	}
-	for _, lease := range leaseList.Items {
-		tlsEnabled := c.parseAndGetTLSEnabledValue(lease)
-		if tlsEnabled != nil {
-			tlsEnabledValues = append(tlsEnabledValues, *tlsEnabled)
-		}
-	}
-	return tlsEnabledValues, nil
-}
-
-func (c *component) parseAndGetTLSEnabledValue(lease coordinationv1.Lease) *bool {
-	const peerURLTLSEnabledKey = "member.etcd.gardener.cloud/tls-enabled"
-	if lease.Annotations != nil {
-		if tlsEnabledStr, ok := lease.Annotations[peerURLTLSEnabledKey]; ok {
-			tlsEnabled, err := strconv.ParseBool(tlsEnabledStr)
-			if err != nil {
-				c.logger.Error(err, "tls-enabled value is not a valid boolean", "namespace", lease.Namespace, "leaseName", lease.Name)
-				return nil
-			}
-			return &tlsEnabled
-		}
-		c.logger.V(4).Info("tls-enabled annotation not present for lease.", "namespace", lease.Namespace, "leaseName", lease.Name)
-	}
-	return nil
-}
-
-// PurposeMemberLease is a constant used as a purpose for etcd member lease objects.
-const PurposeMemberLease = "etcd-member-lease"
-
-func getMemberLeaseLabels(etcdName string) map[string]string {
-	return map[string]string{
-		common.GardenerOwnedBy:           etcdName,
-		v1beta1constants.GardenerPurpose: PurposeMemberLease,
-	}
 }
 
 func memberLeaseName(etcdName string, replica int) string {

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -143,7 +143,6 @@ var _ = Describe("Statefulset", func() {
 
 		sts = &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
-
 				Name:      values.Name,
 				Namespace: values.Namespace,
 			},

--- a/pkg/health/etcdmember/check_ready.go
+++ b/pkg/health/etcdmember/check_ready.go
@@ -19,8 +19,6 @@ import (
 	"strings"
 	"time"
 
-	componentlease "github.com/gardener/etcd-druid/pkg/component/etcd/lease"
-
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -32,6 +30,7 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/etcd-druid/pkg/common"
+	"github.com/gardener/etcd-druid/pkg/utils"
 )
 
 type readyCheck struct {
@@ -52,7 +51,7 @@ func (r *readyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) []Resul
 
 	leases := &coordinationv1.LeaseList{}
 	if err := r.cl.List(ctx, leases, client.InNamespace(etcd.Namespace), client.MatchingLabels{
-		common.GardenerOwnedBy: etcd.Name, v1beta1constants.GardenerPurpose: componentlease.PurposeMemberLease}); err != nil {
+		common.GardenerOwnedBy: etcd.Name, v1beta1constants.GardenerPurpose: utils.PurposeMemberLease}); err != nil {
 		r.logger.Error(err, "failed to get leases for etcd member readiness check")
 	}
 

--- a/pkg/health/etcdmember/check_ready_test.go
+++ b/pkg/health/etcdmember/check_ready_test.go
@@ -39,9 +39,9 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/etcd-druid/pkg/common"
-	componentlease "github.com/gardener/etcd-druid/pkg/component/etcd/lease"
 	. "github.com/gardener/etcd-druid/pkg/health/etcdmember"
 	mockclient "github.com/gardener/etcd-druid/pkg/mock/controller-runtime/client"
+	"github.com/gardener/etcd-druid/pkg/utils"
 )
 
 var _ = Describe("ReadyCheck", func() {
@@ -89,7 +89,7 @@ var _ = Describe("ReadyCheck", func() {
 
 		JustBeforeEach(func() {
 			cl.EXPECT().List(ctx, gomock.AssignableToTypeOf(&coordinationv1.LeaseList{}), client.InNamespace(etcd.Namespace),
-				client.MatchingLabels{common.GardenerOwnedBy: etcd.Name, v1beta1constants.GardenerPurpose: componentlease.PurposeMemberLease}).
+				client.MatchingLabels{common.GardenerOwnedBy: etcd.Name, v1beta1constants.GardenerPurpose: utils.PurposeMemberLease}).
 				DoAndReturn(
 					func(_ context.Context, leases *coordinationv1.LeaseList, _ ...client.ListOption) error {
 						*leases = *leasesList

--- a/pkg/utils/lease.go
+++ b/pkg/utils/lease.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/gardener/etcd-druid/pkg/common"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/go-logr/logr"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsPeerURLTLSEnabled checks if the TLS has been enabled for all existing members of an etcd cluster identified by etcdName and in the provided namespace.
+func IsPeerURLTLSEnabled(ctx context.Context, cli client.Client, namespace, etcdName string, logger logr.Logger) (bool, error) {
+	var tlsEnabledValues []bool
+	labels := GetMemberLeaseLabels(etcdName)
+	leaseList := &coordinationv1.LeaseList{}
+	if err := cli.List(ctx, leaseList, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {
+		return false, err
+	}
+	for _, lease := range leaseList.Items {
+		tlsEnabled := parseAndGetTLSEnabledValue(lease, logger)
+		if tlsEnabled != nil {
+			tlsEnabledValues = append(tlsEnabledValues, *tlsEnabled)
+		}
+	}
+	tlsEnabled := true
+	for _, v := range tlsEnabledValues {
+		tlsEnabled = tlsEnabled && v
+	}
+	return tlsEnabled, nil
+}
+
+// PurposeMemberLease is a constant used as a purpose for etcd member lease objects.
+const PurposeMemberLease = "etcd-member-lease"
+
+// GetMemberLeaseLabels creates a map of default labels for member lease.
+func GetMemberLeaseLabels(etcdName string) map[string]string {
+	return map[string]string{
+		common.GardenerOwnedBy:           etcdName,
+		v1beta1constants.GardenerPurpose: PurposeMemberLease,
+	}
+}
+
+func parseAndGetTLSEnabledValue(lease coordinationv1.Lease, logger logr.Logger) *bool {
+	const peerURLTLSEnabledKey = "member.etcd.gardener.cloud/tls-enabled"
+	if lease.Annotations != nil {
+		if tlsEnabledStr, ok := lease.Annotations[peerURLTLSEnabledKey]; ok {
+			tlsEnabled, err := strconv.ParseBool(tlsEnabledStr)
+			if err != nil {
+				logger.Error(err, "tls-enabled value is not a valid boolean", "namespace", lease.Namespace, "leaseName", lease.Name)
+				return nil
+			}
+			return &tlsEnabled
+		}
+		logger.V(4).Info("tls-enabled annotation not present for lease.", "namespace", lease.Namespace, "leaseName", lease.Name)
+	}
+	return nil
+}

--- a/pkg/utils/statefulset.go
+++ b/pkg/utils/statefulset.go
@@ -31,10 +31,16 @@ import (
 // It returns ready status (bool) and in case it is not ready then the second return value holds the reason.
 func IsStatefulSetReady(etcdReplicas int32, statefulSet *appsv1.StatefulSet) (bool, string) {
 	if statefulSet.Status.ObservedGeneration < statefulSet.Generation {
-		return false, fmt.Sprintf("observed generation outdated (%d/%d)", statefulSet.Status.ObservedGeneration, statefulSet.Generation)
+		return false, fmt.Sprintf("observed generation %d is outdated in comparison to generation %d", statefulSet.Status.ObservedGeneration, statefulSet.Generation)
 	}
 	if statefulSet.Status.ReadyReplicas < etcdReplicas {
 		return false, fmt.Sprintf("not enough ready replicas (%d/%d)", statefulSet.Status.ReadyReplicas, etcdReplicas)
+	}
+	if statefulSet.Status.CurrentRevision != statefulSet.Status.UpdateRevision {
+		return false, fmt.Sprintf("Current StatefulSet revision %s is older than the updated StatefulSet revision %s)", statefulSet.Status.CurrentRevision, statefulSet.Status.UpdateRevision)
+	}
+	if statefulSet.Status.CurrentReplicas != statefulSet.Status.UpdatedReplicas {
+		return false, fmt.Sprintf("StatefulSet status.CurrentReplicas (%d) != status.UpdatedReplicas (%d)", statefulSet.Status.CurrentReplicas, statefulSet.Status.UpdatedReplicas)
 	}
 	return true, ""
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area high-availability
/kind bug

**What this PR does / why we need it**:
In gardener context, peer URL TLS is disabled for all non-HA etcd clusters. When a single-node etcd cluster is scaled to multi-node cluster, peer URLs are TLS enabled. Druid already has code to handle this but there were a few issues with the earlier implementation (in context to scale-up). This PR fixes these issues.

**Which issue(s) this PR fixes**:
Fixes #597 
Details of Issues that it fixes:
- A peer URL change requires either 2 restarts of etcd pods or 1 restart of etcd pods + 1 etcd member API to call to update the peer URL. In the earlier solution we sought to restart etcd pods twice and to achieve that we simply deleted STS twice. This has several issues. 
   -  Deletion and re-creation of STS requires volume detach and attach. On platforms like Azure this could be a problem.
   - Partial failure in deleting STS twice results in re-queuing of the event eventually resulting in a bootstrap from 0->3 instead of a scale-up from 1->3 as the STS has been deleted (at least once) and no update to replicas has yet been done. This causes issues in starting the cluster as etcd members do not join.


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
When scaling from single-node to multi-node etcd cluster, Etcd Druid will now first ensure that any change to the peer URL (e.g TLS enablement)  is seen by the existing etcd process running within the etcd member pod. Once that is confirmed then it will scale up the Etcd StatefulSet and add relevant annotations.
```
