### PR TITLE
Update druid to deploy distroless etcd-wrapper and etcd-backup-restore

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,6 +6,6 @@ images:
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
   tag: "v0.25.0"
 - name: etcd
-  sourceRepository: github.com/gardener/etcd-wrapper #github.com/gardener/etcd-custom-image
-  repository: eu.gcr.io/gardener-project/gardener/etcd-wrapper #aaronfernandes/etcd-wrapper #eu.gcr.io/gardener-project/gardener/etcd
-  tag: "v0.1.0-dev-d59bdbd7c1bb82385266706f80b7b58b956814f8" #"v1.4" #"v3.4.13-bootstrap-11"
+  sourceRepository: github.com/gardener/etcd-wrapper
+  repository: eu.gcr.io/gardener-project/gardener/etcd-wrapper
+  tag: "v0.1.0"

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -7,5 +7,5 @@ images:
   tag: "v0.25.0"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-wrapper #github.com/gardener/etcd-custom-image
-  repository: aaronfernandes/etcd-wrapper #eu.gcr.io/gardener-project/gardener/etcd
-  tag: "v1.4" #"v3.4.13-bootstrap-11"
+  repository: eu.gcr.io/gardener-project/gardener/etcd-wrapper #aaronfernandes/etcd-wrapper #eu.gcr.io/gardener-project/gardener/etcd
+  tag: "v0.1.0-dev-a840477e90c81e928fafe302db01ac65e0022323" #"v1.4" #"v3.4.13-bootstrap-11"

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,6 +6,6 @@ images:
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
   tag: "v0.25.0"
 - name: etcd
-  sourceRepository: github.com/gardener/etcd-custom-image
-  repository: eu.gcr.io/gardener-project/gardener/etcd
-  tag: "v3.4.13-bootstrap-11"
+  sourceRepository: github.com/gardener/etcd-wrapper #github.com/gardener/etcd-custom-image
+  repository: aaronfernandes/etcd-wrapper #eu.gcr.io/gardener-project/gardener/etcd
+  tag: "v1.4" #"v3.4.13-bootstrap-11"

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -8,4 +8,4 @@ images:
 - name: etcd
   sourceRepository: github.com/gardener/etcd-wrapper #github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd-wrapper #aaronfernandes/etcd-wrapper #eu.gcr.io/gardener-project/gardener/etcd
-  tag: "v0.1.0-dev-a840477e90c81e928fafe302db01ac65e0022323" #"v1.4" #"v3.4.13-bootstrap-11"
+  tag: "v0.1.0-dev-d59bdbd7c1bb82385266706f80b7b58b956814f8" #"v1.4" #"v3.4.13-bootstrap-11"

--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -298,7 +298,7 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 						Name:            "compact-backup",
 						Image:           *etcdBackupImage,
 						ImagePullPolicy: v1.PullIfNotPresent,
-						Command:         getCompactionJobCommands(etcd),
+						Args:            getCompactionJobArgs(etcd),
 						VolumeMounts:    getCompactionJobVolumeMounts(etcd, logger),
 						Env:             getCompactionJobEnvVar(etcd, logger),
 					}},
@@ -483,11 +483,10 @@ func getEnvVarFromSecrets(name, secretName, secretKey string) v1.EnvVar {
 	}
 }
 
-func getCompactionJobCommands(etcd *druidv1alpha1.Etcd) []string {
-	command := []string{"" + "etcdbrctl"}
-	command = append(command, "compact")
+func getCompactionJobArgs(etcd *druidv1alpha1.Etcd) []string {
+	command := []string{"" + "compact"}
 	command = append(command, "--data-dir=/var/etcd/data/compaction.etcd")
-	command = append(command, "--restoration-temp-snapshots-dir=/var/etcd/compaction.restoration.temp")
+	command = append(command, "--restoration-temp-snapshots-dir=/var/etcd/data/compaction.restoration.temp")
 	command = append(command, "--snapstore-temp-directory=/var/etcd/data/tmp")
 	command = append(command, "--enable-snapshot-lease-renewal=true")
 	command = append(command, "--full-snapshot-lease-name="+etcd.GetFullSnapshotLeaseName())

--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -484,7 +484,7 @@ func getEnvVarFromSecrets(name, secretName, secretKey string) v1.EnvVar {
 }
 
 func getCompactionJobArgs(etcd *druidv1alpha1.Etcd) []string {
-	command := []string{"" + "compact"}
+	command := []string{"compact"}
 	command = append(command, "--data-dir=/var/etcd/data/compaction.etcd")
 	command = append(command, "--restoration-temp-snapshots-dir=/var/etcd/data/compaction.restoration.temp")
 	command = append(command, "--snapstore-temp-directory=/var/etcd/data/tmp")

--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -353,12 +353,12 @@ func getCompactionJobVolumeMounts(etcd *druidv1alpha1.Etcd, logger logr.Logger) 
 	if provider == utils.GCS {
 		vms = append(vms, v1.VolumeMount{
 			Name:      "etcd-backup",
-			MountPath: "/root/.gcp/",
+			MountPath: "/var/.gcp/",
 		})
 	} else if provider == utils.S3 || provider == utils.ABS || provider == utils.OSS || provider == utils.Swift || provider == utils.OCS {
 		vms = append(vms, v1.VolumeMount{
 			Name:      "etcd-backup",
-			MountPath: "/root/etcd-backup/",
+			MountPath: "/var/etcd-backup/",
 		})
 	}
 
@@ -425,15 +425,15 @@ func getCompactionJobEnvVar(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.E
 
 	switch provider {
 	case utils.S3:
-		env = append(env, getEnvVarFromValues("AWS_APPLICATION_CREDENTIALS", "/root/etcd-backup"))
+		env = append(env, getEnvVarFromValues("AWS_APPLICATION_CREDENTIALS", "/var/etcd-backup"))
 	case utils.ABS:
-		env = append(env, getEnvVarFromValues("AZURE_APPLICATION_CREDENTIALS", "/root/etcd-backup"))
+		env = append(env, getEnvVarFromValues("AZURE_APPLICATION_CREDENTIALS", "/var/etcd-backup"))
 	case utils.GCS:
-		env = append(env, getEnvVarFromValues("GOOGLE_APPLICATION_CREDENTIALS", "/root/.gcp/serviceaccount.json"))
+		env = append(env, getEnvVarFromValues("GOOGLE_APPLICATION_CREDENTIALS", "/var/.gcp/serviceaccount.json"))
 	case utils.Swift:
-		env = append(env, getEnvVarFromValues("OPENSTACK_APPLICATION_CREDENTIALS", "/root/etcd-backup"))
+		env = append(env, getEnvVarFromValues("OPENSTACK_APPLICATION_CREDENTIALS", "/var/etcd-backup"))
 	case utils.OSS:
-		env = append(env, getEnvVarFromValues("ALICLOUD_APPLICATION_CREDENTIALS", "/root/etcd-backup"))
+		env = append(env, getEnvVarFromValues("ALICLOUD_APPLICATION_CREDENTIALS", "/var/etcd-backup"))
 	case utils.ECS:
 		if storeValues.SecretRef == nil {
 			logger.Info("No secretRef is configured for backup store. Compaction job will fail as no storage could be configured.",
@@ -445,7 +445,7 @@ func getCompactionJobEnvVar(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.E
 		env = append(env, getEnvVarFromSecrets("ECS_ACCESS_KEY_ID", storeValues.SecretRef.Name, "accessKeyID"))
 		env = append(env, getEnvVarFromSecrets("ECS_SECRET_ACCESS_KEY", storeValues.SecretRef.Name, "secretAccessKey"))
 	case utils.OCS:
-		env = append(env, getEnvVarFromValues("OPENSHIFT_APPLICATION_CREDENTIALS", "/root/etcd-backup"))
+		env = append(env, getEnvVarFromValues("OPENSHIFT_APPLICATION_CREDENTIALS", "/var/etcd-backup"))
 	}
 
 	return env

--- a/controllers/etcdcopybackupstask/reconciler.go
+++ b/controllers/etcdcopybackupstask/reconciler.go
@@ -454,12 +454,12 @@ func createVolumeMountsFromStore(store *druidv1alpha1.StoreSpec, provider, volum
 	case druidutils.GCS:
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      getVolumeNamePrefix(volumeMountPrefix) + "etcd-backup",
-			MountPath: "/root/." + getVolumeNamePrefix(volumeMountPrefix) + "gcp/",
+			MountPath: "/var/." + getVolumeNamePrefix(volumeMountPrefix) + "gcp/",
 		})
 	case druidutils.S3, druidutils.ABS, druidutils.Swift, druidutils.OCS, druidutils.OSS:
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      getVolumeNamePrefix(volumeMountPrefix) + "etcd-backup",
-			MountPath: "/root/" + getVolumeNamePrefix(volumeMountPrefix) + "etcd-backup/",
+			MountPath: "/var/" + getVolumeNamePrefix(volumeMountPrefix) + "etcd-backup/",
 		})
 	}
 	return
@@ -480,17 +480,17 @@ func createEnvVarsFromStore(store *druidv1alpha1.StoreSpec, storeProvider, envKe
 	envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.STORAGE_CONTAINER, *store.Container))
 	switch storeProvider {
 	case druidutils.S3:
-		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.AWS_APPLICATION_CREDENTIALS, "/root/"+volumePrefix+"etcd-backup"))
+		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.AWS_APPLICATION_CREDENTIALS, "/var/"+volumePrefix+"etcd-backup"))
 	case druidutils.ABS:
