### PR TITLE
[ci:component:github.com/gardener/etcd-backup-restore:v0.24.1->v0.24.2]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -4,7 +4,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.24.1"
+  tag: "v0.24.2"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd


### PR DESCRIPTION
**Release Notes**:
```other operator github.com/gardener/etcd-backup-restore #638 @shreyas-s-rao
Bump alpine base version for Docker build to `3.18.2`. 
```
```other developer github.com/gardener/etcd-backup-restore #644 @shreyas-s-rao
Add CVE categorization for etcd-backup-restore.
```
