### PR TITLE
Fix issue with local provider for etcd-backup-restore distroless image

### DIFF
--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -224,7 +224,7 @@ func (r *Reconciler) delete(ctx context.Context, etcd *druidv1alpha1.Etcd) (ctrl
 	logger := r.logger.WithValues("etcd", kutil.Key(etcd.Namespace, etcd.Name).String(), "operation", "delete")
 	logger.Info("Starting deletion operation", "namespace", etcd.Namespace, "name", etcd.Name)
 
-	stsDeployer := gardenercomponent.OpDestroyAndWait(componentsts.New(r.Client, logger, componentsts.Values{Name: etcd.Name, Namespace: etcd.Namespace}))
+	stsDeployer := gardenercomponent.OpDestroyAndWait(componentsts.New(r.Client, logger, componentsts.Values{Name: etcd.Name, Namespace: etcd.Namespace}, r.config.FeatureGates))
 	if err := stsDeployer.Destroy(ctx); err != nil {
 		if err = r.updateEtcdErrorStatus(ctx, etcd, reconcileResult{err: err}); err != nil {
 			return ctrl.Result{
@@ -383,7 +383,7 @@ func (r *Reconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, etcd
 
 	// Create an OpWaiter because after the deployment we want to wait until the StatefulSet is ready.
 	var (
-		stsDeployer  = componentsts.New(r.Client, logger, statefulSetValues)
+		stsDeployer  = componentsts.New(r.Client, logger, statefulSetValues, r.config.FeatureGates)
 		deployWaiter = gardenercomponent.OpWait(stsDeployer)
 	)
 

--- a/controllers/etcdcopybackupstask/reconciler.go
+++ b/controllers/etcdcopybackupstask/reconciler.go
@@ -309,7 +309,7 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 	env := append(createEnvVarsFromStore(&sourceStore, sourceProvider, "SOURCE_", sourcePrefix), createEnvVarsFromStore(&targetStore, targetProvider, "", "")...)
 
 	// Formulate the job's volume mounts.
-	volumeMounts := append(createVolumeMountsFromStore(&sourceStore, sourceProvider, sourcePrefix), createVolumeMountsFromStore(&targetStore, targetProvider, targetPrefix)...)
+	volumeMounts := append(createVolumeMountsFromStore(&sourceStore, sourceProvider, sourcePrefix, r.Config.FeatureGates[string(features.UseEtcdWrapper)]), createVolumeMountsFromStore(&targetStore, targetProvider, targetPrefix, r.Config.FeatureGates[string(features.UseEtcdWrapper)])...)
 
 	// Formulate the job's volumes from the source store.
 	sourceVolumes, err := r.createVolumesFromStore(ctx, &sourceStore, task.Namespace, sourceProvider, sourcePrefix)
@@ -355,10 +355,37 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 							VolumeMounts:    volumeMounts,
 						},
 					},
-					Volumes: volumes,
+					ShareProcessNamespace: pointer.Bool(true),
+					Volumes:               volumes,
 				},
 			},
 		},
+	}
+
+	if r.Config.FeatureGates[string(features.UseEtcdWrapper)] {
+		if targetProvider == druidutils.Local {
+			// init container to change file permissions of the folders used as store to 65532 (nonroot)
+			// used only with local provider
+			job.Spec.Template.Spec.InitContainers = []corev1.Container{
+				{
+					Name:         "change-backup-bucket-permissions",
+					Image:        "alpine:3.18.2",
+					Command:      []string{"sh", "-c", "--"},
+					Args:         []string{fmt.Sprintf("%s%s%s%s", "chown -R 65532:65532 /home/nonroot/", *targetStore.Container, " /home/nonroot/", *sourceStore.Container)},
+					VolumeMounts: volumeMounts,
+					SecurityContext: &corev1.SecurityContext{
+						RunAsGroup:   pointer.Int64(0),
+						RunAsNonRoot: pointer.Bool(false),
+						RunAsUser:    pointer.Int64(0),
+					},
+				},
+			}
+		}
+		job.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsGroup:   pointer.Int64(65532),
+			RunAsNonRoot: pointer.Bool(true),
+			RunAsUser:    pointer.Int64(65532),
+		}
 	}
 
 	if err := controllerutil.SetControllerReference(task, job, r.Scheme()); err != nil {
@@ -371,7 +398,7 @@ func createJobArgs(task *druidv1alpha1.EtcdCopyBackupsTask, sourceObjStoreProvid
 	// Create the initial arguments for the copy-backups job.
 	args := []string{
 		"copy",
-		"--snapstore-temp-directory=/var/etcd/data/tmp",
+		"--snapstore-temp-directory=/home/nonroot/data/tmp",
 	}
 
 	// Formulate the job's arguments.
@@ -444,13 +471,20 @@ func (r *Reconciler) createVolumesFromStore(ctx context.Context, store *druidv1a
 // createVolumesFromStore generates a slice of volumes for an EtcdCopyBackups job based on the given StoreSpec, namespace,
 // provider, and prefix. The prefix is used to differentiate between source and target volumes.
 // This function creates the necessary Volume configurations for various storage providers and returns any errors encountered.
-func createVolumeMountsFromStore(store *druidv1alpha1.StoreSpec, provider, volumeMountPrefix string) (volumeMounts []corev1.VolumeMount) {
+func createVolumeMountsFromStore(store *druidv1alpha1.StoreSpec, provider, volumeMountPrefix string, useEtcdWrapper bool) (volumeMounts []corev1.VolumeMount) {
 	switch provider {
 	case druidutils.Local:
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      volumeMountPrefix + "host-storage",
-			MountPath: *store.Container,
-		})
+		if useEtcdWrapper {
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      volumeMountPrefix + "host-storage",
+				MountPath: "/home/nonroot/" + *store.Container,
+			})
+		} else {
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      volumeMountPrefix + "host-storage",
+				MountPath: *store.Container,
+			})
+		}
 	case druidutils.GCS:
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      getVolumeNamePrefix(volumeMountPrefix) + "etcd-backup",