-		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.AZURE_APPLICATION_CREDENTIALS, "/root/"+volumePrefix+"etcd-backup"))
+		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.AZURE_APPLICATION_CREDENTIALS, "/var/"+volumePrefix+"etcd-backup"))
 	case druidutils.GCS:
-		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.GOOGLE_APPLICATION_CREDENTIALS, "/root/."+volumePrefix+"gcp/serviceaccount.json"))
+		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.GOOGLE_APPLICATION_CREDENTIALS, "/var/."+volumePrefix+"gcp/serviceaccount.json"))
 	case druidutils.Swift:
-		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.OPENSTACK_APPLICATION_CREDENTIALS, "/root/"+volumePrefix+"etcd-backup"))
+		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.OPENSTACK_APPLICATION_CREDENTIALS, "/var/"+volumePrefix+"etcd-backup"))
 	case druidutils.OCS:
-		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.OPENSHIFT_APPLICATION_CREDENTIALS, "/root/"+volumePrefix+"etcd-backup"))
+		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.OPENSHIFT_APPLICATION_CREDENTIALS, "/var/"+volumePrefix+"etcd-backup"))
 	case druidutils.OSS:
-		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.ALICLOUD_APPLICATION_CREDENTIALS, "/root/"+volumePrefix+"etcd-backup"))
+		envVars = append(envVars, mapToEnvVar(envKeyPrefix+common.ALICLOUD_APPLICATION_CREDENTIALS, "/var/"+volumePrefix+"etcd-backup"))
 	}
 	return envVars
 }

--- a/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/controllers/etcdcopybackupstask/reconciler_test.go
@@ -455,10 +455,10 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 						expectedMountPath = *storeSpec.Container
 					case druidutils.GCS:
 						expectedMountName = volumeMountPrefix + "etcd-backup"
-						expectedMountPath = "/root/." + volumeMountPrefix + "gcp/"
+						expectedMountPath = "/var/." + volumeMountPrefix + "gcp/"
 					case druidutils.S3, druidutils.ABS, druidutils.Swift, druidutils.OCS, druidutils.OSS:
 						expectedMountName = volumeMountPrefix + "etcd-backup"
-						expectedMountPath = "/root/" + volumeMountPrefix + "etcd-backup/"
+						expectedMountPath = "/var/" + volumeMountPrefix + "etcd-backup/"
 					default:
 						Fail(fmt.Sprintf("Unknown provider: %s", provider))
 					}
@@ -689,12 +689,12 @@ func checkEnvVars(envVars []corev1.EnvVar, storeProvider, container, envKeyPrefi
 	case druidutils.S3, druidutils.ABS, druidutils.Swift, druidutils.OCS, druidutils.OSS:
 		expected = append(expected, corev1.EnvVar{
 			Name:  mapToEnvVarKey[storeProvider],
-			Value: "/root/" + volumePrefix + "etcd-backup",
+			Value: "/var/" + volumePrefix + "etcd-backup",
 		})
 	case druidutils.GCS:
 		expected = append(expected, corev1.EnvVar{
 			Name:  mapToEnvVarKey[storeProvider],
-			Value: "/root/." + volumePrefix + "gcp/serviceaccount.json",
+			Value: "/var/." + volumePrefix + "gcp/serviceaccount.json",
 		})
 	}
 	Expect(envVars).To(Equal(expected))
