### PR TITLE
Optimize test runs by running lint check once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ clean: set-permissions
 
 # Check packages
 .PHONY: check
-check: $(GOLANGCI_LINT) $(GOIMPORTS) set-permissions
+check: $(GOLANGCI_LINT) $(GOIMPORTS) set-permissions fmt manifests
 	@"$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check.sh" --golangci-lint-config=./.golangci.yaml ./api/... ./pkg/... ./controllers/...
 
 .PHONY: check-generate
@@ -128,7 +128,7 @@ docker-push:
 
 # Run tests
 .PHONY: test
-test: set-permissions $(GINKGO) $(SETUP_ENVTEST) fmt check manifests
+test: set-permissions $(GINKGO) $(SETUP_ENVTEST)
 	@"$(REPO_ROOT)/hack/test.sh" ./api/... ./controllers/... ./pkg/...
 
 .PHONY: test-cov
@@ -144,7 +144,7 @@ test-e2e: set-permissions $(KUBECTL) $(HELM) $(SKAFFOLD)
 	@"$(REPO_ROOT)/hack/e2e-test/run-e2e-test.sh" $(PROVIDERS)
 
 .PHONY: test-integration
-test-integration: set-permissions $(GINKGO) $(SETUP_ENVTEST) fmt check manifests
+test-integration: set-permissions $(GINKGO) $(SETUP_ENVTEST)
 	@"$(REPO_ROOT)/hack/test.sh" ./test/integration/...
 
 .PHONY: update-dependencies


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area testing dev-productivity
  /area test enhancement
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
  /area testing dev-productivity
  /area test

**What this PR does / why we need it**:

This PR optimizes the way we run our tests by adjusting the `Makefile` so that the lint check is only run once per pull request, instead of with each `test` and `test-integration` execution. The lint check is already handled by a separate job in our CI/CD pipeline job `check`.

### Changes
- Removed `check` from the dependencies of `test` and `test-integration` in the `Makefile`.
- Added `fmt` and `manifests` as dependencies to `check` in the `Makefile`.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc: @acumino 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
