### PR TITLE
Cherry-pick commits for release v0.18.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -4,7 +4,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.24.0"
+  tag: "v0.24.1"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd

--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -361,7 +361,7 @@ func (r *Reconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, etcd
 		return reconcileResult{err: err}
 	}
 
-	peerTLSEnabled, err := leaseDeployer.GetPeerURLTLSEnabledStatus(ctx)
+	peerTLSEnabled, err := druidutils.IsPeerURLTLSEnabled(ctx, r.Client, etcd.Namespace, etcd.Name, logger)
 	if err != nil {
 		return reconcileResult{err: err}
 	}

--- a/pkg/component/etcd/lease/lease.go
+++ b/pkg/component/etcd/lease/lease.go
@@ -30,9 +30,6 @@ import (
 // Interface provides a facade for operations on leases.
 type Interface interface {
 	gardenercomponent.Deployer
-	// GetPeerURLTLSEnabledStatus checks the Peer URL TLS enabled status by inspecting all the lease objects and returns
-	// a result after applying value captured in the lease object for each member in conjunction.
-	GetPeerURLTLSEnabledStatus(context.Context) (bool, error)
 }
 type component struct {
 	client    client.Client
@@ -81,18 +78,6 @@ func (c *component) Destroy(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (c *component) GetPeerURLTLSEnabledStatus(ctx context.Context) (bool, error) {
-	tlsEnabledValues, err := c.getTLSEnabledAnnotationValues(ctx, c.values.EtcdName)
-	if err != nil {
-		return false, err
-	}
-	tlsEnabled := true
-	for _, v := range tlsEnabledValues {
-		tlsEnabled = tlsEnabled && v
-	}
-	return tlsEnabled, nil
 }
 
 // New creates a new lease deployer instance.

--- a/pkg/component/etcd/lease/lease_member.go
+++ b/pkg/component/etcd/lease/lease_member.go
@@ -17,11 +17,9 @@ package lease
 import (
 	"context"
 	"fmt"
-	"strconv"
 
-	"github.com/gardener/etcd-druid/pkg/common"
+	"github.com/gardener/etcd-druid/pkg/utils"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -30,7 +28,7 @@ import (
 )
 
 func (c *component) deleteAllMemberLeases(ctx context.Context) error {
-	labels := getMemberLeaseLabels(c.values.EtcdName)
+	labels := utils.GetMemberLeaseLabels(c.values.EtcdName)
 
 	return c.client.DeleteAllOf(ctx, &coordinationv1.Lease{}, client.InNamespace(c.namespace), client.MatchingLabels(labels))
 }
@@ -39,7 +37,7 @@ func (c *component) syncMemberLeases(ctx context.Context) error {
 	var (
 		fns []flow.TaskFn
 
-		labels     = getMemberLeaseLabels(c.values.EtcdName)
+		labels     = utils.GetMemberLeaseLabels(c.values.EtcdName)
 		prefix     = c.values.EtcdName
 		leaseNames = sets.NewString()
 	)
@@ -86,48 +84,6 @@ func (c *component) syncMemberLeases(ctx context.Context) error {
 	}
 
 	return flow.Parallel(fns...)(ctx)
-}
-
-func (c *component) getTLSEnabledAnnotationValues(ctx context.Context, etcdName string) ([]bool, error) {
-	var tlsEnabledValues []bool
-	labels := getMemberLeaseLabels(etcdName)
-	leaseList := &coordinationv1.LeaseList{}
-	if err := c.client.List(ctx, leaseList, client.InNamespace(c.namespace), client.MatchingLabels(labels)); err != nil {
-		return nil, err
-	}
-	for _, lease := range leaseList.Items {
-		tlsEnabled := c.parseAndGetTLSEnabledValue(lease)
-		if tlsEnabled != nil {
-			tlsEnabledValues = append(tlsEnabledValues, *tlsEnabled)
-		}
-	}
-	return tlsEnabledValues, nil
-}
-
-func (c *component) parseAndGetTLSEnabledValue(lease coordinationv1.Lease) *bool {
-	const peerURLTLSEnabledKey = "member.etcd.gardener.cloud/tls-enabled"
-	if lease.Annotations != nil {
-		if tlsEnabledStr, ok := lease.Annotations[peerURLTLSEnabledKey]; ok {
-			tlsEnabled, err := strconv.ParseBool(tlsEnabledStr)
-			if err != nil {
-				c.logger.Error(err, "tls-enabled value is not a valid boolean", "namespace", lease.Namespace, "leaseName", lease.Name)
-				return nil
-			}
-			return &tlsEnabled
-		}
-		c.logger.V(4).Info("tls-enabled annotation not present for lease.", "namespace", lease.Namespace, "leaseName", lease.Name)
-	}
-	return nil
-}
-
-// PurposeMemberLease is a constant used as a purpose for etcd member lease objects.
-const PurposeMemberLease = "etcd-member-lease"
-
-func getMemberLeaseLabels(etcdName string) map[string]string {
-	return map[string]string{
-		common.GardenerOwnedBy:           etcdName,
-		v1beta1constants.GardenerPurpose: PurposeMemberLease,
-	}
 }
 
 func memberLeaseName(etcdName string, replica int) string {

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -24,6 +24,7 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/etcd-druid/pkg/common"
 	"github.com/gardener/etcd-druid/pkg/utils"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenercomponent "github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -53,7 +54,7 @@ type component struct {
 	values Values
 }
 
-// New creates a new statefulset deployer instance.
+// New creates a new StatefulSet deployer instance.
 func New(c client.Client, logger logr.Logger, values Values) Interface {
 	objectLogger := logger.WithValues("sts", client.ObjectKey{Name: values.Name, Namespace: values.Namespace})
 
@@ -101,8 +102,11 @@ const (
 // Wait waits for the deployment of the StatefulSet to finish
 func (c *component) Wait(ctx context.Context) error {
 	sts := c.emptyStatefulset()
-	err := c.waitDeploy(ctx, sts, c.values.Replicas)
+	err := c.waitDeploy(ctx, sts, c.values.Replicas, defaultTimeout)
 	if err != nil {
+		if getErr := c.client.Get(ctx, client.ObjectKeyFromObject(sts), sts); getErr != nil {
+			return err
+		}
 		messages, err2 := c.fetchPVCEventsFor(ctx, sts)
 		if err2 != nil {
 			c.logger.Error(err2, "Error while fetching events for depending PVC")
@@ -118,16 +122,56 @@ func (c *component) Wait(ctx context.Context) error {
 	return err
 }
 
-func (c *component) waitDeploy(ctx context.Context, sts *appsv1.StatefulSet, replicas int32) error {
-	return gardenerretry.UntilTimeout(ctx, defaultInterval, defaultTimeout, func(ctx context.Context) (bool, error) {
-		if err := c.client.Get(ctx, client.ObjectKeyFromObject(sts), sts); err != nil {
+func (c *component) getLatestPodCreationTime(ctx context.Context, sts *appsv1.StatefulSet) (time.Time, error) {
+	pods := corev1.PodList{}
+	if err := c.client.List(ctx, &pods, client.InNamespace(sts.Namespace), client.MatchingLabels(sts.Spec.Template.Labels)); err != nil {
+		return time.Time{}, err
+	}
+	var recentCreationTime time.Time
+	for _, pod := range pods.Items {
+		if recentCreationTime.Before(pod.CreationTimestamp.Time) {
+			recentCreationTime = pod.CreationTimestamp.Time
+		}
+	}
+	return recentCreationTime, nil
+}
+
+func (c *component) waitUtilPodsReady(ctx context.Context, originalSts *appsv1.StatefulSet, podDeletionTime time.Time, interval time.Duration, timeout time.Duration) error {
+	sts := appsv1.StatefulSet{}
+	return gardenerretry.UntilTimeout(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+		if err := c.client.Get(ctx, client.ObjectKeyFromObject(originalSts), &sts); err != nil {
 			if apierrors.IsNotFound(err) {
 				return gardenerretry.MinorError(err)
 			}
 			return gardenerretry.SevereError(err)
 		}
-		ready, reason := utils.IsStatefulSetReady(replicas, sts)
-		if !ready {
+		if sts.Status.ReadyReplicas < *sts.Spec.Replicas {
+			return gardenerretry.MinorError(fmt.Errorf(fmt.Sprintf("Only %d out of %d replicas are ready", sts.Status.ReadyReplicas, sts.Spec.Replicas)))
+		}
+		recentPodCreationTime, err := c.getLatestPodCreationTime(ctx, &sts)
+		if err != nil {
+			return gardenerretry.MinorError(fmt.Errorf("failed to get most recent pod creation timestamp: %w", err))
+		}
+		if recentPodCreationTime.Before(podDeletionTime) {
+			return gardenerretry.MinorError(fmt.Errorf(fmt.Sprintf("Most recent pod creation time %v is still before the %v time when the pods were deleted.", recentPodCreationTime, podDeletionTime)))
+		}
+		return gardenerretry.Ok()
+	})
+}
+
+func (c *component) waitDeploy(ctx context.Context, originalSts *appsv1.StatefulSet, replicas int32, timeout time.Duration) error {
+	updatedSts := appsv1.StatefulSet{}
+	return gardenerretry.UntilTimeout(ctx, defaultInterval, timeout, func(ctx context.Context) (bool, error) {
+		if err := c.client.Get(ctx, client.ObjectKeyFromObject(originalSts), &updatedSts); err != nil {
+			if apierrors.IsNotFound(err) {
+				return gardenerretry.MinorError(err)
+			}
+			return gardenerretry.SevereError(err)
+		}
+		if updatedSts.Generation < originalSts.Generation {
+			return gardenerretry.MinorError(fmt.Errorf("StatulfulSet generation has not yet been updated in the cache"))
+		}
+		if ready, reason := utils.IsStatefulSetReady(replicas, &updatedSts); !ready {
 			return gardenerretry.MinorError(fmt.Errorf(reason))
 		}
 		return gardenerretry.Ok()
@@ -152,7 +196,11 @@ func (c *component) WaitCleanup(ctx context.Context) error {
 }
 
 func (c *component) createDeployFlow(ctx context.Context) (*flow.Flow, error) {
-	sts, err := c.getExistingSts(ctx)
+	var (
+		sts *appsv1.StatefulSet
+		err error
+	)
+	sts, err = c.getExistingSts(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -168,21 +216,22 @@ func (c *component) createDeployFlow(ctx context.Context) (*flow.Flow, error) {
 			taskID = c.addImmutableFieldUpdateTask(g, sts)
 		}
 	}
-	if taskID != nil || sts == nil {
-		sts = c.emptyStatefulset()
-	}
 	c.addCreateOrPatchTask(g, sts, taskID)
 
 	return g.Compile(), nil
 }
 
 // addTasksForPeerUrlTLSChangedToEnabled adds tasks to the deployment flow in case the peer url tls has been changed to `enabled`.
-// To ensure that the tls enablement of peer url is properly reflected in etcd, the etcd StatefulSet should be recreated twice. Assume
+// To ensure that the tls enablement of peer url is properly reflected in etcd, the existing etcd StatefulSet pods should be restarted twice. Assume
 // that the current state of etcd is that peer url is not TLS enabled. First restart pushes a new configuration which contains
 // PeerUrlTLS configuration. etcd-backup-restore will update the member peer url. This will result in the change of the peer url in the etcd db file,
 // but it will not reflect in the already running etcd container. Ideally a restart of an etcd container would have been sufficient but currently k8s
-// does not expose an API to force restart a single container within a pod. Therefore, we delete the sts once again. When it gets created the second time
-// it will now start etcd with the correct peer url which will be TLS enabled.
+// does not expose an API to force restart a single container within a pod. Therefore, we need to restart the StatefulSet pod(s) once again. When the pod(s) is
+// restarted the second time it will now start etcd with the correct peer url which will be TLS enabled.
+// To achieve 2 restarts following is done:
+// 1. An update is made to the spec mounting the peer URL TLS secrets. This will cause a rolling update of the existing pod.
+// 2. Once the update is successfully completed, then we delete StatefulSet pods, causing a restart by the StatefulSet controller.
+// NOTE: The need to restart etcd pods twice will change in the future.
 func (c *component) addTasksForPeerUrlTLSChangedToEnabled(g *flow.Graph, sts *appsv1.StatefulSet) *flow.TaskID {
 	var existingStsReplicas int32
 	if sts.Spec.Replicas != nil {
@@ -190,30 +239,38 @@ func (c *component) addTasksForPeerUrlTLSChangedToEnabled(g *flow.Graph, sts *ap
 	}
 
 	if c.values.PeerTLSChangedToEnabled {
-		firstDelOpName := "(recreate-sts): delete sts due to peer url tls"
-		delTaskID := g.Add(flow.Task{
-			Name:         firstDelOpName,
-			Fn:           func(ctx context.Context) error { return c.destroyAndWait(ctx, firstDelOpName) },
+		updateStsOpName := "(update-sts-spec): update Peer TLS secret mount"
+		updateTaskID := g.Add(flow.Task{
+			Name: updateStsOpName,
+			Fn: func(ctx context.Context) error {
+				return c.updateAndWait(ctx, updateStsOpName, sts, existingStsReplicas)
+			},
 			Dependencies: nil,
 		})
+		c.logger.Info("adding task to deploy flow", "name", updateStsOpName, "ID", updateTaskID)
 
-		// ensure that the recreation of StatefulSet is done using existing replicas and not the desired replicas as contained in c.values.Replicas
-		createOrPatchOpName := fmt.Sprintf("(recreate-sts): create sts due to peer url tls with replicas: %d", existingStsReplicas)
-		createTaskID := g.Add(flow.Task{
-			Name:         createOrPatchOpName,
-			Fn:           func(ctx context.Context) error { return c.createAndWait(ctx, createOrPatchOpName, existingStsReplicas) },
-			Dependencies: flow.NewTaskIDs(delTaskID),
+		waitForLeaseUpdateOpName := "(wait-lease-update): Wait for lease to be updated with peer TLS"
+		waitLeaseUpdateID := g.Add(flow.Task{
+			Name: waitForLeaseUpdateOpName,
+			Fn: func(ctx context.Context) error {
+				return c.waitUntilTLSEnabled(ctx, waitForLeaseUpdateOpName, 3*time.Minute)
+			},
+			Dependencies: flow.NewTaskIDs(updateTaskID),
+		})
+		c.logger.Info("adding task to deploy flow", "name", updateStsOpName, "ID", waitLeaseUpdateID)
+
+		deleteAllStsPodsOpName := "(delete-sts-pods): deleting all sts pods"
+		deleteAllStsPodsTaskID := g.Add(flow.Task{
+			Name: deleteAllStsPodsOpName,
+			Fn: func(ctx context.Context) error {
+				return c.deleteAllStsPods(ctx, deleteAllStsPodsOpName, sts)
+			},
+			Dependencies: flow.NewTaskIDs(waitLeaseUpdateID),
 		})
 
-		secondDelOpName := "(recreate-sts): second-delete of sts due to peer url tls"
-		secondDeleteTaskID := g.Add(flow.Task{
-			Name:         secondDelOpName,
-			Fn:           func(ctx context.Context) error { return c.destroyAndWait(ctx, secondDelOpName) },
-			Dependencies: flow.NewTaskIDs(createTaskID),
-		})
+		c.logger.Info("adding task to deploy flow", "name", deleteAllStsPodsOpName, "ID", deleteAllStsPodsTaskID)
 
-		c.logger.Info("added tasks to deploy flow due to peer url tls changed to enabled", "namespace", c.values.Namespace, "name", c.values.Name, "etcdUID", c.values.EtcdUID, "replicas", c.values.Replicas)
-		return &secondDeleteTaskID
+		return &deleteAllStsPodsTaskID
 	}
 	return nil
 }
@@ -232,8 +289,10 @@ func (c *component) addImmutableFieldUpdateTask(g *flow.Graph, sts *appsv1.State
 	return nil
 }
 
-func (c *component) addCreateOrPatchTask(g *flow.Graph, sts *appsv1.StatefulSet, taskIDDependency *flow.TaskID) {
-	var dependencies flow.TaskIDs
+func (c *component) addCreateOrPatchTask(g *flow.Graph, originalSts *appsv1.StatefulSet, taskIDDependency *flow.TaskID) {
+	var (
+		dependencies flow.TaskIDs
+	)
 	if taskIDDependency != nil {
 		dependencies = flow.NewTaskIDs(taskIDDependency)
 	}
@@ -241,8 +300,21 @@ func (c *component) addCreateOrPatchTask(g *flow.Graph, sts *appsv1.StatefulSet,
 	taskID := g.Add(flow.Task{
 		Name: "sync StatefulSet task",
 		Fn: func(ctx context.Context) error {
-			c.logger.Info("createOrPatch sts")
-			return c.createOrPatch(ctx, sts, c.values.Replicas)
+			c.logger.Info("createOrPatch sts", "replicas", c.values.Replicas)
+			var (
+				sts = originalSts
+				err error
+			)
+			if taskIDDependency != nil {
+				sts, err = c.getExistingSts(ctx)
+				if err != nil {
+					return err
+				}
+			}
+			if sts == nil {
+				sts = c.emptyStatefulset()
+			}
+			return c.createOrPatch(ctx, sts, c.values.Replicas, false)
 		},
 		Dependencies: dependencies,
 	})
@@ -260,15 +332,46 @@ func (c *component) getExistingSts(ctx context.Context) (*appsv1.StatefulSet, er
 	return sts, nil
 }
 
-func (c *component) createAndWait(ctx context.Context, opName string, replicas int32) error {
-	sts := c.emptyStatefulset()
-	c.logger.Info("createOrPatch sts", "namespace", c.values.Namespace, "name", c.values.Name, "operation", opName, "etcdUID", c.values.EtcdUID, "replicas", replicas)
-	err := c.createOrPatch(ctx, sts, replicas)
-	if err != nil {
+func (c *component) updateAndWait(ctx context.Context, opName string, sts *appsv1.StatefulSet, replicas int32) error {
+	c.logger.Info("Updating StatefulSet spec with Peer URL TLS mount", "namespace", c.values.Namespace, "name", c.values.Name, "operation", opName, "etcdUID", c.values.EtcdUID, "replicas", replicas)
+	return c.doCreateOrUpdate(ctx, opName, sts, replicas, true)
+}
+
+func (c *component) waitUntilTLSEnabled(ctx context.Context, opName string, timeout time.Duration) error {
+	return gardenerretry.UntilTimeout(ctx, defaultInterval, timeout, func(ctx context.Context) (bool, error) {
+		tlsEnabled, err := utils.IsPeerURLTLSEnabled(ctx, c.client, c.values.Namespace, c.values.Name, c.logger)
+		if err != nil {
+			return gardenerretry.MinorError(err)
+		}
+		if !tlsEnabled {
+			return gardenerretry.MinorError(fmt.Errorf("TLS not yet enabled for etcd [name: %s, namespace: %s]", c.values.Name, c.values.Namespace))
+		}
+		return gardenerretry.Ok()
+	})
+}
+
+func (c *component) deleteAllStsPods(ctx context.Context, opName string, sts *appsv1.StatefulSet) error {
+	replicas := sts.Spec.Replicas
+	c.logger.Info("Deleting all StatefulSet pods", "namespace", c.values.Namespace, "name", c.values.Name, "operation", opName, "etcdUID", c.values.EtcdUID, "replicas", replicas, "matching labels", sts.Spec.Template.Labels)
+	timeBeforeDeletion := time.Now()
+
+	if err := c.client.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(sts.Namespace), client.MatchingLabels(sts.Spec.Template.Labels)); err != nil {
 		return err
 	}
-	c.logger.Info("waiting for createOrPatch sts to finish", "namespace", c.values.Namespace, "name", c.values.Name, "operation", opName, "etcdUID", c.values.EtcdUID, "replicas", replicas)
-	return c.waitDeploy(ctx, sts, replicas)
+
+	const timeout = 3 * time.Minute
+	const interval = 2 * time.Second
+
+	c.logger.Info("waiting for StatefulSet pods to start again after delete", "namespace", c.values.Namespace, "name", c.values.Name, "operation", opName, "etcdUID", c.values.EtcdUID, "replicas", replicas)
+	return c.waitUtilPodsReady(ctx, sts, timeBeforeDeletion, interval, timeout)
+}
+
+func (c *component) doCreateOrUpdate(ctx context.Context, opName string, sts *appsv1.StatefulSet, replicas int32, preserveObjectMetadata bool) error {
+	if err := c.createOrPatch(ctx, sts, replicas, preserveObjectMetadata); err != nil {
+		return err
+	}
+	c.logger.Info("waiting for StatefulSet replicas to be ready", "namespace", c.values.Namespace, "name", c.values.Name, "operation", opName, "target-replicas", replicas)
+	return c.waitDeploy(ctx, sts, replicas, defaultTimeout)
 }
 
 func (c *component) destroyAndWait(ctx context.Context, opName string) error {
@@ -286,117 +389,121 @@ func immutableFieldUpdate(sts *appsv1.StatefulSet, val Values) bool {
 
 func clusterScaledUpToMultiNode(val *Values, sts *appsv1.StatefulSet) bool {
 	if sts != nil && sts.Spec.Replicas != nil {
-		return (val.Replicas > 1 && *sts.Spec.Replicas == 1) ||
+		return (val.Replicas > 1 && *sts.Spec.Replicas == 1 && sts.Status.AvailableReplicas == 1) ||
 			(metav1.HasAnnotation(sts.ObjectMeta, scaleToMultiNodeAnnotationKey) && sts.Status.UpdatedReplicas < *sts.Spec.Replicas)
 	}
 	return val.Replicas > 1 && val.StatusReplicas == 1
 }
 
-func (c *component) createOrPatch(ctx context.Context, sts *appsv1.StatefulSet, replicas int32) error {
-	var (
-		stsOriginal = sts.DeepCopy()
-		patch       = client.StrategicMergeFrom(stsOriginal)
-	)
+func (c *component) createOrPatch(ctx context.Context, sts *appsv1.StatefulSet, replicas int32, preserveAnnotations bool) error {
+	mutatingFn := func() error {
+		var stsOriginal = sts.DeepCopy()
 
-	podVolumes, err := getVolumes(ctx, c.client, c.logger, c.values)
-	if err != nil {
-		return err
-	}
+		podVolumes, err := getVolumes(ctx, c.client, c.logger, c.values)
+		if err != nil {
+			return err
+		}
 
-	sts.ObjectMeta = getObjectMeta(&c.values, sts)
-	sts.Spec = appsv1.StatefulSetSpec{
-		PodManagementPolicy: appsv1.ParallelPodManagement,
-		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-			Type: appsv1.RollingUpdateStatefulSetStrategyType,
-		},
-		Replicas:    &replicas,
-		ServiceName: c.values.PeerServiceName,
-		Selector: &metav1.LabelSelector{
-			MatchLabels: getCommonLabels(&c.values),
-		},
-		Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: c.values.Annotations,
-				Labels:      sts.GetLabels(),
+		sts.ObjectMeta = getObjectMeta(&c.values, sts, preserveAnnotations)
+		sts.Spec = appsv1.StatefulSetSpec{
+			PodManagementPolicy: appsv1.ParallelPodManagement,
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 			},
-			Spec: corev1.PodSpec{
-				HostAliases: []corev1.HostAlias{
-					{
-						IP:        "127.0.0.1",
-						Hostnames: []string{c.values.Name + "-local"},
-					},
+			Replicas:    &replicas,
+			ServiceName: c.values.PeerServiceName,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: getCommonLabels(&c.values),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: c.values.Annotations,
+					Labels:      sts.GetLabels(),
 				},
-				ServiceAccountName:        c.values.ServiceAccountName,
-				Affinity:                  c.values.Affinity,
-				TopologySpreadConstraints: c.values.TopologySpreadConstraints,
-				Containers: []corev1.Container{
-					{
-						Name:            "etcd",
-						Image:           c.values.EtcdImage,
-						ImagePullPolicy: corev1.PullIfNotPresent,
-						Command:         c.values.EtcdCommand,
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler:        getReadinessHandler(c.values),
-							InitialDelaySeconds: 15,
-							PeriodSeconds:       5,
-							FailureThreshold:    5,
+				Spec: corev1.PodSpec{
+					HostAliases: []corev1.HostAlias{
+						{
+							IP:        "127.0.0.1",
+							Hostnames: []string{c.values.Name + "-local"},
 						},
-						Ports:        getEtcdPorts(c.values),
-						Resources:    getEtcdResources(c.values),
-						Env:          getEtcdEnvVars(c.values),
-						VolumeMounts: getEtcdVolumeMounts(c.values),
 					},
-					{
-						Name:            "backup-restore",
-						Image:           c.values.BackupImage,
-						ImagePullPolicy: corev1.PullIfNotPresent,
-						Command:         c.values.EtcdBackupCommand,
-						Ports:           getBackupPorts(c.values),
-						Resources:       getBackupResources(c.values),
-						Env:             getBackupRestoreEnvVars(c.values),
-						VolumeMounts:    getBackupRestoreVolumeMounts(c.values),
-						SecurityContext: &corev1.SecurityContext{
-							Capabilities: &corev1.Capabilities{
-								Add: []corev1.Capability{
-									"SYS_PTRACE",
+					ServiceAccountName:        c.values.ServiceAccountName,
+					Affinity:                  c.values.Affinity,
+					TopologySpreadConstraints: c.values.TopologySpreadConstraints,
+					Containers: []corev1.Container{
+						{
+							Name:            "etcd",
+							Image:           c.values.EtcdImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command:         c.values.EtcdCommand,
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler:        getReadinessHandler(c.values),
+								InitialDelaySeconds: 15,
+								PeriodSeconds:       5,
+								FailureThreshold:    5,
+							},
+							Ports:        getEtcdPorts(c.values),
+							Resources:    getEtcdResources(c.values),
+							Env:          getEtcdEnvVars(c.values),
+							VolumeMounts: getEtcdVolumeMounts(c.values),
+						},
+						{
+							Name:            "backup-restore",
+							Image:           c.values.BackupImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command:         c.values.EtcdBackupCommand,
+							Ports:           getBackupPorts(c.values),
+							Resources:       getBackupResources(c.values),
+							Env:             getBackupRestoreEnvVars(c.values),
+							VolumeMounts:    getBackupRestoreVolumeMounts(c.values),
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{
+										"SYS_PTRACE",
+									},
 								},
 							},
 						},
 					},
+					ShareProcessNamespace: pointer.Bool(true),
+					Volumes:               podVolumes,
 				},
-				ShareProcessNamespace: pointer.Bool(true),
-				Volumes:               podVolumes,
 			},
-		},
-		VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: c.values.VolumeClaimTemplateName,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					AccessModes: []corev1.PersistentVolumeAccessMode{
-						corev1.ReadWriteOnce,
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: c.values.VolumeClaimTemplateName,
 					},
-					Resources: getStorageReq(c.values),
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: getStorageReq(c.values),
+					},
 				},
 			},
-		},
-	}
-	if c.values.StorageClass != nil && *c.values.StorageClass != "" {
-		sts.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = c.values.StorageClass
-	}
-	if c.values.PriorityClassName != nil {
-		sts.Spec.Template.Spec.PriorityClassName = *c.values.PriorityClassName
+		}
+		if c.values.StorageClass != nil && *c.values.StorageClass != "" {
+			sts.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = c.values.StorageClass
+		}
+		if c.values.PriorityClassName != nil {
+			sts.Spec.Template.Spec.PriorityClassName = *c.values.PriorityClassName
+		}
+
+		if stsOriginal.Generation > 0 {
+			// Keep immutable fields
+			sts.Spec.PodManagementPolicy = stsOriginal.Spec.PodManagementPolicy
+			sts.Spec.ServiceName = stsOriginal.Spec.ServiceName
+		}
+		return nil
 	}
 
-	if stsOriginal.Generation > 0 {
-		// Keep immutable fields
-		sts.Spec.PodManagementPolicy = stsOriginal.Spec.PodManagementPolicy
-		sts.Spec.ServiceName = stsOriginal.Spec.ServiceName
-		return c.client.Patch(ctx, sts, patch)
+	operationResult, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, c.client, sts, mutatingFn)
+	if err != nil {
+		return err
 	}
-
-	return c.client.Create(ctx, sts)
+	c.logger.Info("createOrPatch is completed", "Namespace", sts.Namespace, "Name", sts.Name, "operation-result", operationResult)
+	return nil
 }
 
 func (c *component) fetchPVCEventsFor(ctx context.Context, ss *appsv1.StatefulSet) (string, error) {
@@ -442,9 +549,14 @@ func getCommonLabels(val *Values) map[string]string {
 	}
 }
 
-func getObjectMeta(val *Values, sts *appsv1.StatefulSet) metav1.ObjectMeta {
+func getObjectMeta(val *Values, sts *appsv1.StatefulSet, preserveAnnotations bool) metav1.ObjectMeta {
+	var annotations map[string]string
 	labels := utils.MergeStringMaps(getCommonLabels(val), val.Labels)
-	annotations := getStsAnnotations(val, sts)
+	if preserveAnnotations {
+		annotations = sts.Annotations
+	} else {
+		annotations = getStsAnnotations(val, sts)
+	}
 	ownerRefs := []metav1.OwnerReference{
 		{
 			APIVersion:         druidv1alpha1.GroupVersion.String(),

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -143,7 +143,6 @@ var _ = Describe("Statefulset", func() {
 
 		sts = &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
-
 				Name:      values.Name,
 				Namespace: values.Namespace,
 			},

--- a/pkg/health/etcdmember/check_ready.go
+++ b/pkg/health/etcdmember/check_ready.go
@@ -19,8 +19,6 @@ import (
 	"strings"
 	"time"
 
-	componentlease "github.com/gardener/etcd-druid/pkg/component/etcd/lease"
-
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -32,6 +30,7 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/etcd-druid/pkg/common"
+	"github.com/gardener/etcd-druid/pkg/utils"
 )
 
 type readyCheck struct {
@@ -52,7 +51,7 @@ func (r *readyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) []Resul
 
 	leases := &coordinationv1.LeaseList{}
 	if err := r.cl.List(ctx, leases, client.InNamespace(etcd.Namespace), client.MatchingLabels{
-		common.GardenerOwnedBy: etcd.Name, v1beta1constants.GardenerPurpose: componentlease.PurposeMemberLease}); err != nil {
+		common.GardenerOwnedBy: etcd.Name, v1beta1constants.GardenerPurpose: utils.PurposeMemberLease}); err != nil {
 		r.logger.Error(err, "failed to get leases for etcd member readiness check")
 	}
 

--- a/pkg/health/etcdmember/check_ready_test.go
+++ b/pkg/health/etcdmember/check_ready_test.go
@@ -39,9 +39,9 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/etcd-druid/pkg/common"
-	componentlease "github.com/gardener/etcd-druid/pkg/component/etcd/lease"
 	. "github.com/gardener/etcd-druid/pkg/health/etcdmember"
 	mockclient "github.com/gardener/etcd-druid/pkg/mock/controller-runtime/client"
+	"github.com/gardener/etcd-druid/pkg/utils"
 )
 
 var _ = Describe("ReadyCheck", func() {
@@ -89,7 +89,7 @@ var _ = Describe("ReadyCheck", func() {
 
 		JustBeforeEach(func() {
 			cl.EXPECT().List(ctx, gomock.AssignableToTypeOf(&coordinationv1.LeaseList{}), client.InNamespace(etcd.Namespace),
-				client.MatchingLabels{common.GardenerOwnedBy: etcd.Name, v1beta1constants.GardenerPurpose: componentlease.PurposeMemberLease}).
+				client.MatchingLabels{common.GardenerOwnedBy: etcd.Name, v1beta1constants.GardenerPurpose: utils.PurposeMemberLease}).
 				DoAndReturn(
 					func(_ context.Context, leases *coordinationv1.LeaseList, _ ...client.ListOption) error {
 						*leases = *leasesList

--- a/pkg/utils/lease.go
+++ b/pkg/utils/lease.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/gardener/etcd-druid/pkg/common"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/go-logr/logr"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsPeerURLTLSEnabled checks if the TLS has been enabled for all existing members of an etcd cluster identified by etcdName and in the provided namespace.
+func IsPeerURLTLSEnabled(ctx context.Context, cli client.Client, namespace, etcdName string, logger logr.Logger) (bool, error) {
+	var tlsEnabledValues []bool
+	labels := GetMemberLeaseLabels(etcdName)
+	leaseList := &coordinationv1.LeaseList{}
+	if err := cli.List(ctx, leaseList, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {
+		return false, err
+	}
+	for _, lease := range leaseList.Items {
+		tlsEnabled := parseAndGetTLSEnabledValue(lease, logger)
+		if tlsEnabled != nil {
+			tlsEnabledValues = append(tlsEnabledValues, *tlsEnabled)
+		}
+	}
+	tlsEnabled := true
+	for _, v := range tlsEnabledValues {
+		tlsEnabled = tlsEnabled && v
+	}
+	return tlsEnabled, nil
+}
+
+// PurposeMemberLease is a constant used as a purpose for etcd member lease objects.
+const PurposeMemberLease = "etcd-member-lease"
+
+// GetMemberLeaseLabels creates a map of default labels for member lease.
+func GetMemberLeaseLabels(etcdName string) map[string]string {
+	return map[string]string{
+		common.GardenerOwnedBy:           etcdName,
+		v1beta1constants.GardenerPurpose: PurposeMemberLease,
+	}
+}
+
+func parseAndGetTLSEnabledValue(lease coordinationv1.Lease, logger logr.Logger) *bool {
+	const peerURLTLSEnabledKey = "member.etcd.gardener.cloud/tls-enabled"
+	if lease.Annotations != nil {
+		if tlsEnabledStr, ok := lease.Annotations[peerURLTLSEnabledKey]; ok {
+			tlsEnabled, err := strconv.ParseBool(tlsEnabledStr)
+			if err != nil {
+				logger.Error(err, "tls-enabled value is not a valid boolean", "namespace", lease.Namespace, "leaseName", lease.Name)
+				return nil
+			}
+			return &tlsEnabled
+		}
+		logger.V(4).Info("tls-enabled annotation not present for lease.", "namespace", lease.Namespace, "leaseName", lease.Name)
+	}
+	return nil
+}

--- a/pkg/utils/statefulset.go
+++ b/pkg/utils/statefulset.go
@@ -31,10 +31,16 @@ import (
 // It returns ready status (bool) and in case it is not ready then the second return value holds the reason.
 func IsStatefulSetReady(etcdReplicas int32, statefulSet *appsv1.StatefulSet) (bool, string) {
 	if statefulSet.Status.ObservedGeneration < statefulSet.Generation {
-		return false, fmt.Sprintf("observed generation outdated (%d/%d)", statefulSet.Status.ObservedGeneration, statefulSet.Generation)
+		return false, fmt.Sprintf("observed generation %d is outdated in comparison to generation %d", statefulSet.Status.ObservedGeneration, statefulSet.Generation)
 	}
 	if statefulSet.Status.ReadyReplicas < etcdReplicas {
 		return false, fmt.Sprintf("not enough ready replicas (%d/%d)", statefulSet.Status.ReadyReplicas, etcdReplicas)
+	}
+	if statefulSet.Status.CurrentRevision != statefulSet.Status.UpdateRevision {
+		return false, fmt.Sprintf("Current StatefulSet revision %s is older than the updated StatefulSet revision %s)", statefulSet.Status.CurrentRevision, statefulSet.Status.UpdateRevision)
+	}
+	if statefulSet.Status.CurrentReplicas != statefulSet.Status.UpdatedReplicas {
+		return false, fmt.Sprintf("StatefulSet status.CurrentReplicas (%d) != status.UpdatedReplicas (%d)", statefulSet.Status.CurrentReplicas, statefulSet.Status.UpdatedReplicas)
 	}
 	return true, ""
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR cherry picks commits from the following PRs:

1. https://github.com/gardener/etcd-druid/pull/598
2. https://github.com/gardener/etcd-druid/pull/601

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Backup-restore waits for its etcd to be ready before attempting to update peerUrl
```

```other operator
When scaling from single-node to multi-node etcd cluster, Etcd Druid will now first ensure that any change to the peer URL (e.g TLS enablement)  is seen by the existing etcd process running within the etcd member pod. Once that is confirmed then it will scale up the Etcd StatefulSet and add relevant annotations.

```
