### PR TITLE
Print build version and go runtime info

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -37,8 +37,12 @@ source "${SOURCE_PATH}/.ci/common.sh"
 
 ###############################################################################
 
+VERSION="$("${SOURCE_PATH}"/hack/get-version.sh)"
+GIT_SHA="${GIT_SHA:-$(git rev-parse --short HEAD || echo "GitNotFound")}"
+
 CGO_ENABLED=0 GO111MODULE=on go build \
   -mod vendor \
   -v \
   -o "${BINARY_PATH}"/etcd-druid \
+  -ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION} -X ${REPOSITORY}/pkg/version.GitSHA=${GIT_SHA}" \
   main.go

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,4 @@
 !LICENSE.md
 !Makefile
 !VERSION
+!hack/get-version.sh

--- a/main.go
+++ b/main.go
@@ -17,12 +17,14 @@ package main
 import (
 	"flag"
 	"os"
+	"runtime"
 
+	"github.com/go-logr/logr"
 	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/etcd-druid/controllers"
-	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"github.com/gardener/etcd-druid/pkg/version"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,6 +37,8 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	ctrl.SetLogger(zap.New(buildDefaultLoggerOpts()...))
+
+	printVersionInfo()
 
 	mgrConfig := controllers.ManagerConfig{}
 	controllers.InitFromFlags(flag.CommandLine, &mgrConfig)
@@ -60,6 +64,11 @@ func main() {
 		logger.Error(err, "Error running manager")
 		os.Exit(1)
 	}
+}
+
+func printVersionInfo() {
+	logger.Info("Etcd-druid build information", "Etcd-druid Version", version.Version, "Git SHA", version.GitSHA)
+	logger.Info("Golang runtime information", "Version", runtime.Version(), "OS", runtime.GOOS, "Arch", runtime.GOARCH)
 }
 
 func printFlags(logger logr.Logger) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+var (
+	// These variables are typically populated using -ldflags settings when building the binary
+
+	// Version stores the etcd-druid binary version.
+	Version string
+	// GitSHA stores the etcd-druid binary code commit SHA on git.
+	GitSHA string
+)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Print build version and go runtime info when running a built version of etcd-druid.

**Which issue(s) this PR fixes**:
Fixes #628 

**Special notes for your reviewer**:
/invite @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Print build version and go runtime info.
```
