### PR TITLE
Improved scale-up detection.

### DIFF
--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -391,7 +391,8 @@ func immutableFieldUpdate(sts *appsv1.StatefulSet, val Values) bool {
 func clusterScaledUpToMultiNode(val *Values, sts *appsv1.StatefulSet) bool {
 	if sts != nil && sts.Spec.Replicas != nil {
 		return (val.Replicas > 1 && *sts.Spec.Replicas == 1 && sts.Status.AvailableReplicas == 1) ||
-			(metav1.HasAnnotation(sts.ObjectMeta, scaleToMultiNodeAnnotationKey) && sts.Status.UpdatedReplicas < *sts.Spec.Replicas)
+			(metav1.HasAnnotation(sts.ObjectMeta, scaleToMultiNodeAnnotationKey) &&
+				(sts.Status.UpdatedReplicas < *sts.Spec.Replicas || sts.Status.AvailableReplicas < sts.Status.UpdatedReplicas))
 	}
 	return val.Replicas > 1 && val.StatusReplicas == 1
 }


### PR DESCRIPTION
/area high-availability
/kind technical-debt

**What this PR does / why we need it**:
While testing this PR: https://github.com/gardener/etcd-backup-restore/pull/649 I found out that when third member of etcd cluster won't come up but pod spec has been updated, so etcd statefulset's status `.status.updatedReplicas` becomes `3`:
```
status:
  availableReplicas: 2
  collisionCount: 0
  currentReplicas: 1
  currentRevision: etcd-main-79f88bd678
  observedGeneration: 2
  readyReplicas: 2
  replicas: 3
  updateRevision: etcd-main-86b48fdf9c
  updatedReplicas: 3
```
druid remove the scale-up annotation: `gardener.cloud/scaled-to-multi-node` from etcd statefulset as 
[func clusterScaledUpToMultiNode(){...}](https://github.com/ishan16696/etcd-druid/blob/b4d722f84abb6d9fa83e7c0a8675bcd49e6e514e/pkg/component/etcd/statefulset/statefulset.go#L391) has returned false which is not correct.
more info please refer to this: https://github.com/gardener/etcd-druid/pull/587#discussion_r1183231059, now it won't be an issue as backup-restore will skip checking scale-up conditions for first member

**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/etcd-druid/pull/587#discussion_r1182771744

**Special notes for your reviewer**:

**Release note**:
```other operator
None
```