@@ -861,42 +861,42 @@ func getProviderEnvElements(storeProvider, prefix, volumePrefix string) Elements
 		return Elements{
 			prefix + "AWS_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "AWS_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "ABS":
 		return Elements{
 			prefix + "AZURE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "AZURE_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "GCS":
 		return Elements{
 			prefix + "GOOGLE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "GOOGLE_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/.%sgcp/serviceaccount.json", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/.%sgcp/serviceaccount.json", volumePrefix)),
 			}),
 		}
 	case "Swift":
 		return Elements{
 			prefix + "OPENSTACK_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "OPENSTACK_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "OSS":
 		return Elements{
 			prefix + "ALICLOUD_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "ALICLOUD_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "OCS":
 		return Elements{
 			prefix + "OPENSHIFT_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "OPENSHIFT_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	default:
@@ -910,14 +910,14 @@ func getVolumeMountsElements(storeProvider, volumePrefix string) Elements {
 		return Elements{
 			volumePrefix + "etcd-backup": MatchFields(IgnoreExtras, Fields{
 				"Name":      Equal(volumePrefix + "etcd-backup"),
-				"MountPath": Equal(fmt.Sprintf("/root/.%sgcp/", volumePrefix)),
+				"MountPath": Equal(fmt.Sprintf("/var/.%sgcp/", volumePrefix)),
 			}),
 		}
 	default:
 		return Elements{
 			volumePrefix + "etcd-backup": MatchFields(IgnoreExtras, Fields{
 				"Name":      Equal(volumePrefix + "etcd-backup"),
-				"MountPath": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"MountPath": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	}

--- a/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/controllers/etcdcopybackupstask/reconciler_test.go
@@ -231,16 +231,16 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 		})
 	})
 
-	Describe("#createJobCommandFromStore", func() {
+	Describe("#createJobArgumentFromStore", func() {
 		Context("when given a nil store", func() {
-			It("returns an empty command slice", func() {
-				Expect(createJobCommandFromStore(nil, "provider", "prefix")).To(BeEmpty())
+			It("returns an empty argument slice", func() {
+				Expect(createJobArgumentFromStore(nil, "provider", "prefix")).To(BeEmpty())
 			})
 		})
 
 		Context("when given a empty provider", func() {
-			It("returns an empty command slice", func() {
-				Expect(createJobCommandFromStore(nil, "", "prefix")).To(BeEmpty())
+			It("returns an empty argument slice", func() {
+				Expect(createJobArgumentFromStore(nil, "", "prefix")).To(BeEmpty())
 			})
 		})
 
@@ -260,47 +260,46 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 				prefix = "prefix"
 			})
 
-			It("returns a command slice with provider, prefix, and container information", func() {
+			It("returns a argument slice with provider, prefix, and container information", func() {
 				expected := []string{
 					"--prefixstorage-provider=storage_provider",
 					"--prefixstore-prefix=store_prefix",
 					"--prefixstore-container=store_container",
 				}
-				Expect(createJobCommandFromStore(&store, provider, prefix)).To(Equal(expected))
+				Expect(createJobArgumentFromStore(&store, provider, prefix)).To(Equal(expected))
 			})
 
-			It("should return a command slice with provider and prefix information only when StoreSpec.Container is nil", func() {
+			It("should return a argument slice with provider and prefix information only when StoreSpec.Container is nil", func() {
 				expected := []string{
 					"--prefixstorage-provider=storage_provider",
 					"--prefixstore-prefix=store_prefix",
 				}
 				store.Container = nil
-				Expect(createJobCommandFromStore(&store, provider, prefix)).To(Equal(expected))
+				Expect(createJobArgumentFromStore(&store, provider, prefix)).To(Equal(expected))
 			})
 
-			It("should return a command slice with provider and container information only when StoreSpec.Prefix is empty", func() {
+			It("should return a argument slice with provider and container information only when StoreSpec.Prefix is empty", func() {
 				expected := []string{
 					"--prefixstorage-provider=storage_provider",
 					"--prefixstore-container=store_container",
 				}
 				store.Prefix = ""
-				Expect(createJobCommandFromStore(&store, provider, prefix)).To(Equal(expected))
+				Expect(createJobArgumentFromStore(&store, provider, prefix)).To(Equal(expected))
 			})
 
-			It("returns an empty command slice when StoreSpec.Provider is empty", func() {
+			It("returns an empty argument slice when StoreSpec.Provider is empty", func() {
 				provider = ""
-				Expect(createJobCommandFromStore(&store, provider, prefix)).To(BeEmpty())
+				Expect(createJobArgumentFromStore(&store, provider, prefix)).To(BeEmpty())
 			})
 		})
 	})
 
-	Describe("#createJobCommand", func() {
+	Describe("#createJobArguments", func() {
 		var (
 			providerLocal = druidv1alpha1.StorageProvider(druidutils.Local)
 			providerS3    = druidv1alpha1.StorageProvider(druidutils.S3)
 			task          *druidv1alpha1.EtcdCopyBackupsTask
 			expected      = []string{
-				"etcdbrctl",
 				"copy",
 				"--snapstore-temp-directory=/var/etcd/data/tmp",
 				"--storage-provider=S3",
@@ -332,38 +331,38 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 			}
 		})
 
-		It("should create the correct command", func() {
-			command := createJobCommand(task, druidutils.Local, druidutils.S3)
-			Expect(command).To(Equal(expected))
+		It("should create the correct arguments", func() {
+			arguments := createJobArgs(task, druidutils.Local, druidutils.S3)
+			Expect(arguments).To(Equal(expected))
 		})
 
-		It("should include the max backup age in the command", func() {
+		It("should include the max backup age in the arguments", func() {
 			task.Spec.MaxBackupAge = pointer.Uint32(10)
-			command := createJobCommand(task, druidutils.Local, druidutils.S3)
-			Expect(command).To(Equal(append(expected, "--max-backup-age=10")))
+			arguments := createJobArgs(task, druidutils.Local, druidutils.S3)
+			Expect(arguments).To(Equal(append(expected, "--max-backup-age=10")))
 		})
 
-		It("should include the max number of backups in the command", func() {
+		It("should include the max number of backups in the arguments", func() {
 			task.Spec.MaxBackups = pointer.Uint32(5)
-			command := createJobCommand(task, druidutils.Local, druidutils.S3)
-			Expect(command).To(Equal(append(expected, "--max-backups-to-copy=5")))
+			arguments := createJobArgs(task, druidutils.Local, druidutils.S3)
+			Expect(arguments).To(Equal(append(expected, "--max-backups-to-copy=5")))
 		})
 
-		It("should include the wait for final snapshot in the command", func() {
+		It("should include the wait for final snapshot in the arguments", func() {
 			task.Spec.WaitForFinalSnapshot = &druidv1alpha1.WaitForFinalSnapshotSpec{
 				Enabled: true,
 			}
-			command := createJobCommand(task, druidutils.Local, druidutils.S3)
-			Expect(command).To(Equal(append(expected, "--wait-for-final-snapshot=true")))
+			arguments := createJobArgs(task, druidutils.Local, druidutils.S3)
+			Expect(arguments).To(Equal(append(expected, "--wait-for-final-snapshot=true")))
 		})
 
-		It("should include the wait for final snapshot and timeout in the command", func() {
+		It("should include the wait for final snapshot and timeout in the arguments", func() {
 			task.Spec.WaitForFinalSnapshot = &druidv1alpha1.WaitForFinalSnapshotSpec{
 				Enabled: true,
 				Timeout: &metav1.Duration{Duration: time.Minute},
 			}
-			command := createJobCommand(task, druidutils.Local, druidutils.S3)
-			Expect(command).To(Equal(append(expected, "--wait-for-final-snapshot=true", "--wait-for-final-snapshot-timeout=1m0s")))
+			arguments := createJobArgs(task, druidutils.Local, druidutils.S3)
+			Expect(arguments).To(Equal(append(expected, "--wait-for-final-snapshot=true", "--wait-for-final-snapshot-timeout=1m0s")))
 		})
 	})
 
@@ -744,7 +743,7 @@ func matchJob(task *druidv1alpha1.EtcdCopyBackupsTask, imageVector imagevector.I
 							"Name":            Equal("copy-backups"),
 							"Image":           Equal(fmt.Sprintf("%s:%s", backupRestoreImage.Repository, *backupRestoreImage.Tag)),
 							"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
-							"Command":         MatchAllElements(testutils.CmdIterator, getCmdElements(task, sourceProvider, targetProvider)),
+							"Args":            MatchAllElements(testutils.CmdIterator, getArgElements(task, sourceProvider, targetProvider)),
 							"Env":             MatchElements(testutils.EnvIterator, IgnoreExtras, getEnvElements(task)),
 						}),
 					}),
@@ -756,10 +755,9 @@ func matchJob(task *druidv1alpha1.EtcdCopyBackupsTask, imageVector imagevector.I
 	return And(matcher, matchJobWithProviders(task, sourceProvider, targetProvider))
 }
 
-func getCmdElements(task *druidv1alpha1.EtcdCopyBackupsTask, sourceProvider, targetProvider string) Elements {
+func getArgElements(task *druidv1alpha1.EtcdCopyBackupsTask, sourceProvider, targetProvider string) Elements {
 	elements := Elements{
-		"etcdbrctl": Equal("etcdbrctl"),
-		"copy":      Equal("copy"),
+		"copy": Equal("copy"),
 		"--snapstore-temp-directory=/var/etcd/data/tmp": Equal("--snapstore-temp-directory=/var/etcd/data/tmp"),
 	}
 	if targetProvider != "" {

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -430,12 +430,31 @@ func (c *component) createOrPatch(ctx context.Context, sts *appsv1.StatefulSet, 
 					ServiceAccountName:        c.values.ServiceAccountName,
 					Affinity:                  c.values.Affinity,
 					TopologySpreadConstraints: c.values.TopologySpreadConstraints,
+					InitContainers: []corev1.Container{
+						{
+							Name:         "change-permissions",
+							Image:        "alpine:3.18.0",
+							Command:      []string{"sh", "-c", "--"},
+							Args:         []string{"chown -R 65532:65532 /var/etcd/data"},
+							VolumeMounts: getEtcdVolumeMounts(c.values),
+							SecurityContext: &corev1.SecurityContext{
+								RunAsGroup:   pointer.Int64(0),
+								RunAsNonRoot: pointer.Bool(false),
+								RunAsUser:    pointer.Int64(0),
+							},
+						},
+					},
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsGroup:   pointer.Int64(65532),
+						RunAsNonRoot: pointer.Bool(true),
+						RunAsUser:    pointer.Int64(65532),
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            "etcd",
 							Image:           c.values.EtcdImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Command:         c.values.EtcdCommand,
+							Args:            c.values.EtcdCommand,
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler:        getReadinessHandler(c.values),
 								InitialDelaySeconds: 15,
@@ -451,7 +470,7 @@ func (c *component) createOrPatch(ctx context.Context, sts *appsv1.StatefulSet, 
 							Name:            "backup-restore",
 							Image:           c.values.BackupImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Command:         c.values.EtcdBackupCommand,
+							Args:            c.values.EtcdBackupCommand,
 							Ports:           getBackupPorts(c.values),
 							Resources:       getBackupResources(c.values),
 							Env:             getBackupRestoreEnvVars(c.values),
@@ -698,12 +717,12 @@ func getBackupRestoreVolumeMounts(val Values) []corev1.VolumeMount {
 	case utils.GCS:
 		vms = append(vms, corev1.VolumeMount{
 			Name:      "etcd-backup",
-			MountPath: "/root/.gcp/",
+			MountPath: "/var/.gcp/",
 		})
 	case utils.S3, utils.ABS, utils.OSS, utils.Swift, utils.OCS:
 		vms = append(vms, corev1.VolumeMount{
 			Name:      "etcd-backup",
-			MountPath: "/root/etcd-backup/",
+			MountPath: "/var/etcd-backup/",
 		})
 	}
 
@@ -878,7 +897,7 @@ func getBackupRestoreEnvVars(val Values) []corev1.EnvVar {
 	}
 
 	// TODO(timuthy): move this to a non root path when we switch to a rootless distribution
-	const credentialsMountPath = "/root/etcd-backup"
+	const credentialsMountPath = "/var/etcd-backup"
 	switch provider {
 	case utils.S3:
 		env = append(env, getEnvVarFromValue("AWS_APPLICATION_CREDENTIALS", credentialsMountPath))
@@ -887,7 +906,7 @@ func getBackupRestoreEnvVars(val Values) []corev1.EnvVar {
 		env = append(env, getEnvVarFromValue("AZURE_APPLICATION_CREDENTIALS", credentialsMountPath))
 
 	case utils.GCS:
-		env = append(env, getEnvVarFromValue("GOOGLE_APPLICATION_CREDENTIALS", "/root/.gcp/serviceaccount.json"))
+		env = append(env, getEnvVarFromValue("GOOGLE_APPLICATION_CREDENTIALS", "/var/.gcp/serviceaccount.json"))
 
 	case utils.Swift:
 		env = append(env, getEnvVarFromValue("OPENSTACK_APPLICATION_CREDENTIALS", credentialsMountPath))
@@ -964,9 +983,16 @@ func getReadinessHandlerForSingleNode(val Values) corev1.ProbeHandler {
 }
 
 func getReadinessHandlerForMultiNode(val Values) corev1.ProbeHandler {
+	scheme := corev1.URISchemeHTTPS
+	if val.BackupTLS == nil {
+		scheme = corev1.URISchemeHTTP
+	}
+
 	return corev1.ProbeHandler{
-		Exec: &corev1.ExecAction{
-			Command: val.ReadinessProbeCommand,
+		HTTPGet: &corev1.HTTPGetAction{
+			Path:   "/readyz",
+			Port:   intstr.FromInt(int(pointer.Int32Deref(pointer.Int32(9095), *pointer.Int32(9095)))),
+			Scheme: scheme,
 		},
 	}
 }

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -991,7 +991,7 @@ func getReadinessHandlerForMultiNode(val Values) corev1.ProbeHandler {
 	return corev1.ProbeHandler{
 		HTTPGet: &corev1.HTTPGetAction{
 			Path:   "/readyz",
-			Port:   intstr.FromInt(int(pointer.Int32Deref(pointer.Int32(9095), *pointer.Int32(9095)))),
+			Port:   intstr.FromInt(int(pointer.Int32Deref(val.WrapperPort, defaultWrapperPort))),
 			Scheme: scheme,
 		},
 	}

--- a/pkg/component/etcd/statefulset/values.go
+++ b/pkg/component/etcd/statefulset/values.go
@@ -57,9 +57,8 @@ type Values struct {
 	EtcdResourceRequirements   *corev1.ResourceRequirements
 	BackupResourceRequirements *corev1.ResourceRequirements
 
-	EtcdCommand           []string
-	ReadinessProbeCommand []string
-	EtcdBackupCommand     []string
+	EtcdCommand       []string
+	EtcdBackupCommand []string
 
 	EnableClientTLS string
 	EnablePeerTLS   string
@@ -114,8 +113,10 @@ type Values struct {
 	PeerServiceName string
 	// ServerPort is the peer port.
 	ServerPort *int32
-	// ServerPort is the backup-restore side-car port.
+	// BackupPort is the backup-restore side-car port.
 	BackupPort *int32
+	// WrapperPort is the port where etcd-wrapper registers and exposes it's ready endpoint
+	WrapperPort *int32
 
 	// AutoCompactionMode defines the auto-compaction-mode: 'periodic' or 'revision'.
 	AutoCompactionMode *druidv1alpha1.CompactionMode

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -119,7 +119,7 @@ func GenerateValues(
 		PeerTLSChangedToEnabled: peerTLSChangedToEnabled,
 	}
 
-	values.EtcdCommand = getEtcdCommand()
+	values.EtcdCommand = getEtcdCommand(values)
 
 	// Use linearizability for readiness probe so that pod is only considered ready
 	// when it has an active connection to the cluster and the cluster maintains a quorum.
@@ -130,8 +130,27 @@ func GenerateValues(
 	return values
 }
 
-func getEtcdCommand() []string {
-	return []string{"/var/etcd/bin/bootstrap.sh"}
+func getEtcdCommand(val Values) []string {
+	command := []string{"" + "start-etcd"}
+
+	if val.ClientUrlTLS != nil {
+		dataKey := "ca.crt"
+		if val.ClientUrlTLS.TLSCASecretRef.DataKey != nil {
+			dataKey = *val.ClientUrlTLS.TLSCASecretRef.DataKey
+		}
+		command = append(command, "--backup-restore-tls-enabled=true")
+		command = append(command, fmt.Sprintf("--backup-restore-host-port=%s-local:8080", val.Name))
+		command = append(command, fmt.Sprintf("--etcd-server-name=%s-local", val.Name))
+		command = append(command, "--etcd-client-cert-path=/var/etcd/ssl/client/client/tls.crt")
+		command = append(command, "--etcd-client-key-path=/var/etcd/ssl/client/client/tls.key")
+		command = append(command, fmt.Sprintf("--backup-restore-ca-cert-bundle-path=/var/etcd/ssl/client/ca/%s", dataKey))
+	} else {
+		command = append(command, "--backup-restore-tls-enabled=false")
+		command = append(command, fmt.Sprintf("--backup-restore-host-port=%s-local:8080", val.Name))
+		command = append(command, fmt.Sprintf("--etcd-server-name=%s-local", val.Name))
+	}
+
+	return command
 }
 
 type consistencyLevel string
@@ -178,8 +197,7 @@ func getProbeCommand(val Values, consistency consistencyLevel) []string {
 }
 
 func getBackupRestoreCommand(val Values) []string {
-	command := []string{"" + "etcdbrctl"}
-	command = append(command, "server")
+	command := []string{"" + "server"}
 
 	if val.BackupStore != nil {
 		command = append(command, "--enable-snapshot-lease-renewal=true")
@@ -206,7 +224,7 @@ func getBackupRestoreCommand(val Values) []string {
 	}
 
 	command = append(command, "--data-dir=/var/etcd/data/new.etcd")
-	command = append(command, "--restoration-temp-snapshots-dir=/var/etcd/restoration.temp")
+	command = append(command, "--restoration-temp-snapshots-dir=/var/etcd/data/restoration.temp")
 
 	if val.BackupStore != nil {
 		store, _ := utils.StorageProviderFromInfraProvider(val.BackupStore.Provider)

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -28,6 +28,7 @@ const (
 	defaultBackupPort              int32 = 8080
 	defaultServerPort              int32 = 2380
 	defaultClientPort              int32 = 2379
+	defaultWrapperPort             int32 = 9095
 	defaultQuota                   int64 = 8 * 1024 * 1024 * 1024 // 8Gi
 	defaultSnapshotMemoryLimit     int64 = 100 * 1024 * 1024      // 100Mi
 	defaultHeartbeatDuration             = "10s"
@@ -112,6 +113,7 @@ func GenerateValues(
 		PeerServiceName:   etcd.GetPeerServiceName(),
 		ServerPort:        serverPort,
 		BackupPort:        backupPort,
+		WrapperPort:       pointer.Int32(defaultWrapperPort),
 
 		AutoCompactionMode:      etcd.Spec.Common.AutoCompactionMode,
 		AutoCompactionRetention: etcd.Spec.Common.AutoCompactionRetention,
@@ -120,10 +122,6 @@ func GenerateValues(
 	}
 
 	values.EtcdCommand = getEtcdCommand(values)
-
-	// Use linearizability for readiness probe so that pod is only considered ready
-	// when it has an active connection to the cluster and the cluster maintains a quorum.
-	values.ReadinessProbeCommand = getProbeCommand(values, linearizable)
 
 	values.EtcdBackupCommand = getBackupRestoreCommand(values)
 
@@ -197,7 +195,7 @@ func getProbeCommand(val Values, consistency consistencyLevel) []string {
 }
 
 func getBackupRestoreCommand(val Values) []string {
-	command := []string{"" + "server"}
+	command := []string{"server"}
 
 	if val.BackupStore != nil {
 		command = append(command, "--enable-snapshot-lease-renewal=true")

--- a/test/e2e/etcd_backup_test.go
+++ b/test/e2e/etcd_backup_test.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"time"
 
+	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	"github.com/gardener/etcd-druid/api/v1alpha1"
 
-	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
 	"github.com/gardener/gardener/pkg/utils/test/matchers"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -75,7 +75,7 @@ var _ = Describe("Etcd Backup", func() {
 					Expect(deployBackupSecret(parentCtx, cl, logger, provider, etcdNamespace, storageContainer))
 				})
 
-				It("should create, test backup and delete etcd with backup", func() {
+				It("Should create, test backup and delete etcd with backup", func() {
 					ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
 					defer cancelFunc()
 
@@ -85,10 +85,12 @@ var _ = Describe("Etcd Backup", func() {
 					By("Create etcd")
 					createAndCheckEtcd(ctx, cl, objLogger, etcd, singleNodeEtcdTimeout)
 
-					By("Check initial snapshot is available")
-					var podName = fmt.Sprintf("%s-0", etcdName)
+					By("Create debug pod")
+					debugPod := createDebugPod(ctx, etcd)
 
-					latestSnapshotsBeforePopulate, err := getLatestSnapshots(kubeconfigPath, namespace, etcdName, podName, "backup-restore", 8080)
+					By("Check initial snapshot is available")
+
+					latestSnapshotsBeforePopulate, err := getLatestSnapshots(kubeconfigPath, namespace, etcdName, debugPod.Name, "etcd-debug", 8080)
 					Expect(err).ShouldNot(HaveOccurred())
 					// We don't expect any delta snapshot as the cluster
 					Expect(latestSnapshotsBeforePopulate.DeltaSnapshots).To(HaveLen(0))
@@ -102,14 +104,14 @@ var _ = Describe("Etcd Backup", func() {
 						"toKey", fmt.Sprintf("%s-10", etcdKeyPrefix), "toValue", fmt.Sprintf("%s-10", etcdValuePrefix))
 
 					// populate 10 keys in etcd, finishing in 10 seconds
-					err = populateEtcdWithCount(logger, kubeconfigPath, namespace, etcdName, podName, "etcd", etcdKeyPrefix, etcdValuePrefix, 1, 10, time.Second*1)
+					err = populateEtcd(logger, kubeconfigPath, namespace, etcdName, debugPod.Name, "etcd-debug", etcdKeyPrefix, etcdValuePrefix, 1, 10, time.Second*1)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					By("Check snapshot after putting data into etcd")
 					// allow 5 second buffer to upload full/delta snapshot
 					time.Sleep(time.Second * 5)
 
-					latestSnapshotsAfterPopulate, err := getLatestSnapshots(kubeconfigPath, namespace, etcdName, podName, "backup-restore", 8080)
+					latestSnapshotsAfterPopulate, err := getLatestSnapshots(kubeconfigPath, namespace, etcdName, debugPod.Name, "etcd-debug", 8080)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					latestSnapshotAfterPopulate := latestSnapshotsAfterPopulate.FullSnapshot
@@ -121,7 +123,7 @@ var _ = Describe("Etcd Backup", func() {
 					Expect(latestSnapshotAfterPopulate.CreatedOn.After(latestSnapshotBeforePopulate.CreatedOn)).To(BeTrue())
 
 					By("Trigger on-demand full snapshot")
-					fullSnapshot, err := triggerOnDemandSnapshot(kubeconfigPath, namespace, podName, "backup-restore", 8080, brtypes.SnapshotKindFull)
+					fullSnapshot, err := triggerOnDemandSnapshot(kubeconfigPath, namespace, debugPod.Name, "etcd-debug", 8080, brtypes.SnapshotKindFull)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(fullSnapshot.LastRevision).To(Equal(10 + latestSnapshotBeforePopulate.LastRevision))
 
@@ -130,15 +132,15 @@ var _ = Describe("Etcd Backup", func() {
 						"fromKey", fmt.Sprintf("%s-11", etcdKeyPrefix), "fromValue", fmt.Sprintf("%s-11", etcdValuePrefix),
 						"toKey", fmt.Sprintf("%s-15", etcdKeyPrefix), "toValue", fmt.Sprintf("%s-15", etcdValuePrefix))
 					// populate 5 keys in etcd, finishing in 5 seconds
-					err = populateEtcdWithCount(logger, kubeconfigPath, namespace, etcdName, podName, "etcd", etcdKeyPrefix, etcdValuePrefix, 11, 15, time.Second*1)
+					err = populateEtcd(logger, kubeconfigPath, namespace, etcdName, debugPod.Name, "etcd-debug", etcdKeyPrefix, etcdValuePrefix, 11, 15, time.Second*1)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					By("Trigger on-demand delta snapshot")
-					_, err = triggerOnDemandSnapshot(kubeconfigPath, namespace, podName, "backup-restore", 8080, brtypes.SnapshotKindDelta)
+					_, err = triggerOnDemandSnapshot(kubeconfigPath, namespace, debugPod.Name, "etcd-debug", 8080, brtypes.SnapshotKindDelta)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					By("Test cluster restoration by deleting data directory")
-					Expect(deleteDir(kubeconfigPath, namespace, podName, "backup-restore", "/var/etcd/data/new.etcd/member")).To(Succeed())
+					Expect(deleteDir(kubeconfigPath, namespace, debugPod.Name, "etcd-debug", "/var/etcd/data/new.etcd/member")).To(Succeed())
 
 					logger.Info("waiting for sts to become unready", "statefulSetName", etcdName)
 					Eventually(func() error {
@@ -174,21 +176,41 @@ var _ = Describe("Etcd Backup", func() {
 
 					// verify existence and correctness of keys 1 to 30
 					logger.Info("fetching etcd key-value pairs")
-					keyValueMap, err := getEtcdKeys(logger, kubeconfigPath, namespace, etcdName, podName, "etcd", etcdKeyPrefix, 1, 15)
+					keyValueMap, err := getEtcdKeys(logger, kubeconfigPath, namespace, etcdName, debugPod.Name, "etcd-debug", etcdKeyPrefix, 1, 15)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for i := 1; i <= 15; i++ {
 						Expect(keyValueMap[fmt.Sprintf("%s-%d", etcdKeyPrefix, i)]).To(Equal(fmt.Sprintf("%s-%d", etcdValuePrefix, i)))
 					}
 
+					By("Delete debug pod")
+					Expect(cl.Delete(ctx, debugPod)).ToNot(HaveOccurred())
+
 					By("Delete etcd")
 					deleteAndCheckEtcd(ctx, cl, objLogger, etcd, singleNodeEtcdTimeout)
-
 				})
 			})
 		}
 	})
 })
+
+func createDebugPod(ctx context.Context, etcd *v1alpha1.Etcd) *corev1.Pod {
+	debugPod := getDebugPod(etcd)
+	ExpectWithOffset(1, cl.Create(ctx, debugPod)).ShouldNot(HaveOccurred())
+	//Make sure pod is competed
+	EventuallyWithOffset(1, func() error {
+		dPod := &corev1.Pod{}
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "etcd-debug"}, dPod); err != nil {
+			return fmt.Errorf("error occurred while getting pod object: %v ", err)
+		}
+		if dPod.Status.Phase == "Running" {
+			return nil
+		}
+		return fmt.Errorf("waiting for pod %v to be ready", dPod.Name)
+	}, 2*time.Minute, pollingInterval).Should(BeNil())
+
+	return debugPod
+}
 
 func createAndCheckEtcd(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd, timeout time.Duration) {
 	ExpectWithOffset(1, cl.Create(ctx, etcd)).ShouldNot(HaveOccurred())

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -126,9 +126,14 @@ var _ = Describe("Etcd", func() {
 			checkEtcdReady(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 
 			By("Single member restoration")
+			objLogger.Info("Create debug pod")
+			debugPod := createDebugPod(ctx, etcd)
 			objLogger.Info("Delete member dir of one member pod")
-			deleteMemberDir(ctx, cl, objLogger, etcd, "etcd-aws-2")
+			deleteMemberDir(ctx, cl, objLogger, etcd, debugPod.Name)
 			checkEtcdReady(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
+
+			By("Delete debug pod")
+			Expect(cl.Delete(ctx, debugPod)).ToNot(HaveOccurred())
 
 			By("Delete etcd")
 			deleteAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
@@ -151,7 +156,7 @@ var _ = Describe("Etcd", func() {
 			etcd.Spec.Replicas = 3
 			updateAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 
-			By("Deleting the single-node etcd")
+			By("Deleting etcd")
 			deleteAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 		})
 
@@ -237,7 +242,7 @@ var _ = Describe("Etcd", func() {
 })
 
 func deleteMemberDir(ctx context.Context, cl client.Client, logger logr.Logger, etcd *v1alpha1.Etcd, podName string) {
-	ExpectWithOffset(1, deleteDir(kubeconfigPath, namespace, podName, "backup-restore", "/var/etcd/data/new.etcd/member")).To(Succeed())
+	ExpectWithOffset(1, deleteDir(kubeconfigPath, namespace, podName, "etcd-debug", "/var/etcd/data/new.etcd/member")).To(Succeed())
 	checkUnreadySts(ctx, cl, logger, etcd)
 }
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -840,7 +840,7 @@ func etcdZeroDownTimeValidatorJob(etcdSvc, testName string, tls *v1alpha1.TLSCon
 							"failed=0 ; threshold=2 ; " +
 							"while [ $failed -lt $threshold ] ; do  " +
 							"$(curl --cacert /var/etcd/ssl/client/ca/ca.crt --cert /var/etcd/ssl/client/client/tls.crt --key /var/etcd/ssl/client/client/tls.key https://" + etcdSvc + ":2379/health -s -f  -o /dev/null ); " +
-							"if [ $? -gt 0 ] ; then let failed++; echo \"etcd is unhealthy and retrying\"; continue;  fi ; " +
+							"if [ $? -gt 0 ] ; then let failed++; echo \"etcd is unhealthy and retrying\"; sleep 1; continue;  fi ; " +
 							"echo \"etcd is healthy\";  touch /tmp/healthy; let failed=0; " +
 							"sleep 1; done;  echo \"etcd is unhealthy\"; exit 1;" +
 							"' > test.sh && sh test.sh",

--- a/test/integration/controllers/compaction/reconciler_test.go
+++ b/test/integration/controllers/compaction/reconciler_test.go
@@ -269,9 +269,9 @@ func validateEtcdForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.Job) 
 					"RestartPolicy": Equal(corev1.RestartPolicyNever),
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 						"compact-backup": MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--data-dir=/var/etcd/data/compaction.etcd":                                                                 Equal("--data-dir=/var/etcd/data/compaction.etcd"),
-								"--restoration-temp-snapshots-dir=/var/etcd/compaction.restoration.temp":                                    Equal("--restoration-temp-snapshots-dir=/var/etcd/compaction.restoration.temp"),
+								"--restoration-temp-snapshots-dir=/var/etcd/data/compaction.restoration.temp":                               Equal("--restoration-temp-snapshots-dir=/var/etcd/data/compaction.restoration.temp"),
 								"--snapstore-temp-directory=/var/etcd/data/tmp":                                                             Equal("--snapstore-temp-directory=/var/etcd/data/tmp"),
 								"--enable-snapshot-lease-renewal=true":                                                                      Equal("--enable-snapshot-lease-renewal=true"),
 								fmt.Sprintf("%s=%s", "--full-snapshot-lease-name", instance.GetFullSnapshotLeaseName()):                     Equal(fmt.Sprintf("%s=%s", "--full-snapshot-lease-name", instance.GetFullSnapshotLeaseName())),
@@ -331,7 +331,7 @@ func validateStoreGCPForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.J
 				"Spec": MatchFields(IgnoreExtras, Fields{
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 						"compact-backup": MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--storage-provider=GCS": Equal("--storage-provider=GCS"),
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix):        Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 								fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container): Equal(fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container)),
@@ -385,7 +385,7 @@ func validateStoreAWSForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.J
 				"Spec": MatchFields(IgnoreExtras, Fields{
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 						"compact-backup": MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--storage-provider=S3": Equal("--storage-provider=S3"),
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix):        Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 								fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container): Equal(fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container)),
@@ -433,7 +433,7 @@ func validateStoreAzureForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1
 				"Spec": MatchFields(IgnoreExtras, Fields{
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 						"compact-backup": MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--storage-provider=ABS": Equal("--storage-provider=ABS"),
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix):        Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 								fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container): Equal(fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container)),
@@ -481,7 +481,7 @@ func validateStoreOpenstackForCompactionJob(instance *druidv1alpha1.Etcd, j *bat
 				"Spec": MatchFields(IgnoreExtras, Fields{
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 						"compact-backup": MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--storage-provider=Swift": Equal("--storage-provider=Swift"),
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix):        Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 								fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container): Equal(fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container)),
@@ -529,7 +529,7 @@ func validateStoreAlicloudForCompactionJob(instance *druidv1alpha1.Etcd, j *batc
 				"Spec": MatchFields(IgnoreExtras, Fields{
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 						"compact-backup": MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--storage-provider=OSS": Equal("--storage-provider=OSS"),
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix):        Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 								fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container): Equal(fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container)),

--- a/test/integration/controllers/compaction/reconciler_test.go
+++ b/test/integration/controllers/compaction/reconciler_test.go
@@ -339,7 +339,7 @@ func validateStoreGCPForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.J
 							"VolumeMounts": MatchElements(testutils.VolumeMountIterator, IgnoreExtras, Elements{
 								"etcd-backup": MatchFields(IgnoreExtras, Fields{
 									"Name":      Equal("etcd-backup"),
-									"MountPath": Equal("/root/.gcp/"),
+									"MountPath": Equal("/var/.gcp/"),
 								}),
 							}),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
@@ -357,7 +357,7 @@ func validateStoreGCPForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.J
 								}),
 								"GOOGLE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 									"Name":  Equal("GOOGLE_APPLICATION_CREDENTIALS"),
-									"Value": Equal("/root/.gcp/serviceaccount.json"),
+									"Value": Equal("/var/.gcp/serviceaccount.json"),
 								}),
 							}),
 						}),
@@ -405,7 +405,7 @@ func validateStoreAWSForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.J
 								}),
 								"AWS_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 									"Name":  Equal("AWS_APPLICATION_CREDENTIALS"),
-									"Value": Equal("/root/etcd-backup"),
+									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
 						}),
@@ -453,7 +453,7 @@ func validateStoreAzureForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1
 								}),
 								"AZURE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 									"Name":  Equal("AZURE_APPLICATION_CREDENTIALS"),
-									"Value": Equal("/root/etcd-backup"),
+									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
 						}),
@@ -501,7 +501,7 @@ func validateStoreOpenstackForCompactionJob(instance *druidv1alpha1.Etcd, j *bat
 								}),
 								"OPENSTACK_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 									"Name":  Equal("OPENSTACK_APPLICATION_CREDENTIALS"),
-									"Value": Equal("/root/etcd-backup"),
+									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
 						}),
@@ -550,7 +550,7 @@ func validateStoreAlicloudForCompactionJob(instance *druidv1alpha1.Etcd, j *batc
 								}),
 								"ALICLOUD_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 									"Name":  Equal("ALICLOUD_APPLICATION_CREDENTIALS"),
-									"Value": Equal("/root/etcd-backup"),
+									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
 						}),

--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -668,8 +668,11 @@ func validateDefaultValuesForEtcd(instance *druidv1alpha1.Etcd, s *appsv1.Statef
 									ContainerPort: clientPort,
 								},
 							}),
-							"Command": MatchAllElements(testutils.CmdIterator, Elements{
-								"/var/etcd/bin/bootstrap.sh": Equal("/var/etcd/bin/bootstrap.sh"),
+							"Args": MatchAllElements(testutils.CmdIterator, Elements{
+								"start-etcd":                         Equal("start-etcd"),
+								"--backup-restore-tls-enabled=false": Equal("--backup-restore-tls-enabled=false"),
+								fmt.Sprintf("--backup-restore-host-port=%s-local:%d", instance.Name, backupPort): Equal(fmt.Sprintf("--backup-restore-host-port=%s-local:%d", instance.Name, backupPort)),
+								fmt.Sprintf("--etcd-server-name=%s-local", instance.Name):                        Equal(fmt.Sprintf("--etcd-server-name=%s-local", instance.Name)),
 							}),
 							"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
 							"Image":           Equal(fmt.Sprintf("%s:%s", images[common.Etcd].Repository, *images[common.Etcd].Tag)),
@@ -700,17 +703,16 @@ func validateDefaultValuesForEtcd(instance *druidv1alpha1.Etcd, s *appsv1.Statef
 						}),
 
 						backupRestore: MatchFields(IgnoreExtras, Fields{
-							"Command": MatchAllElements(testutils.CmdIterator, Elements{
-								"etcdbrctl":                          Equal("etcdbrctl"),
+							"Args": MatchAllElements(testutils.CmdIterator, Elements{
 								"server":                             Equal("server"),
 								"--data-dir=/var/etcd/data/new.etcd": Equal("--data-dir=/var/etcd/data/new.etcd"),
-								"--restoration-temp-snapshots-dir=/var/etcd/restoration.temp": Equal("--restoration-temp-snapshots-dir=/var/etcd/restoration.temp"),
-								"--insecure-transport=true":                                   Equal("--insecure-transport=true"),
-								"--insecure-skip-tls-verify=true":                             Equal("--insecure-skip-tls-verify=true"),
-								"--etcd-connection-timeout=5m":                                Equal("--etcd-connection-timeout=5m"),
-								"--snapstore-temp-directory=/var/etcd/data/temp":              Equal("--snapstore-temp-directory=/var/etcd/data/temp"),
-								"--enable-member-lease-renewal=true":                          Equal("--enable-member-lease-renewal=true"),
-								"--k8s-heartbeat-duration=10s":                                Equal("--k8s-heartbeat-duration=10s"),
+								"--restoration-temp-snapshots-dir=/var/etcd/data/restoration.temp": Equal("--restoration-temp-snapshots-dir=/var/etcd/data/restoration.temp"),
+								"--insecure-transport=true":                                        Equal("--insecure-transport=true"),
+								"--insecure-skip-tls-verify=true":                                  Equal("--insecure-skip-tls-verify=true"),
+								"--etcd-connection-timeout=5m":                                     Equal("--etcd-connection-timeout=5m"),
+								"--snapstore-temp-directory=/var/etcd/data/temp":                   Equal("--snapstore-temp-directory=/var/etcd/data/temp"),
+								"--enable-member-lease-renewal=true":                               Equal("--enable-member-lease-renewal=true"),
+								"--k8s-heartbeat-duration=10s":                                     Equal("--k8s-heartbeat-duration=10s"),
 
 								fmt.Sprintf("--delta-snapshot-memory-limit=%d", deltaSnapShotMemLimit.Value()):                 Equal(fmt.Sprintf("--delta-snapshot-memory-limit=%d", deltaSnapShotMemLimit.Value())),
 								fmt.Sprintf("--garbage-collection-policy=%s", druidv1alpha1.GarbageCollectionPolicyLimitBased): Equal(fmt.Sprintf("--garbage-collection-policy=%s", druidv1alpha1.GarbageCollectionPolicyLimitBased)),
@@ -1025,8 +1027,14 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 									ContainerPort: *instance.Spec.Etcd.ClientPort,
 								},
 							}),
-							"Command": MatchAllElements(testutils.CmdIterator, Elements{
-								"/var/etcd/bin/bootstrap.sh": Equal("/var/etcd/bin/bootstrap.sh"),
+							"Args": MatchAllElements(testutils.CmdIterator, Elements{
+								"start-etcd":                        Equal("start-etcd"),
+								"--backup-restore-tls-enabled=true": Equal("--backup-restore-tls-enabled=true"),
+								"--etcd-client-cert-path=/var/etcd/ssl/client/client/tls.crt":                    Equal("--etcd-client-cert-path=/var/etcd/ssl/client/client/tls.crt"),
+								"--etcd-client-key-path=/var/etcd/ssl/client/client/tls.key":                     Equal("--etcd-client-key-path=/var/etcd/ssl/client/client/tls.key"),
+								"--backup-restore-ca-cert-bundle-path=/var/etcd/ssl/client/ca/ca.crt":            Equal("--backup-restore-ca-cert-bundle-path=/var/etcd/ssl/client/ca/ca.crt"),
+								fmt.Sprintf("--backup-restore-host-port=%s-local:%d", instance.Name, backupPort): Equal(fmt.Sprintf("--backup-restore-host-port=%s-local:%d", instance.Name, backupPort)),
+								fmt.Sprintf("--etcd-server-name=%s-local", instance.Name):                        Equal(fmt.Sprintf("--etcd-server-name=%s-local", instance.Name)),
 							}),
 							"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
 							"Image":           Equal(*instance.Spec.Etcd.Image),
@@ -1081,16 +1089,15 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 						}),
 
 						backupRestore: MatchFields(IgnoreExtras, Fields{
-							"Command": MatchAllElements(testutils.CmdIterator, Elements{
-								"etcdbrctl": Equal("etcdbrctl"),
-								"server":    Equal("server"),
+							"Args": MatchAllElements(testutils.CmdIterator, Elements{
+								"server": Equal("server"),
 								"--cert=/var/etcd/ssl/client/client/tls.crt":                                                                        Equal("--cert=/var/etcd/ssl/client/client/tls.crt"),
 								"--key=/var/etcd/ssl/client/client/tls.key":                                                                         Equal("--key=/var/etcd/ssl/client/client/tls.key"),
 								"--cacert=/var/etcd/ssl/client/ca/ca.crt":                                                                           Equal("--cacert=/var/etcd/ssl/client/ca/ca.crt"),
 								"--server-cert=/var/etcd/ssl/client/server/tls.crt":                                                                 Equal("--server-cert=/var/etcd/ssl/client/server/tls.crt"),
 								"--server-key=/var/etcd/ssl/client/server/tls.key":                                                                  Equal("--server-key=/var/etcd/ssl/client/server/tls.key"),
 								"--data-dir=/var/etcd/data/new.etcd":                                                                                Equal("--data-dir=/var/etcd/data/new.etcd"),
-								"--restoration-temp-snapshots-dir=/var/etcd/restoration.temp":                                                       Equal("--restoration-temp-snapshots-dir=/var/etcd/restoration.temp"),
+								"--restoration-temp-snapshots-dir=/var/etcd/data/restoration.temp":                                                  Equal("--restoration-temp-snapshots-dir=/var/etcd/data/restoration.temp"),
 								"--insecure-transport=false":                                                                                        Equal("--insecure-transport=false"),
 								"--insecure-skip-tls-verify=false":                                                                                  Equal("--insecure-skip-tls-verify=false"),
 								"--snapstore-temp-directory=/var/etcd/data/temp":                                                                    Equal("--snapstore-temp-directory=/var/etcd/data/temp"),
@@ -1274,14 +1281,14 @@ func validateStoreGCP(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *co
 				"Spec": MatchFields(IgnoreExtras, Fields{
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 						backupRestore: MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--storage-provider=GCS": Equal("--storage-provider=GCS"),
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix): Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 							}),
 							"VolumeMounts": MatchElements(testutils.VolumeMountIterator, IgnoreExtras, Elements{
 								"etcd-backup": MatchFields(IgnoreExtras, Fields{
 									"Name":      Equal("etcd-backup"),
-									"MountPath": Equal("/root/.gcp/"),
+									"MountPath": Equal("/var/.gcp/"),
 								}),
 							}),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
@@ -1307,7 +1314,7 @@ func validateStoreGCP(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *co
 								}),
 								"GOOGLE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 									"Name":  Equal("GOOGLE_APPLICATION_CREDENTIALS"),
-									"Value": Equal("/root/.gcp/serviceaccount.json"),
+									"Value": Equal("/var/.gcp/serviceaccount.json"),
 								}),
 							}),
 						}),
@@ -1337,7 +1344,7 @@ func validateStoreAzure(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *
 				"Spec": MatchFields(IgnoreExtras, Fields{
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 						backupRestore: MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--storage-provider=ABS": Equal("--storage-provider=ABS"),
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix): Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 							}),
@@ -1364,7 +1371,7 @@ func validateStoreAzure(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *
 								}),
 								"AZURE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 									"Name":  Equal("AZURE_APPLICATION_CREDENTIALS"),
-									"Value": Equal("/root/etcd-backup"),
+									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
 						}),
@@ -1393,7 +1400,7 @@ func validateStoreOpenstack(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet,
 				"Spec": MatchFields(IgnoreExtras, Fields{
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 						backupRestore: MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--storage-provider=Swift": Equal("--storage-provider=Swift"),
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix): Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 							}),
@@ -1420,7 +1427,7 @@ func validateStoreOpenstack(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet,
 								}),
 								"OPENSTACK_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 									"Name":  Equal("OPENSTACK_APPLICATION_CREDENTIALS"),
-									"Value": Equal("/root/etcd-backup"),
+									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
 						}),
@@ -1450,7 +1457,7 @@ func validateStoreAlicloud(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, 
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 
 						backupRestore: MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--storage-provider=OSS": Equal("--storage-provider=OSS"),
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix): Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 							}),
@@ -1478,7 +1485,7 @@ func validateStoreAlicloud(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, 
 								}),
 								"ALICLOUD_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 									"Name":  Equal("ALICLOUD_APPLICATION_CREDENTIALS"),
-									"Value": Equal("/root/etcd-backup"),
+									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
 						}),
@@ -1508,7 +1515,7 @@ func validateStoreAWS(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *co
 					"Containers": MatchElements(testutils.ContainerIterator, IgnoreExtras, Elements{
 
 						backupRestore: MatchFields(IgnoreExtras, Fields{
-							"Command": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
+							"Args": MatchElements(testutils.CmdIterator, IgnoreExtras, Elements{
 								"--storage-provider=S3": Equal("--storage-provider=S3"),
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix): Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 							}),
@@ -1536,7 +1543,7 @@ func validateStoreAWS(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *co
 								}),
 								"AWS_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 									"Name":  Equal("AWS_APPLICATION_CREDENTIALS"),
-									"Value": Equal("/root/etcd-backup"),
+									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
 						}),

--- a/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
@@ -175,7 +175,7 @@ func matchJob(task *druidv1alpha1.EtcdCopyBackupsTask, imageVector imagevector.I
 							"Name":            Equal("copy-backups"),
 							"Image":           Equal(fmt.Sprintf("%s:%s", backupRestoreImage.Repository, *backupRestoreImage.Tag)),
 							"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
-							"Command":         MatchAllElements(testutils.CmdIterator, getCmdElements(task, sourceProvider, targetProvider)),
+							"Args":            MatchAllElements(testutils.CmdIterator, getArgElements(task, sourceProvider, targetProvider)),
 							"Env":             MatchElements(testutils.EnvIterator, IgnoreExtras, getEnvElements(task)),
 						}),
 					}),
@@ -187,10 +187,9 @@ func matchJob(task *druidv1alpha1.EtcdCopyBackupsTask, imageVector imagevector.I
 	return And(matcher, matchJobWithProviders(task, sourceProvider, targetProvider))
 }
 
-func getCmdElements(task *druidv1alpha1.EtcdCopyBackupsTask, sourceProvider, targetProvider string) Elements {
+func getArgElements(task *druidv1alpha1.EtcdCopyBackupsTask, sourceProvider, targetProvider string) Elements {
 	elements := Elements{
-		"etcdbrctl": Equal("etcdbrctl"),
-		"copy":      Equal("copy"),
+		"copy": Equal("copy"),
 		"--snapstore-temp-directory=/var/etcd/data/tmp": Equal("--snapstore-temp-directory=/var/etcd/data/tmp"),
 	}
 	if targetProvider != "" {

--- a/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
@@ -292,42 +292,42 @@ func getProviderEnvElements(storeProvider, prefix, volumePrefix string) Elements
 		return Elements{
 			prefix + "AWS_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "AWS_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "ABS":
 		return Elements{
 			prefix + "AZURE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "AZURE_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "GCS":
 		return Elements{
 			prefix + "GOOGLE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "GOOGLE_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/.%sgcp/serviceaccount.json", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/.%sgcp/serviceaccount.json", volumePrefix)),
 			}),
 		}
 	case "Swift":
 		return Elements{
 			prefix + "OPENSTACK_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "OPENSTACK_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "OSS":
 		return Elements{
 			prefix + "ALICLOUD_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "ALICLOUD_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "OCS":
 		return Elements{
 			prefix + "OPENSHIFT_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
 				"Name":  Equal(prefix + "OPENSHIFT_APPLICATION_CREDENTIALS"),
-				"Value": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	default:
@@ -341,14 +341,14 @@ func getVolumeMountsElements(storeProvider, volumePrefix string) Elements {
 		return Elements{
 			volumePrefix + "etcd-backup": MatchFields(IgnoreExtras, Fields{
 				"Name":      Equal(volumePrefix + "etcd-backup"),
-				"MountPath": Equal(fmt.Sprintf("/root/.%sgcp/", volumePrefix)),
+				"MountPath": Equal(fmt.Sprintf("/var/.%sgcp/", volumePrefix)),
 			}),
 		}
 	default:
 		return Elements{
 			volumePrefix + "etcd-backup": MatchFields(IgnoreExtras, Fields{
 				"Name":      Equal(volumePrefix + "etcd-backup"),
-				"MountPath": Equal(fmt.Sprintf("/root/%setcd-backup", volumePrefix)),
+				"MountPath": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	}

--- a/test/utils/etcdcopybackupstask.go
+++ b/test/utils/etcdcopybackupstask.go
@@ -104,7 +104,7 @@ func CreateEtcdCopyBackupsJob(taskName, namespace string) *batchv1.Job {
 							Name:            "copy-backups",
 							Image:           "eu.gcr.io/gardener-project/gardener/etcdbrctl",
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Command:         []string{"etcdbrctl", "copy"}, // since this is only used for testing the command here is not complete.
+							Args:            []string{"copy"}, // since this is only used for testing the command here is not complete.
 						},
 					},
 					RestartPolicy: "OnFailure",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance security
/kind epic

**What this PR does / why we need it**:
This PR enables druid to be able to deploy etcd statefulsets using the new distroless `etcd-wrapper` image for the `etcd` container and a distroless `etcd-backup-restore` image for the `backup-restore` container.
Along with this, file paths for secrets are also changes from `/root/` to `/var/`

The statefulset now also contains an init container to change file permissions of the etcd files keeping in mind that the distroless images will now run as non root user.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Etcd-druid will now deploy distroless `etcd-wrapper` and `etcd-backup-restore` images. Please refer to [etcd-wrapper](https://github.com/gardener/etcd-wrapper) for more information.
```
```breaking operator
File ownership for `var/etcd/data` will be changed to non-root user (65532).
```
```breaking operator
Etcd-related secrets will now be mounted onto the `/var/` directory instead of `/root/`.
```