--- a/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/controllers/etcdcopybackupstask/reconciler_test.go
@@ -158,6 +158,9 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 					Repository: "test-repo",
 					Tag:        pointer.String("etcd-test-tag"),
 				}},
+				Config: &Config{
+					FeatureGates: make(map[string]bool),
+				},
 			}
 		})
 
@@ -301,7 +304,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 			task          *druidv1alpha1.EtcdCopyBackupsTask
 			expected      = []string{
 				"copy",
-				"--snapstore-temp-directory=/var/etcd/data/tmp",
+				"--snapstore-temp-directory=/home/nonroot/data/tmp",
 				"--storage-provider=S3",
 				"--store-prefix=/target",
 				"--store-container=target-container",
@@ -442,7 +445,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 				})
 
 				It("should create the correct volume mounts", func() {
-					volumeMounts := createVolumeMountsFromStore(storeSpec, provider, volumeMountPrefix)
+					volumeMounts := createVolumeMountsFromStore(storeSpec, provider, volumeMountPrefix, false)
 					Expect(volumeMounts).To(HaveLen(1))
 
 					expectedMountPath := ""
@@ -758,7 +761,7 @@ func matchJob(task *druidv1alpha1.EtcdCopyBackupsTask, imageVector imagevector.I
 func getArgElements(task *druidv1alpha1.EtcdCopyBackupsTask, sourceProvider, targetProvider string) Elements {
 	elements := Elements{
 		"copy": Equal("copy"),
-		"--snapstore-temp-directory=/var/etcd/data/tmp": Equal("--snapstore-temp-directory=/var/etcd/data/tmp"),
+		"--snapstore-temp-directory=/home/nonroot/data/tmp": Equal("--snapstore-temp-directory=/home/nonroot/data/tmp"),
 	}
 	if targetProvider != "" {
 		addEqual(elements, fmt.Sprintf("%s=%s", "--storage-provider", targetProvider))

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -143,7 +143,10 @@ var _ = Describe("Statefulset", func() {
 			false,
 			true,
 		)
-		stsDeployer = New(cl, logr.Discard(), values)
+		fg := map[string]bool{
+			"UseEtcdWrapper": true,
+		}
+		stsDeployer = New(cl, logr.Discard(), values, fg)
 
 		sts = &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -924,6 +927,6 @@ func checkLocalProviderVaues(etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet, 
 	// check volume mount
 	ExpectWithOffset(1, backupRestoreContainer.VolumeMounts).To(ContainElement(corev1.VolumeMount{
 		Name:      "host-storage",
-		MountPath: container,
+		MountPath: "/home/nonroot/" + container,
 	}))
 }

--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -1145,7 +1145,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								}),
 								"host-storage": MatchFields(IgnoreExtras, Fields{
 									"Name":      Equal("host-storage"),
-									"MountPath": Equal(*instance.Spec.Backup.Store.Container),
+									"MountPath": Equal("/home/nonroot/" + *instance.Spec.Backup.Store.Container),
 								}),
 							}),
 							"Env": MatchElements(testutils.EnvIterator, IgnoreExtras, Elements{

--- a/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
@@ -190,7 +190,7 @@ func matchJob(task *druidv1alpha1.EtcdCopyBackupsTask, imageVector imagevector.I
 func getArgElements(task *druidv1alpha1.EtcdCopyBackupsTask, sourceProvider, targetProvider string) Elements {
 	elements := Elements{
 		"copy": Equal("copy"),
-		"--snapstore-temp-directory=/var/etcd/data/tmp": Equal("--snapstore-temp-directory=/var/etcd/data/tmp"),
+		"--snapstore-temp-directory=/home/nonroot/data/tmp": Equal("--snapstore-temp-directory=/home/nonroot/data/tmp"),
 	}
 	if targetProvider != "" {
 		addEqual(elements, fmt.Sprintf("%s=%s", "--storage-provider", targetProvider))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
1. We found an issue with the etcd pod deploys with the distroless image setup and using the `Local` provider where the snapshots were saved in a different directory than what was expected.
2. The `etcdcopybackupstask` job was not correctly adapted for the `Local` provider when distroless `etcd-backup-restore` image was integrated. It also used incorrect `snapstore-temp-directory` for distroless etcd-backup-restore container.

This PR fixed both these issues

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing incorrect volume mount path for `Etcd`s and `EtcdCopyBackupsTask`s using `Local` snapshot storage provider while using distroless etcd-backup-restore image `v0.25.x` has been resolved.
```
```bugfix operator
A bug causing `EtcdCopyBackupsTask` jobs to fail to create temp snapshot directory while using distroless etcd-backup-restore image `v0.25.x` has been resolved.
```
