### PR TITLE
Use structured log messages

### DIFF
--- a/controllers/custodian/reconciler.go
+++ b/controllers/custodian/reconciler.go
@@ -75,7 +75,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	logger := r.logger.WithValues("etcd", kutil.Key(etcd.Namespace, etcd.Name).String())
 
 	if etcd.Status.LastError != nil && *etcd.Status.LastError != "" {
-		logger.Info("Requeue item because of last error", "lastError", *etcd.Status.LastError)
+		logger.Info("Requeue item because of last error", "namespace", etcd.Namespace, "name", etcd.Name, "lastError", *etcd.Status.LastError)
 		return ctrl.Result{
 			RequeueAfter: 30 * time.Second,
 		}, nil
@@ -110,7 +110,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 func (r *Reconciler) updateEtcdStatus(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) error {
-	logger.Info("Updating etcd status with statefulset information")
+	logger.Info("Updating etcd status with statefulset information", "namespace", etcd.Namespace, "name", etcd.Name)
 
 	// Bootstrap is a special case which is handled by the etcd controller.
 	if !inBootstrap(etcd) && len(etcd.Status.Members) != 0 {
@@ -131,10 +131,8 @@ func (r *Reconciler) updateEtcdStatus(ctx context.Context, logger logr.Logger, e
 		etcd.Status.ReadyReplicas = sts.Status.ReadyReplicas
 		etcd.Status.UpdatedReplicas = sts.Status.UpdatedReplicas
 		etcd.Status.Ready = &ready
-		logger.Info("ETCD status updated for statefulset",
-			"currentReplicas", sts.Status.CurrentReplicas,
-			"readyReplicas", sts.Status.ReadyReplicas,
-			"updatedReplicas", sts.Status.UpdatedReplicas)
+		logger.Info("ETCD status updated for statefulset", "namespace", etcd.Namespace, "name", etcd.Name,
+			"currentReplicas", sts.Status.CurrentReplicas, "readyReplicas", sts.Status.ReadyReplicas, "updatedReplicas", sts.Status.UpdatedReplicas)
 	} else {
 		etcd.Status.CurrentReplicas = 0
 		etcd.Status.ReadyReplicas = 0

--- a/controllers/custodian/reconciler.go
+++ b/controllers/custodian/reconciler.go
@@ -16,7 +16,6 @@ package custodian
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
@@ -76,7 +75,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	logger := r.logger.WithValues("etcd", kutil.Key(etcd.Namespace, etcd.Name).String())
 
 	if etcd.Status.LastError != nil && *etcd.Status.LastError != "" {
-		logger.Info(fmt.Sprintf("Requeue item because of last error: %v", *etcd.Status.LastError))
+		logger.Info("Requeue item because of last error", "lastError", *etcd.Status.LastError)
 		return ctrl.Result{
 			RequeueAfter: 30 * time.Second,
 		}, nil
@@ -132,7 +131,10 @@ func (r *Reconciler) updateEtcdStatus(ctx context.Context, logger logr.Logger, e
 		etcd.Status.ReadyReplicas = sts.Status.ReadyReplicas
 		etcd.Status.UpdatedReplicas = sts.Status.UpdatedReplicas
 		etcd.Status.Ready = &ready
-		logger.Info(fmt.Sprintf("ETCD status updated for statefulset current replicas: %v, ready replicas: %v, updated replicas: %v", sts.Status.CurrentReplicas, sts.Status.ReadyReplicas, sts.Status.UpdatedReplicas))
+		logger.Info("ETCD status updated for statefulset",
+			"currentReplicas", sts.Status.CurrentReplicas,
+			"readyReplicas", sts.Status.ReadyReplicas,
+			"updatedReplicas", sts.Status.UpdatedReplicas)
 	} else {
 		etcd.Status.CurrentReplicas = 0
 		etcd.Status.ReadyReplicas = 0

--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -164,7 +164,7 @@ func (r *Reconciler) reconcile(ctx context.Context, etcd *druidv1alpha1.Etcd) (c
 
 	// Add Finalizers to Etcd
 	if finalizers := sets.NewString(etcd.Finalizers...); !finalizers.Has(common.FinalizerName) {
-		logger.Info("Adding finalizer", "finalizerName", common.FinalizerName)
+		logger.Info("Adding finalizer", "namespace", etcd.Namespace, "name", etcd.Name, "finalizerName", common.FinalizerName)
 		if err := controllerutils.AddFinalizers(ctx, r.Client, etcd, common.FinalizerName); err != nil {
 			if err := r.updateEtcdErrorStatus(ctx, etcd, reconcileResult{err: err}); err != nil {
 				return ctrl.Result{
@@ -221,7 +221,7 @@ func (r *Reconciler) reconcile(ctx context.Context, etcd *druidv1alpha1.Etcd) (c
 
 func (r *Reconciler) delete(ctx context.Context, etcd *druidv1alpha1.Etcd) (ctrl.Result, error) {
 	logger := r.logger.WithValues("etcd", kutil.Key(etcd.Namespace, etcd.Name).String(), "operation", "delete")
-	logger.Info("Starting operation")
+	logger.Info("Starting deletion operation", "namespace", etcd.Namespace, "name", etcd.Name)
 
 	stsDeployer := gardenercomponent.OpDestroyAndWait(componentsts.New(r.Client, logger, componentsts.Values{Name: etcd.Name, Namespace: etcd.Namespace}))
 	if err := stsDeployer.Destroy(ctx); err != nil {
@@ -288,14 +288,14 @@ func (r *Reconciler) delete(ctx context.Context, etcd *druidv1alpha1.Etcd) (ctrl
 	}
 
 	if sets.NewString(etcd.Finalizers...).Has(common.FinalizerName) {
-		logger.Info("Removing finalizer", "finalizerName", common.FinalizerName)
+		logger.Info("Removing finalizer", "namespace", etcd.Namespace, "name", etcd.Name, "finalizerName", common.FinalizerName)
 		if err := controllerutils.RemoveFinalizers(ctx, r.Client, etcd, common.FinalizerName); client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{
 				Requeue: true,
 			}, err
 		}
 	}
-	logger.Info("Deleted etcd successfully.")
+	logger.Info("Deleted etcd successfully", "namespace", etcd.Namespace, "name", etcd.Name)
 	return ctrl.Result{}, nil
 }
 
@@ -444,7 +444,7 @@ func (r *Reconciler) updateEtcdStatus(ctx context.Context, etcd *druidv1alpha1.E
 
 func (r *Reconciler) removeOperationAnnotation(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd) error {
 	if _, ok := etcd.Annotations[v1beta1constants.GardenerOperation]; ok {
-		logger.Info("Removing operation annotation", "annotation", v1beta1constants.GardenerOperation)
+		logger.Info("Removing operation annotation", "namespace", etcd.Namespace, "name", etcd.Name, "annotation", v1beta1constants.GardenerOperation)
 		withOpAnnotation := etcd.DeepCopy()
 		delete(etcd.Annotations, v1beta1constants.GardenerOperation)
 		return r.Patch(ctx, etcd, client.MergeFrom(withOpAnnotation))

--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -164,7 +164,7 @@ func (r *Reconciler) reconcile(ctx context.Context, etcd *druidv1alpha1.Etcd) (c
 
 	// Add Finalizers to Etcd
 	if finalizers := sets.NewString(etcd.Finalizers...); !finalizers.Has(common.FinalizerName) {
-		logger.Info("Adding finalizer")
+		logger.Info("Adding finalizer", "finalizerName", common.FinalizerName)
 		if err := controllerutils.AddFinalizers(ctx, r.Client, etcd, common.FinalizerName); err != nil {
 			if err := r.updateEtcdErrorStatus(ctx, etcd, reconcileResult{err: err}); err != nil {
 				return ctrl.Result{
@@ -288,7 +288,7 @@ func (r *Reconciler) delete(ctx context.Context, etcd *druidv1alpha1.Etcd) (ctrl
 	}
 
 	if sets.NewString(etcd.Finalizers...).Has(common.FinalizerName) {
-		logger.Info("Removing finalizer")
+		logger.Info("Removing finalizer", "finalizerName", common.FinalizerName)
 		if err := controllerutils.RemoveFinalizers(ctx, r.Client, etcd, common.FinalizerName); client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{
 				Requeue: true,
@@ -409,7 +409,7 @@ func clusterInBootstrap(etcd *druidv1alpha1.Etcd) bool {
 }
 
 func (r *Reconciler) updateEtcdErrorStatus(ctx context.Context, etcd *druidv1alpha1.Etcd, result reconcileResult) error {
-	lastErrStr := fmt.Sprintf("%v", result.err)
+	lastErrStr := result.err.Error()
 	etcd.Status.LastError = &lastErrStr
 	etcd.Status.ObservedGeneration = &etcd.Generation
 	if result.sts != nil {
@@ -444,7 +444,7 @@ func (r *Reconciler) updateEtcdStatus(ctx context.Context, etcd *druidv1alpha1.E
 
 func (r *Reconciler) removeOperationAnnotation(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd) error {
 	if _, ok := etcd.Annotations[v1beta1constants.GardenerOperation]; ok {
-		logger.Info("Removing operation annotation")
+		logger.Info("Removing operation annotation", "annotation", v1beta1constants.GardenerOperation)
 		withOpAnnotation := etcd.DeepCopy()
 		delete(etcd.Annotations, v1beta1constants.GardenerOperation)
 		return r.Patch(ctx, etcd, client.MergeFrom(withOpAnnotation))

--- a/controllers/etcdcopybackupstask/reconciler.go
+++ b/controllers/etcdcopybackupstask/reconciler.go
@@ -99,7 +99,7 @@ func (r *Reconciler) reconcile(ctx context.Context, task *druidv1alpha1.EtcdCopy
 
 	// Ensure finalizer
 	if !controllerutil.ContainsFinalizer(task, common.FinalizerName) {
-		logger.V(1).Info("Adding finalizer")
+		logger.V(1).Info("Adding finalizer", "finalizerName", common.FinalizerName)
 		if err := controllerutils.AddFinalizers(ctx, r.Client, task, common.FinalizerName); err != nil {
 			return ctrl.Result{}, fmt.Errorf("could not add finalizer: %w", err)
 		}
@@ -160,7 +160,7 @@ func (r *Reconciler) delete(ctx context.Context, task *druidv1alpha1.EtcdCopyBac
 
 	// Check finalizer
 	if !controllerutil.ContainsFinalizer(task, common.FinalizerName) {
-		logger.V(1).Info("Skipping as it does not have a finalizer")
+		logger.V(1).Info("Skipping since finalizer not present", "finalizerName", common.FinalizerName)
 		return ctrl.Result{}, nil
 	}
 
@@ -185,7 +185,7 @@ func (r *Reconciler) delete(ctx context.Context, task *druidv1alpha1.EtcdCopyBac
 
 	// Remove finalizer if requested
 	if removeFinalizer {
-		logger.V(1).Info("Removing finalizer")
+		logger.V(1).Info("Removing finalizer", "finalizerName", common.FinalizerName)
 		if err := controllerutils.RemoveFinalizers(ctx, r.Client, task, common.FinalizerName); err != nil {
 			return ctrl.Result{}, fmt.Errorf("could not remove finalizer: %w", err)
 		}

--- a/controllers/etcdcopybackupstask/reconciler.go
+++ b/controllers/etcdcopybackupstask/reconciler.go
@@ -147,7 +147,7 @@ func (r *Reconciler) doReconcile(ctx context.Context, task *druidv1alpha1.EtcdCo
 	}
 
 	// Create job
-	logger.Info("Creating job", "job", kutil.ObjectName(job))
+	logger.Info("Creating job", "namespace", job.Namespace, "name", job.Name)
 	if err := r.Create(ctx, job); err != nil {
 		return status, fmt.Errorf("could not create job %s: %w", kutil.ObjectName(job), err)
 	}
@@ -213,7 +213,7 @@ func (r *Reconciler) doDelete(ctx context.Context, task *druidv1alpha1.EtcdCopyB
 
 	// Delete job if needed
 	if job.DeletionTimestamp == nil {
-		logger.Info("Deleting job", "job", kutil.ObjectName(job))
+		logger.Info("Deleting job", "namespace", job.Namespace, "name", job.Name)
 		if err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationForeground)); client.IgnoreNotFound(err) != nil {
 			return status, false, fmt.Errorf("could not delete job %s: %w", kutil.ObjectName(job), err)
 		}

--- a/controllers/secret/reconciler.go
+++ b/controllers/secret/reconciler.go
@@ -101,7 +101,7 @@ func addFinalizer(ctx context.Context, logger logr.Logger, k8sClient client.Clie
 	if finalizers := sets.NewString(secret.Finalizers...); finalizers.Has(common.FinalizerName) {
 		return nil
 	}
-	logger.Info("Adding finalizer")
+	logger.Info("Adding finalizer", "finalizerName", common.FinalizerName)
 	return client.IgnoreNotFound(controllerutils.AddFinalizers(ctx, k8sClient, secret, common.FinalizerName))
 }
 
@@ -109,6 +109,6 @@ func removeFinalizer(ctx context.Context, logger logr.Logger, k8sClient client.C
 	if finalizers := sets.NewString(secret.Finalizers...); !finalizers.Has(common.FinalizerName) {
 		return nil
 	}
-	logger.Info("Removing finalizer")
+	logger.Info("Removing finalizer", "finalizerName", common.FinalizerName)
 	return client.IgnoreNotFound(controllerutils.RemoveFinalizers(ctx, k8sClient, secret, common.FinalizerName))
 }

--- a/controllers/secret/reconciler_test.go
+++ b/controllers/secret/reconciler_test.go
@@ -61,7 +61,8 @@ var _ = Describe("SecretController", func() {
 		})
 
 		It("should return false if secret is not referred to by any Etcd object", func() {
-			Expect(isFinalizerNeeded(testSecretName, &etcdList)).To(BeFalse())
+			isFinalizerNeeded, _ := isFinalizerNeeded(testSecretName, &etcdList)
+			Expect(isFinalizerNeeded).To(BeFalse())
 		})
 
 		It("should return true if secret is referred to in an Etcd object's Spec.Etcd.ClientUrlTLS section", func() {
@@ -71,7 +72,8 @@ var _ = Describe("SecretController", func() {
 					Namespace: testNamespace,
 				},
 			}
-			Expect(isFinalizerNeeded(testSecretName, &etcdList)).To(BeTrue())
+			isFinalizerNeeded, _ := isFinalizerNeeded(testSecretName, &etcdList)
+			Expect(isFinalizerNeeded).To(BeTrue())
 		})
 
 		It("should return true if secret is referred to in an Etcd object's Spec.Etcd.PeerUrlTLS section", func() {
@@ -81,7 +83,8 @@ var _ = Describe("SecretController", func() {
 					Namespace: testNamespace,
 				},
 			}
-			Expect(isFinalizerNeeded(testSecretName, &etcdList)).To(BeTrue())
+			isFinalizerNeeded, _ := isFinalizerNeeded(testSecretName, &etcdList)
+			Expect(isFinalizerNeeded).To(BeTrue())
 		})
 
 		It("should return true if secret is referred to in an Etcd object's Spec.Backup.Store section", func() {
@@ -91,7 +94,8 @@ var _ = Describe("SecretController", func() {
 					Namespace: testNamespace,
 				},
 			}
-			Expect(isFinalizerNeeded(testSecretName, &etcdList)).To(BeTrue())
+			isFinalizerNeeded, _ := isFinalizerNeeded(testSecretName, &etcdList)
+			Expect(isFinalizerNeeded).To(BeTrue())
 		})
 	})
 

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
 	"go.uber.org/zap/zapcore"
@@ -64,12 +63,12 @@ func main() {
 }
 
 func printFlags(logger logr.Logger) {
-	var flagsToPrint string
+	var flagKVs []interface{}
 	flag.VisitAll(func(f *flag.Flag) {
-		flagsToPrint += fmt.Sprintf("%s: %s, ", f.Name, f.Value)
+		flagKVs = append(flagKVs, f.Name, f.Value.String())
 	})
 
-	logger.Info(fmt.Sprintf("Running with flags: %s", flagsToPrint[:len(flagsToPrint)-2]))
+	logger.Info("Running with flags", flagKVs...)
 }
 
 func buildDefaultLoggerOpts() []zap.Opts {

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -146,14 +146,14 @@ func (c *component) waitUtilPodsReady(ctx context.Context, originalSts *appsv1.S
 			return gardenerretry.SevereError(err)
 		}
 		if sts.Status.ReadyReplicas < *sts.Spec.Replicas {
-			return gardenerretry.MinorError(fmt.Errorf(fmt.Sprintf("Only %d out of %d replicas are ready", sts.Status.ReadyReplicas, sts.Spec.Replicas)))
+			return gardenerretry.MinorError(fmt.Errorf("only %d out of %d replicas are ready", sts.Status.ReadyReplicas, sts.Spec.Replicas))
 		}
 		recentPodCreationTime, err := c.getLatestPodCreationTime(ctx, &sts)
 		if err != nil {
 			return gardenerretry.MinorError(fmt.Errorf("failed to get most recent pod creation timestamp: %w", err))
 		}
 		if recentPodCreationTime.Before(podDeletionTime) {
-			return gardenerretry.MinorError(fmt.Errorf(fmt.Sprintf("Most recent pod creation time %v is still before the %v time when the pods were deleted.", recentPodCreationTime, podDeletionTime)))
+			return gardenerretry.MinorError(fmt.Errorf("most recent pod creation time %v is still before the %v time when the pods were deleted", recentPodCreationTime, podDeletionTime))
 		}
 		return gardenerretry.Ok()
 	})
@@ -169,7 +169,7 @@ func (c *component) waitDeploy(ctx context.Context, originalSts *appsv1.Stateful
 			return gardenerretry.SevereError(err)
 		}
 		if updatedSts.Generation < originalSts.Generation {
-			return gardenerretry.MinorError(fmt.Errorf("StatulfulSet generation has not yet been updated in the cache"))
+			return gardenerretry.MinorError(fmt.Errorf("statefulset generation has not yet been updated in the cache"))
 		}
 		if ready, reason := utils.IsStatefulSetReady(replicas, &updatedSts); !ready {
 			return gardenerretry.MinorError(fmt.Errorf(reason))
@@ -300,7 +300,7 @@ func (c *component) addCreateOrPatchTask(g *flow.Graph, originalSts *appsv1.Stat
 	taskID := g.Add(flow.Task{
 		Name: "sync StatefulSet task",
 		Fn: func(ctx context.Context) error {
-			c.logger.Info("createOrPatch sts", "replicas", c.values.Replicas)
+			c.logger.Info("createOrPatch sts", "namespace", c.values.Namespace, "name", c.values.Name, "replicas", c.values.Replicas)
 			var (
 				sts = originalSts
 				err error
@@ -501,7 +501,7 @@ func (c *component) createOrPatch(ctx context.Context, sts *appsv1.StatefulSet, 
 	if err != nil {
 		return err
 	}
-	c.logger.Info("createOrPatch is completed", "Namespace", sts.Namespace, "Name", sts.Name, "operation-result", operationResult)
+	c.logger.Info("createOrPatch is completed", "namespace", sts.Namespace, "name", sts.Name, "operation-result", operationResult)
 	return nil
 }
 

--- a/pkg/utils/store.go
+++ b/pkg/utils/store.go
@@ -64,7 +64,7 @@ const (
 // GetHostMountPathFromSecretRef returns the hostPath configured for the given store.
 func GetHostMountPathFromSecretRef(ctx context.Context, client client.Client, logger logr.Logger, store *druidv1alpha1.StoreSpec, namespace string) (string, error) {
 	if store.SecretRef == nil {
-		logger.Info("secretRef is not defined for store, using default hostPath")
+		logger.Info("secretRef is not defined for store, using default hostPath", "namespace", namespace)
 		return LocalProviderDefaultMountPath, nil
 	}
 

--- a/test/e2e/etcd_backup_test.go
+++ b/test/e2e/etcd_backup_test.go
@@ -97,7 +97,10 @@ var _ = Describe("Etcd Backup", func() {
 					Expect(latestSnapshotBeforePopulate).To(Not(BeNil()))
 
 					By("Put keys into etcd")
-					logger.Info(fmt.Sprintf("populating etcd with %s-1 to %s-10", etcdKeyPrefix, etcdKeyPrefix))
+					logger.Info("populating etcd with sequential key-value pairs",
+						"fromKey", fmt.Sprintf("%s-1", etcdKeyPrefix), "fromValue", fmt.Sprintf("%s-1", etcdValuePrefix),
+						"toKey", fmt.Sprintf("%s-10", etcdKeyPrefix), "toValue", fmt.Sprintf("%s-10", etcdValuePrefix))
+
 					// populate 10 keys in etcd, finishing in 10 seconds
 					err = populateEtcdWithCount(logger, kubeconfigPath, namespace, etcdName, podName, "etcd", etcdKeyPrefix, etcdValuePrefix, 1, 10, time.Second*1)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -123,7 +126,9 @@ var _ = Describe("Etcd Backup", func() {
 					Expect(fullSnapshot.LastRevision).To(Equal(10 + latestSnapshotBeforePopulate.LastRevision))
 
 					By("Put additional data into etcd")
-					logger.Info(fmt.Sprintf("populating etcd with %s-11 to %s-15", etcdKeyPrefix, etcdKeyPrefix))
+					logger.Info("populating etcd with sequential key-value pairs",
+						"fromKey", fmt.Sprintf("%s-11", etcdKeyPrefix), "fromValue", fmt.Sprintf("%s-11", etcdValuePrefix),
+						"toKey", fmt.Sprintf("%s-15", etcdKeyPrefix), "toValue", fmt.Sprintf("%s-15", etcdValuePrefix))
 					// populate 5 keys in etcd, finishing in 5 seconds
 					err = populateEtcdWithCount(logger, kubeconfigPath, namespace, etcdName, podName, "etcd", etcdKeyPrefix, etcdValuePrefix, 11, 15, time.Second*1)
 					Expect(err).ShouldNot(HaveOccurred())

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -434,18 +434,18 @@ func checkJobReady(ctx context.Context, cl client.Client, jobName string) {
 }
 
 // etcdZeroDownTimeValidatorJob returns k8s job which ensures
-// Etcd cluster zero down time by continuously checking etcd cluster health.
+// Etcd cluster zero downtime by continuously checking etcd cluster health.
 // This job fails once health check fails and associated pod results in error status.
 func startEtcdZeroDownTimeValidatorJob(ctx context.Context, cl client.Client,
 	etcd *v1alpha1.Etcd, testName string) *batchv1.Job {
 	job := etcdZeroDownTimeValidatorJob(etcd.Name+"-client", testName, etcd.Spec.Etcd.ClientUrlTLS)
 
-	logger.Info(fmt.Sprintf("Creating job %s to ensure etcd zero downtime", job.Name))
+	logger.Info("Creating job to ensure etcd zero downtime", "job", job.Name)
 	ExpectWithOffset(1, cl.Create(ctx, job)).ShouldNot(HaveOccurred())
 
 	// Wait until zeroDownTimeValidator job is up and running.
 	checkJobReady(ctx, cl, job.Name)
-	logger.Info(fmt.Sprintf("Job %s is ready", job.Name))
+	logger.Info("Job is ready", "job", job.Name)
 	return job
 }
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -117,7 +117,7 @@ var _ = AfterSuite(func() {
 
 	namespaceLogger := logger.WithValues("namespace", etcdNamespace)
 
-	namespaceLogger.Info("deleting namespace")
+	namespaceLogger.Info("deleting namespace", "namespace", etcdNamespace)
 	err = cl.Delete(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: etcdNamespace,

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -645,7 +645,7 @@ func populateEtcdWithCount(logger logr.Logger, kubeconfigPath, namespace, etcdNa
 			}
 			continue
 		}
-		logger.Info(fmt.Sprintf("put (%s-%d, %s-%d) successful", keyPrefix, i, valuePrefix, i))
+		logger.Info("put key-value successful", "key", fmt.Sprintf("%s-%d", keyPrefix, i), "value", fmt.Sprintf("%s-%d", valuePrefix, i))
 		retries = 0
 		i++
 	}
@@ -685,7 +685,7 @@ func getEtcdKeys(logger logr.Logger, kubeconfigPath, namespace, etcdName, podNam
 	for i := start; i <= end; {
 		key, val, err = getEtcdKey(kubeconfigPath, namespace, etcdName, podName, containerName, keyPrefix, i)
 		if err != nil {
-			logger.Info(fmt.Sprintf("failed to get key %s-%d. Retrying", keyPrefix, i))
+			logger.Info("failed to get key. Retrying...", "key", fmt.Sprintf("%s-%d", keyPrefix, i))
 			retries++
 			if retries >= etcdCommandMaxRetries {
 				return nil, fmt.Errorf("failed to get key %s-%d", keyPrefix, i)
@@ -693,7 +693,7 @@ func getEtcdKeys(logger logr.Logger, kubeconfigPath, namespace, etcdName, podNam
 			continue
 		}
 		retries = 0
-		logger.Info(fmt.Sprintf("fetched (%s, %s) from etcd", key, val))
+		logger.Info("fetched key-value pair from etcd", "key", key, "value", val)
 		keyValueMap[key] = val
 		i++
 	}
@@ -751,15 +751,6 @@ func deleteDir(kubeconfigPath, namespace, podName, containerName string, dirPath
 	stdout, stderr, err := executeRemoteCommand(kubeconfigPath, namespace, podName, containerName, cmd)
 	if err != nil || stdout != "" {
 		return fmt.Errorf("failed to delete directory %s for %s: stdout: %s; stderr: %s; err: %v", dirPath, podName, stdout, stderr, err)
-	}
-	return nil
-}
-
-func corruptDBFile(kubeconfigPath, namespace, podName, containerName string, dirPath string) error {
-	cmd := fmt.Sprintf("echo destrory > %s", dirPath)
-	stdout, stderr, err := executeRemoteCommand(kubeconfigPath, namespace, podName, containerName, cmd)
-	if err != nil || stdout != "" {
-		return fmt.Errorf("failed to corrupt db %s for %s: stdout: %s; stderr: %s; err: %v", dirPath, podName, stdout, stderr, err)
 	}
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind cleanup

**What this PR does / why we need it**:
Uses structured logging for all log messages. Also removes unused `corruptDBFile` function in e2e tests.

**Which issue(s) this PR fixes**:
Fixes #524 

**Special notes for your reviewer**:
/cc @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
