### PR TITLE
Extend `Etcd` CRD and `etcd-druid` to Support Configurable Delta Snapshot Retention

### DIFF
--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -179,9 +179,9 @@ type BackupSpec struct {
 	// +optional
 	DeltaSnapshotMemoryLimit *resource.Quantity `json:"deltaSnapshotMemoryLimit,omitempty"`
 	// DeltaSnapshotRetentionPeriod defines the duration for which delta snapshots will be retained, excluding the latest snapshot set.
-	// The value should be a string formatted as a duration (e.g., '1s', '2m', '3h', '4d') with a minimum value of 1 second.
+	// The value should be a string formatted as a duration (e.g., '1s', '2m', '3h', '4d')
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern="^([1-9][0-9]*([.][0-9]+)?(s|m|h|d))+$"
+	// +kubebuilder:validation:Pattern="^([0-9][0-9]*([.][0-9]+)?(s|m|h|d))+$"
 	// +optional
 	DeltaSnapshotRetentionPeriod *metav1.Duration `json:"deltaSnapshotRetentionPeriod,omitempty"`
 

--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -178,9 +178,10 @@ type BackupSpec struct {
 	// DeltaSnapshotMemoryLimit defines the memory limit after which delta snapshots will be taken
 	// +optional
 	DeltaSnapshotMemoryLimit *resource.Quantity `json:"deltaSnapshotMemoryLimit,omitempty"`
-	// DeltaSnapshotRetentionPeriod defines the duration to retain old delta snapshots. Delta snapshots within this
-	// duration will not be deleted. This provides more flexibility for backup retention by allowing older delta snapshots
-	// to be preserved.
+	// DeltaSnapshotRetentionPeriod defines the duration for which delta snapshots will be retained, excluding the latest snapshot set.
+	// The value should be a string formatted as a duration (e.g., '1s', '2m', '3h', '4d') with a minimum value of 1 second.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([1-9][0-9]*([.][0-9]+)?(s|m|h|d))+$"
 	// +optional
 	DeltaSnapshotRetentionPeriod *metav1.Duration `json:"deltaSnapshotRetentionPeriod,omitempty"`
 

--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -178,6 +178,12 @@ type BackupSpec struct {
 	// DeltaSnapshotMemoryLimit defines the memory limit after which delta snapshots will be taken
 	// +optional
 	DeltaSnapshotMemoryLimit *resource.Quantity `json:"deltaSnapshotMemoryLimit,omitempty"`
+	// DeltaSnapshotRetentionPeriod defines the duration to retain old delta snapshots. Delta snapshots within this
+	// duration will not be deleted. This provides more flexibility for backup retention by allowing older delta snapshots
+	// to be preserved.
+	// +optional
+	DeltaSnapshotRetentionPeriod *metav1.Duration `json:"deltaSnapshotRetentionPeriod,omitempty"`
+
 	// SnapshotCompression defines the specification for compression of Snapshots.
 	// +optional
 	SnapshotCompression *CompressionSpec `json:"compression,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -83,6 +83,11 @@ func (in *BackupSpec) DeepCopyInto(out *BackupSpec) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.DeltaSnapshotRetentionPeriod != nil {
+		in, out := &in.DeltaSnapshotRetentionPeriod, &out.DeltaSnapshotRetentionPeriod
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.SnapshotCompression != nil {
 		in, out := &in.SnapshotCompression, &out.SnapshotCompression
 		*out = new(CompressionSpec)

--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -146,6 +146,10 @@ spec:
                     description: DeltaSnapshotPeriod defines the period after which
                       delta snapshots will be taken
                     type: string
+                  deltaSnapshotRetentionPeriod:
+                    description: "The retention period for delta snapshots, excluding the latest snapshot set. The value should be a string formatted as a duration (e.g., '1s', '2m', '3h', '4d'). The minimum value is 1 second."
+                    type: string
+                    pattern: ^([1-9][0-9]*([.][0-9]+)?(s|m|h|d))+$
                   enableProfiling:
                     description: EnableProfiling defines if profiling should be enabled
                       for the etcd-backup-restore-sidecar

--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -150,8 +150,8 @@ spec:
                     description: DeltaSnapshotRetentionPeriod defines the duration
                       for which delta snapshots will be retained, excluding the latest
                       snapshot set. The value should be a string formatted as a duration
-                      (e.g., '1s', '2m', '3h', '4d') with a minimum value of 1 second.
-                    pattern: ^([1-9][0-9]*([.][0-9]+)?(s|m|h|d))+$
+                      (e.g., '1s', '2m', '3h', '4d')
+                    pattern: ^([0-9][0-9]*([.][0-9]+)?(s|m|h|d))+$
                     type: string
                   enableProfiling:
                     description: EnableProfiling defines if profiling should be enabled

--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -147,9 +147,12 @@ spec:
                       delta snapshots will be taken
                     type: string
                   deltaSnapshotRetentionPeriod:
-                    description: "The retention period for delta snapshots, excluding the latest snapshot set. The value should be a string formatted as a duration (e.g., '1s', '2m', '3h', '4d'). The minimum value is 1 second."
-                    type: string
+                    description: DeltaSnapshotRetentionPeriod defines the duration
+                      for which delta snapshots will be retained, excluding the latest
+                      snapshot set. The value should be a string formatted as a duration
+                      (e.g., '1s', '2m', '3h', '4d') with a minimum value of 1 second.
                     pattern: ^([1-9][0-9]*([.][0-9]+)?(s|m|h|d))+$
+                    type: string
                   enableProfiling:
                     description: EnableProfiling defines if profiling should be enabled
                       for the etcd-backup-restore-sidecar

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -146,6 +146,10 @@ spec:
                     description: DeltaSnapshotPeriod defines the period after which
                       delta snapshots will be taken
                     type: string
+                  deltaSnapshotRetentionPeriod:
+                    description: "The retention period for delta snapshots, excluding the latest snapshot set. The value should be a string formatted as a duration (e.g., '1s', '2m', '3h', '4d'). The minimum value is 1 second."
+                    type: string
+                    pattern: ^([1-9][0-9]*([.][0-9]+)?(s|m|h|d))+$
                   enableProfiling:
                     description: EnableProfiling defines if profiling should be enabled
                       for the etcd-backup-restore-sidecar

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -150,8 +150,8 @@ spec:
                     description: DeltaSnapshotRetentionPeriod defines the duration
                       for which delta snapshots will be retained, excluding the latest
                       snapshot set. The value should be a string formatted as a duration
-                      (e.g., '1s', '2m', '3h', '4d') with a minimum value of 1 second.
-                    pattern: ^([1-9][0-9]*([.][0-9]+)?(s|m|h|d))+$
+                      (e.g., '1s', '2m', '3h', '4d')
+                    pattern: ^([0-9][0-9]*([.][0-9]+)?(s|m|h|d))+$
                     type: string
                   enableProfiling:
                     description: EnableProfiling defines if profiling should be enabled

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -147,9 +147,12 @@ spec:
                       delta snapshots will be taken
                     type: string
                   deltaSnapshotRetentionPeriod:
-                    description: "The retention period for delta snapshots, excluding the latest snapshot set. The value should be a string formatted as a duration (e.g., '1s', '2m', '3h', '4d'). The minimum value is 1 second."
-                    type: string
+                    description: DeltaSnapshotRetentionPeriod defines the duration
+                      for which delta snapshots will be retained, excluding the latest
+                      snapshot set. The value should be a string formatted as a duration
+                      (e.g., '1s', '2m', '3h', '4d') with a minimum value of 1 second.
                     pattern: ^([1-9][0-9]*([.][0-9]+)?(s|m|h|d))+$
+                    type: string
                   enableProfiling:
                     description: EnableProfiling defines if profiling should be enabled
                       for the etcd-backup-restore-sidecar

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -973,7 +973,6 @@ func expectedBackupArgs(values *Values) Elements {
 
 	if values.DeltaSnapshotRetentionPeriod != nil {
 		elements[fmt.Sprintf("--delta-snapshot-retention-period=%s", values.DeltaSnapshotRetentionPeriod.Duration.String())] = Equal(fmt.Sprintf("--delta-snapshot-retention-period=%s", values.DeltaSnapshotRetentionPeriod.Duration.String()))
-		println("Adding the check.....")
 	}
 	return elements
 }

--- a/pkg/component/etcd/statefulset/values.go
+++ b/pkg/component/etcd/statefulset/values.go
@@ -89,7 +89,8 @@ type Values struct {
 
 	EnableProfiling *bool
 
-	DeltaSnapshotPeriod *metav1.Duration
+	DeltaSnapshotPeriod          *metav1.Duration
+	DeltaSnapshotRetentionPeriod *metav1.Duration
 
 	SnapshotCompression *druidv1alpha1.CompressionSpec
 	HeartbeatDuration   *metav1.Duration

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -91,8 +91,9 @@ func GenerateValues(
 		BackupStore:     etcd.Spec.Backup.Store,
 		EnableProfiling: etcd.Spec.Backup.EnableProfiling,
 
-		DeltaSnapshotPeriod:      etcd.Spec.Backup.DeltaSnapshotPeriod,
-		DeltaSnapshotMemoryLimit: etcd.Spec.Backup.DeltaSnapshotMemoryLimit,
+		DeltaSnapshotPeriod:          etcd.Spec.Backup.DeltaSnapshotPeriod,
+		DeltaSnapshotRetentionPeriod: etcd.Spec.Backup.DeltaSnapshotRetentionPeriod,
+		DeltaSnapshotMemoryLimit:     etcd.Spec.Backup.DeltaSnapshotMemoryLimit,
 
 		DefragmentationSchedule: etcd.Spec.Etcd.DefragmentationSchedule,
 		FullSnapshotSchedule:    etcd.Spec.Backup.FullSnapshotSchedule,
@@ -275,6 +276,10 @@ func getBackupRestoreCommand(val Values) []string {
 
 	if val.DeltaSnapshotPeriod != nil {
 		command = append(command, "--delta-snapshot-period="+val.DeltaSnapshotPeriod.Duration.String())
+	}
+
+	if val.DeltaSnapshotRetentionPeriod != nil {
+		command = append(command, "--delta-snapshot-retention-period="+val.DeltaSnapshotRetentionPeriod.Duration.String())
 	}
 
 	var deltaSnapshotMemoryLimit = defaultSnapshotMemoryLimit


### PR DESCRIPTION
**How to categorize this PR?**
/area backup
/kind api-change

**What this PR does / why we need it:**
This PR extends the Etcd CRD to include a `DeltaSnapshotRetentionPeriod` field. This new field allows users to define the duration for retaining old delta snapshots, providing more flexibility in managing backup retention. Additionally, this PR modifies etcd-druid to propagate the --delta-snapshot-retention-period flag from the Etcd CRD to the etcd-backup-restore component.

This change allows the etcd-backup-restore to have access to the `DeltaSnapshotRetentionPeriod` configuration which was not previously propagated. As such, it provides greater flexibility in the configuration of backup parameters.

**Which issue(s) this PR fixes:**
Fixes https://github.com/gardener/etcd-druid/issues/649

**Special notes for your reviewer:**

**Release note:**
```feature operator
Introduce `Spec.Backup.DeltaSnapshotRetentionPeriod` in the `Etcd` resource to allow configuring retention period for delta snapshots.
```