### PR TITLE
Optimize Registration Logic for Snapshot Compaction controller

### DIFF
--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -176,17 +176,15 @@ func (r *Reconciler) reconcileJob(ctx context.Context, logger logr.Logger, etcd 
 			}, fmt.Errorf("error while fetching compaction job: %v", err)
 		}
 
-		if r.config.EnableBackupCompaction {
-			// Required job doesn't exist. Create new
-			logger.Info("Creating etcd compaction job", "namespace", etcd.Namespace, "name", etcd.GetCompactionJobName())
-			job, err = r.createCompactionJob(ctx, logger, etcd)
-			if err != nil {
-				return ctrl.Result{
-					RequeueAfter: 10 * time.Second,
-				}, fmt.Errorf("error during compaction job creation: %v", err)
-			}
-			metricJobsCurrent.With(prometheus.Labels{druidmetrics.EtcdNamespace: etcd.Namespace}).Set(1)
+		// Required job doesn't exist. Create new
+		logger.Info("Creating etcd compaction job", "namespace", etcd.Namespace, "name", etcd.GetCompactionJobName())
+		job, err = r.createCompactionJob(ctx, logger, etcd)
+		if err != nil {
+			return ctrl.Result{
+				RequeueAfter: 10 * time.Second,
+			}, fmt.Errorf("error during compaction job creation: %v", err)
 		}
+		metricJobsCurrent.With(prometheus.Labels{druidmetrics.EtcdNamespace: etcd.Namespace}).Set(1)
 	}
 
 	if !job.DeletionTimestamp.IsZero() {

--- a/controllers/manager.go
+++ b/controllers/manager.go
@@ -103,13 +103,15 @@ func registerControllersWithManager(mgr ctrl.Manager, config *ManagerConfig) err
 		return err
 	}
 
-	// Add compaction reconciler to the manager
-	compactionReconciler, err := compaction.NewReconciler(mgr, config.CompactionControllerConfig)
-	if err != nil {
-		return err
-	}
-	if err = compactionReconciler.RegisterWithManager(mgr); err != nil {
-		return err
+	// Add compaction reconciler to the manager if the CLI flag enable-backup-compaction is true.
+	if config.CompactionControllerConfig.EnableBackupCompaction {
+		compactionReconciler, err := compaction.NewReconciler(mgr, config.CompactionControllerConfig)
+		if err != nil {
+			return err
+		}
+		if err = compactionReconciler.RegisterWithManager(mgr); err != nil {
+			return err
+		}
 	}
 
 	// Add etcd-copy-backups-task reconciler to the manager


### PR DESCRIPTION
**How to categorize this PR?**
/area storage
/kind enhancement

**What this PR does / why we need it**:
This PR optimizes the logic behind registering snapshot compaction-controller. Instead of always running the compaction-controller and checking the CLI flag `--enable-backup-compaction` just before deploying the compaction job, the new approach registers the compaction-controller based on the presence of the CLI flag `--enable-backup-compaction`. 


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-druid/issues/655#issuecomment-1696786117

**Special notes for your reviewer**:

**Release note**:
```other operator
None
```