### PR TITLE
Updated the docforge manifest & added index files

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,12 +1,14 @@
+nodesSelector:
+  path: /docs
 structure:
 - name: _index.md
+  properties:
+    frontmatter:
+      title: etcd Druid
+      description: A druid for etcd management in Gardener
   source: /README.md
-- name: etcd-druid
-  nodesSelector:
-    path: https://github.com/gardener/etcd-druid/tree/DEFAULT_BRANCH/docs
-  nodes:
-  - name: api-reference
-    properties:
-      frontmatter:
-        title: API Reference
-    source: https://github.com/gardener/etcd-druid-api/blob/DEFAULT_BRANCH/docs/api-reference/druid.md
+- name: api-reference
+  properties:
+    frontmatter:
+      title: API Reference
+  source: https://github.com/gardener/etcd-druid-api/blob/DEFAULT_BRANCH/docs/api-reference/druid.md

--- a/docs/development/_index.md
+++ b/docs/development/_index.md
@@ -1,0 +1,4 @@
+---
+title: Development
+weight: 1
+---

--- a/docs/operation/_index.md
+++ b/docs/operation/_index.md
@@ -1,0 +1,4 @@
+---
+title: Operation
+weight: 2
+---

--- a/docs/proposals/_index.md
+++ b/docs/proposals/_index.md
@@ -1,0 +1,4 @@
+---
+title: Proposals
+weight: 3
+---

--- a/docs/proposals/multi-node/README.md
+++ b/docs/proposals/multi-node/README.md
@@ -426,11 +426,11 @@ I.e. every time an etcd container restarts, [the old member (represented by the 
 Since the likelyhood of a member not having valid metadata in the WAL files is much more likely in the [ephemeral](#ephemeral) persistence scenario, one option is to pass the information that ephemeral persistence is being used to the `etcd-backup-restore` sidecar (say, via command-line flags or environment variables).
 
 But in principle, it might be better to determine this from the WAL files directly so that the possibility of corrupted WAL files also gets handled correctly.
-To do this, the [wal](https://github.com/etcd-io/etcd/tree/master/server/wal) package has [some](https://github.com/etcd-io/etcd/blob/57a092b45d0eae6c9e600e62513ffcd2f1f25a92/server/wal/wal.go#L324-L326) [functions](https://github.com/etcd-io/etcd/blob/57a092b45d0eae6c9e600e62513ffcd2f1f25a92/server/wal/wal.go#L429-L548) that might be useful.
+To do this, the [wal](https://github.com/etcd-io/etcd/tree/main/server/storage/wal) package has [some](https://github.com/etcd-io/etcd/blob/57a092b45d0eae6c9e600e62513ffcd2f1f25a92/server/wal/wal.go#L324-L326) [functions](https://github.com/etcd-io/etcd/blob/57a092b45d0eae6c9e600e62513ffcd2f1f25a92/server/wal/wal.go#L429-L548) that might be useful.
 
 #### Recommendation
 
-It might be possible that using the [wal](https://github.com/etcd-io/etcd/tree/master/server/wal) package for verifying if valid metadata exists might be performance intensive.
+It might be possible that using the [wal](https://github.com/etcd-io/etcd/tree/main/server/storage/wal) package for verifying if valid metadata exists might be performance intensive.
 So, the performance impact needs to be measured.
 If the performance impact is acceptable (both in terms of resource usage and time), it is recommended to use this way to verify if the member contains valid metadata.
 Otherwise, alternatives such as a simple check that WAL folder exists coupled with the static information about use of [persistent](#persistent) or [ephemeral](#ephemeral) storage might be considered.
@@ -996,7 +996,7 @@ Remove `d - n` existing members (numbered `d`, `d + 1` ... `n`) by scaling the `
 
 Also, delete the [member `leases`](#member-leases) for the `d - n` members being removed.
 
-The [superfluous entries in the `members` array](13-superfluous-member-entries-in-etcd-status) will be cleaned up as explained [here](#recommended-action-12).
+The [superfluous entries in the `members` array](#13-superfluous-member-entries-in-etcd-status) will be cleaned up as explained [here](#recommended-action-12).
 The superfluous members in the ETCD cluster will be cleaned up by the [leading `etcd-backup-restore` sidecar](#work-flows-only-on-the-leading-member).
 
 ### 13. Superfluous member entries in `Etcd` status
@@ -1353,7 +1353,7 @@ In case of a conflict, the recommendation is to use the highest of the applicabl
 ## Rolling updates to etcd members
 
 Any changes to the `Etcd` resource spec that might result in a change to `StatefulSet` spec or otherwise result in a rolling update of member pods should be applied/propagated by `etcd-druid` only when the etcd cluster is fully healthy to reduce the risk of quorum loss during the updates.
-This would include vertical autoscaling changes (via, [HVPA](https://github.com/gsrdener/hvpa-controller)).
+This would include vertical autoscaling changes (via, [HVPA](https://github.com/gardener/hvpa-controller)).
 If the cluster [status](#status) unhealthy (i.e. if either `AllMembersReady` or `BackupReady` [conditions](#conditions) are `false`), `etcd-druid` must restore it to full health [before proceeding](#backup-failure) with such operations that lead to rolling updates.
 This can be further optimized in the future to handle the cases where rolling updates can still be performed on an etcd cluster that is not fully healthy.
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR updates the file structure in the etcd Druid section of the public Gardener website. It is connected to a PR in [gardener/documentation](https://github.com/gardener/documentation/pull/417) that modifies the manifest file there.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
