### PR TITLE
Fix unit tests in pkg/component/etcd/statefulset.

### DIFF
--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -212,7 +212,10 @@ var _ = Describe("Statefulset", func() {
 						imageEtcd,
 						imageBR,
 						checkSumAnnotations, false, true)
-					stsDeployer = New(cl, logr.Discard(), values)
+					fg := map[string]bool{
+						"UseEtcdWrapper": true,
+					}
+					stsDeployer = New(cl, logr.Discard(), values, fg)
 					Expect(stsDeployer.Deploy(ctx)).To(Succeed())
 
 					sts := &appsv1.StatefulSet{}
@@ -284,7 +287,10 @@ var _ = Describe("Statefulset", func() {
 						imageEtcd,
 						imageBR,
 						checkSumAnnotations, false, true)
-					stsDeployer = New(cl, logr.Discard(), values)
+					fg := map[string]bool{
+						"UseEtcdWrapper": true,
+					}
+					stsDeployer = New(cl, logr.Discard(), values, fg)
 					Expect(stsDeployer.Deploy(ctx)).To(Succeed())
 
 					sts := &appsv1.StatefulSet{}


### PR DESCRIPTION
**What this PR does / why we need it**:
I run the unit tests locally for package `/component/etcd/statefulset` and they failed
```bash
~/go/src/etcd-druid master *1 > ginkgo pkg/component/etcd/statefulset   
Failed to compile statefulset:

# github.com/gardener/etcd-druid/pkg/component/etcd/statefulset_test [github.com/gardener/etcd-druid/pkg/component/etcd/statefulset.test]
./statefulset_test.go:215:44: not enough arguments in call to New
	have (client.Client, logr.Logger, statefulset.Values)
	want (client.Client, logr.Logger, statefulset.Values, map[string]bool)
./statefulset_test.go:287:44: not enough arguments in call to New
	have (client.Client, logr.Logger, statefulset.Values)
	want (client.Client, logr.Logger, statefulset.Values, map[string]bool)


Ginkgo ran 1 suite in 743.781334ms

Test Suite Failed
```

I guess this PR: https://github.com/gardener/etcd-druid/pull/651 was not rebased on master after merging of this PR: https://github.com/gardener/etcd-druid/pull/662

This PR fixes the unit tests in `pkg/component/etcd/statefulset`
```bash
~/go/src/etcd-druid fix/unit-tests > ginkgo pkg/component/etcd/statefulset 
Running Suite: Statefulset Component Suite - ~/go/src/etcd-druid/pkg/component/etcd/statefulset
=========================================================================================================================
Random Seed: 1691599633

Will run 17 of 17 specs
•••••••••••••••••

Ran 17 of 17 Specs in 0.011 seconds
SUCCESS! -- 17 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 6.570192084s
Test Suite Passed

```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
None
```
