### PR TITLE
Replaces the use of `etcd-custom-image` with `etcd-wrapper` in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ spec:
     garbageCollectionPeriod: 43200s
     garbageCollectionPolicy: Exponential
     imageRepository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-    imageVersion: v0.12.0
+    imageVersion: v0.25.0
     port: 8080
     resources:
       limits:
@@ -67,8 +67,8 @@ spec:
     clientPort: 2379
     defragmentationSchedule: 0 */24 * * *
     enableTLS: false
-    imageRepository: eu.gcr.io/gardener-project/gardener/etcd
-    imageVersion: v3.4.13-bootstrap
+    imageRepository: eu.gcr.io/gardener-project/gardener/etcd-wrapper
+    imageVersion: v0.1.0
     initialClusterState: new
     initialClusterToken: new
     metrics: basic

--- a/api/v1alpha1/types_etcd_test.go
+++ b/api/v1alpha1/types_etcd_test.go
@@ -168,8 +168,8 @@ func getEtcd(name, namespace string) *Etcd {
 	deltaSnapshotPeriod := metav1.Duration{
 		Duration: 300 * time.Second,
 	}
-	imageEtcd := "eu.gcr.io/gardener-project/gardener/etcd:v3.4.13-bootstrap-10"
-	imageBR := "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.20.2"
+	imageEtcd := "eu.gcr.io/gardener-project/gardener/etcd-wrapper:v0.1.0"
+	imageBR := "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.25.0"
 	snapshotSchedule := "0 */24 * * *"
 	defragSchedule := "0 */24 * * *"
 	container := "my-object-storage-container-name"

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -62,8 +62,8 @@ var (
 	backupPort              int32 = 8080
 	wrapperPort             int32 = 9095
 	uid                           = "a9b8c7d6e5f4"
-	imageEtcd                     = "eu.gcr.io/gardener-project/gardener/etcd:v3.4.13-bootstrap"
-	imageBR                       = "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.12.0"
+	imageEtcd                     = "eu.gcr.io/gardener-project/gardener/etcd-wrapper:v0.1.0"
+	imageBR                       = "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.25.0"
 	snapshotSchedule              = "0 */24 * * *"
 	defragSchedule                = "0 */24 * * *"
 	container                     = "default.bkp"

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -40,8 +40,8 @@ var (
 	clientPort              int32 = 2379
 	serverPort              int32 = 2380
 	backupPort              int32 = 8080
-	imageEtcd                     = "eu.gcr.io/gardener-project/gardener/etcd:v3.4.13-bootstrap-10"
-	imageBR                       = "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.21.0"
+	imageEtcd                     = "eu.gcr.io/gardener-project/gardener/etcd-wrapper:v0.1.0"
+	imageBR                       = "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.25.0"
 	snapshotSchedule              = "0 */24 * * *"
 	defragSchedule                = "0 */24 * * *"
 	container                     = "default.bkp"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing 
/kind technical-debt

**What this PR does / why we need it**:
This PR updates a few test files that still refer and use `etcd-custom-image` to their tests. These files now use `etcd-wrapper` to run their tests

**Which issue(s) this PR fixes**:
Fixes #609 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
