### PR TITLE
Update `Makefile` for simplified local development using `Skaffold`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ add-license-headers: $(GO_ADD_LICENSE)
 	
 .PHONY: kind-up
 kind-up:
+	@printf "\n\033[0;33m📌 NOTE: To target the newly created KinD cluster, please run the following command:\n\n    export KUBECONFIG=hack/e2e-test/infrastructure/kind/kubeconfig\n\033[0m\n"
 	kind create cluster --name etcd-druid-e2e --config hack/e2e-test/infrastructure/kind/cluster.yaml 
 
 .PHONY: kind-down

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,10 @@ run: fmt check
 install: manifests
 	kubectl apply -f config/crd/bases
 
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+# Deploy controller to the Kubernetes cluster specified in the environment variable KUBECONFIG
+# Modify the Helm template located at charts/druid/templates if any changes are required
 .PHONY: deploy
-deploy: manifests $(KUSTOMIZE)
+deploy: $(SKAFFOLD) 
 	$(SKAFFOLD) run -m etcd-druid
 
 # Generate manifests e.g. CRD, RBAC etc.

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ add-license-headers: $(GO_ADD_LICENSE)
 	
 .PHONY: kind-up
 kind-up:
-	@printf "\n\033[0;33m📌 NOTE: To target the newly created KinD cluster, please run the following command:\n\n    export KUBECONFIG=hack/e2e-test/infrastructure/kind/kubeconfig\n\033[0m\n"
+	@printf "\n\033[0;33m📌 NOTE: To target the newly created KinD cluster, please run the following command:\n\n    export KUBECONFIG=$(KUBECONFIG_PATH)\n\033[0m\n"
 	kind create cluster --name etcd-druid-e2e --config hack/e2e-test/infrastructure/kind/cluster.yaml 
 
 .PHONY: kind-down

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,12 @@ run: fmt check
 install: manifests
 	kubectl apply -f config/crd/bases
 
+# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+.PHONY: deploy
+deploy-via-kustomize: manifests $(KUSTOMIZE)
+	kubectl apply -f config/crd/bases
+	kustomize build config/default | kubectl apply -f -
+
 # Deploy controller to the Kubernetes cluster specified in the environment variable KUBECONFIG
 # Modify the Helm template located at charts/druid/templates if any changes are required
 .PHONY: deploy

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,7 @@ install: manifests
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: deploy
 deploy: manifests $(KUSTOMIZE)
-	kubectl apply -f config/crd/bases
-	kustomize build config/default | kubectl apply -f -
+	$(SKAFFOLD) run -m etcd-druid
 
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR updates the `Makefile` to use `Skaffold` for deploying the `etcd-druid`. It replaces the use of `kustomize` with `Skaffold` and it builds the image from the current code base and deploys the pod. This approach simplifies the deployment process and eliminates the need to push the image to the container registry for each local development testing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
Developer Action Required: The `make deploy` command has been replaced with `make deploy-via-kustomize`. Please update your deployment workflows accordingly.
```
```feature developer
Makefile has been updated to use `Skaffold` for deploying `etcd-druid` with the `make deploy` target, simplifying the deployment process and eliminating the need to push the image to the container registry for each local development testing.
```
