### PR TITLE
Bumped up the custom image version to v3.4.13-bootstrap-11 in Druid.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,12 +151,13 @@ add-license-headers: $(GO_ADD_LICENSE)
 	@./hack/addlicenseheaders.sh ${YEAR}
 	
 .PHONY: kind-up
-kind-up:
-	kind create cluster --name etcd-druid-e2e --config hack/e2e-test/infrastructure/kind/cluster.yaml 
+kind-up: $(KIND)
+	@printf "\n\033[0;33m📌 NOTE: To target the newly created KinD cluster, please run the following command:\n\n    export KUBECONFIG=$(KUBECONFIG_PATH)\n\033[0m\n"
+	./hack/kind-up.sh
 
 .PHONY: kind-down
-kind-down:
-	kind delete cluster --name etcd-druid-e2e
+kind-down: $(KIND)
+	$(KIND) delete cluster --name etcd-druid-e2e
 
 .PHONY: deploy-localstack
 deploy-localstack: $(KUBECTL)

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -8,4 +8,4 @@ images:
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd
-  tag: "v3.4.13-bootstrap-10"
+  tag: "v3.4.13-bootstrap-11"

--- a/hack/e2e-test/infrastructure/kind/cluster.yaml
+++ b/hack/e2e-test/infrastructure/kind/cluster.yaml
@@ -2,6 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: kindest/node:v1.27.1
   # port forward 80 on the host to 80 on this node
   extraPortMappings:
   - containerPort: 4566

--- a/hack/e2e-test/run-e2e-test.sh
+++ b/hack/e2e-test/run-e2e-test.sh
@@ -116,7 +116,7 @@ function test_e2e {
       echo "-------------------"
 
       SOURCE_PATH=$PWD \
-      go test -timeout=0 -mod=vendor ./test/e2e --v -args -ginkgo.v -ginkgo.progress
+      go test -timeout=0 -mod=vendor ./test/e2e --v -args -ginkgo.v -ginkgo.show-node-events
     fi
 }
 

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname "${0}")/../vendor/github.com/gardener/gardener/hack/ci-common.sh
+
+clamp_mss_to_pmtu
+
+kind create cluster --name etcd-druid-e2e --config hack/e2e-test/infrastructure/kind/cluster.yaml

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -48,7 +48,7 @@ fi
 export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=2m
 export GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=5s
 export GOMEGA_DEFAULT_EVENTUALLY_POLLING_INTERVAL=200ms
-GINKGO_COMMON_FLAGS="-r -timeout=1h0m0s --randomize-all --randomize-suites --fail-on-pending --progress"
+GINKGO_COMMON_FLAGS="-r -timeout=1h0m0s --randomize-all --randomize-suites --fail-on-pending --show-node-events"
 
 if ${TEST_COV:-false}; then
   output_dir=test/output


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Bumped up the custom image version to v3.4.13-bootstrap-11
```
