### PR TITLE
Adds e2e tests for scale-up feature: moving from non-HA(peer TLS not enable) -> HA (peerUrl TLS enable)

### DIFF
--- a/charts/druid/templates/druid-clusterrole.yaml
+++ b/charts/druid/templates/druid-clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
   - list
   - watch
   - delete
+  - deletecollection
 - apiGroups:
   - ""
   resources:

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Etcd", func() {
 	})
 
 	Context("when a single-node is configured", func() {
-		It("should scale a single-node etcd without peerUrl TLS enabled to a multi-node etcd cluster with peerUrl TLS enabled", func() {
+		It("should scale a single-node etcd (TLS not enabled for peerUrl) to a multi-node etcd cluster (TLS not enabled for peerUrl)", func() {
 			ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
 			defer cancelFunc()
 
@@ -165,7 +165,7 @@ var _ = Describe("Etcd", func() {
 			By("Creating a single-node etcd")
 			createAndCheckEtcd(ctx, cl, objLogger, etcd, singleNodeEtcdTimeout)
 
-			By("Scaling up a healthy cluster (from 1 to 3 replicas)")
+			By("Scaling up a healthy cluster (from 1 to 3 replicas) with TLS enabled for peerUrl")
 			Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
 			etcd.Spec.Replicas = 3
 			etcd.Spec.Etcd.PeerUrlTLS = getPeerTls(provider.Suffix)
@@ -204,7 +204,7 @@ var _ = Describe("Etcd", func() {
 			deleteAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 		})
 
-		It("should scale down a single-node etcd to 0 replica, then scale up from 0->1 replica and then from 1->3 replicas with Tls enabled for cluster peerUrl", func() {
+		It("should scale down a single-node etcd to 0 replica, then scale up from 0->1 replica and then from 1->3 replicas with TLS enabled for cluster peerUrl", func() {
 			ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
 			defer cancelFunc()
 
@@ -224,7 +224,7 @@ var _ = Describe("Etcd", func() {
 			etcd.Spec.Replicas = 1
 			updateAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 
-			By("Scaling up a healthy cluster (from 1 to 3 replica) with TLS enablement for peerUrl")
+			By("Scaling up a healthy cluster (from 1 to 3 replica) with TLS enabled for peerUrl")
 			Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
 			etcd.Spec.Replicas = 3
 			etcd.Spec.Etcd.PeerUrlTLS = getPeerTls(provider.Suffix)

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -80,13 +80,13 @@ var _ = Describe("Etcd", func() {
 			ctx, cancelFunc := context.WithTimeout(parentCtx, 15*time.Minute)
 			defer cancelFunc()
 
-			etcd := getDefaultMultiNodeEtcdWithPeerTlsEnabled(etcdName, namespace, storageContainer, storePrefix, provider)
+			etcd := getDefaultMultiNodeEtcd(etcdName, namespace, storageContainer, storePrefix, provider)
 			objLogger := logger.WithValues("etcd-multi-node", client.ObjectKeyFromObject(etcd))
 
 			By("Create etcd")
 			createAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 
-			By("Hibernate etcd (Scale down from 3->0 replica)")
+			By("Hibernate etcd (Scale down from 3 replicas to 0)")
 			hibernateAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 
 			By("Wakeup etcd (Scale up from 0->3 replicas)")
@@ -136,7 +136,7 @@ var _ = Describe("Etcd", func() {
 	})
 
 	Context("when a single-node is configured", func() {
-		It("should scale a single-node etcd (TLS not enabled for peerUrl) to a multi-node etcd cluster (TLS not enabled for peerUrl)", func() {
+		It("should scale a single-node etcd without peerUrl TLS enabled to a multi-node etcd cluster with peerUrl TLS enabled", func() {
 			ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
 			defer cancelFunc()
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -238,9 +238,16 @@ func getDefaultEtcd(name, namespace, container, prefix string, provider TestProv
 	return etcd
 }
 
-func getDefaultMultiNodeEtcd(name, namespace, container, prefix string, provider TestProvider) *v1alpha1.Etcd {
+func getDefaultMultiNodeEtcdWithPeerTlsNotEnabled(name, namespace, container, prefix string, provider TestProvider) *v1alpha1.Etcd {
 	etcd := getDefaultEtcd(name, namespace, container, prefix, provider)
 	etcd.Spec.Replicas = multiNodeEtcdReplicas
+	return etcd
+}
+
+func getDefaultMultiNodeEtcdWithPeerTlsEnabled(name, namespace, container, prefix string, provider TestProvider) *v1alpha1.Etcd {
+	etcd := getDefaultEtcd(name, namespace, container, prefix, provider)
+	etcd.Spec.Replicas = multiNodeEtcdReplicas
+	etcd.Spec.Etcd.PeerUrlTLS = getPeerTls(provider.Suffix)
 	return etcd
 }
 
@@ -252,6 +259,21 @@ func defaultTls(provider string) v1alpha1.TLSConfig {
 		},
 		ClientTLSSecretRef: corev1.SecretReference{
 			Name:      fmt.Sprintf("%s-%s", "etcd-client-tls", provider),
+			Namespace: namespace,
+		},
+		TLSCASecretRef: v1alpha1.SecretReference{
+			SecretReference: corev1.SecretReference{
+				Name:      fmt.Sprintf("%s-%s", "ca-etcd", provider),
+				Namespace: namespace,
+			},
+		},
+	}
+}
+
+func getPeerTls(provider string) *v1alpha1.TLSConfig {
+	return &v1alpha1.TLSConfig{
+		ServerTLSSecretRef: corev1.SecretReference{
+			Name:      fmt.Sprintf("%s-%s", "etcd-server-cert", provider),
 			Namespace: namespace,
 		},
 		TLSCASecretRef: v1alpha1.SecretReference{

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -238,13 +238,7 @@ func getDefaultEtcd(name, namespace, container, prefix string, provider TestProv
 	return etcd
 }
 
-func getDefaultMultiNodeEtcdWithPeerTlsNotEnabled(name, namespace, container, prefix string, provider TestProvider) *v1alpha1.Etcd {
-	etcd := getDefaultEtcd(name, namespace, container, prefix, provider)
-	etcd.Spec.Replicas = multiNodeEtcdReplicas
-	return etcd
-}
-
-func getDefaultMultiNodeEtcdWithPeerTlsEnabled(name, namespace, container, prefix string, provider TestProvider) *v1alpha1.Etcd {
+func getDefaultMultiNodeEtcd(name, namespace, container, prefix string, provider TestProvider) *v1alpha1.Etcd {
 	etcd := getDefaultEtcd(name, namespace, container, prefix, provider)
 	etcd.Spec.Replicas = multiNodeEtcdReplicas
 	etcd.Spec.Etcd.PeerUrlTLS = getPeerTls(provider.Suffix)


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/kind test

**What this PR does / why we need it**:
This PR adds an e2e tests while scaling a non-HA etcd cluster(peerUrl TLS is not enabled) to a HA etcd cluster (peerUrl TLS will get enable).
This PR also improves existing multi-node e2e tests by enabling the TLS for peers for bootstrap multi-node case (0->3 replicas)

**Which issue(s) this PR fixes**:
Fixes #600 

**Special notes for your reviewer**:

**Release note**:
```other operator
None
```
