### PR TITLE
Use better naming for compaction jobs

### DIFF
--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -444,7 +444,7 @@ func (e *Etcd) GetConfigmapName() string {
 
 // GetCompactionJobName returns the compaction job name for the Etcd.
 func (e *Etcd) GetCompactionJobName() string {
-	return fmt.Sprintf("%s-compact-job", string(e.UID[:6]))
+	return fmt.Sprintf("compact-job-%s", string(e.UID[:6]))
 }
 
 // GetOrdinalPodName returns the Etcd pod name based on the ordinal.

--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -444,7 +444,7 @@ func (e *Etcd) GetConfigmapName() string {
 
 // GetCompactionJobName returns the compaction job name for the Etcd.
 func (e *Etcd) GetCompactionJobName() string {
-	return fmt.Sprintf("compact-job-%s", string(e.UID[:6]))
+	return fmt.Sprintf("%s-compactor", e.Name)
 }
 
 // GetOrdinalPodName returns the Etcd pod name based on the ordinal.

--- a/api/v1alpha1/types_etcd_test.go
+++ b/api/v1alpha1/types_etcd_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Etcd", func() {
 
 	Context("GetCompactionJobName", func() {
 		It("should return the correct compaction job name", func() {
-			Expect(created.GetCompactionJobName()).To(Equal("123456-compact-job"))
+			Expect(created.GetCompactionJobName()).To(Equal("compact-job-123456"))
 		})
 	})
 

--- a/api/v1alpha1/types_etcd_test.go
+++ b/api/v1alpha1/types_etcd_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Etcd", func() {
 
 	Context("GetCompactionJobName", func() {
 		It("should return the correct compaction job name", func() {
-			Expect(created.GetCompactionJobName()).To(Equal("compact-job-123456"))
+			Expect(created.GetCompactionJobName()).To(Equal("foo-compactor"))
 		})
 	})
 

--- a/controllers/compaction/metrics.go
+++ b/controllers/compaction/metrics.go
@@ -56,6 +56,8 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: namespaceEtcdDruid,
 			Subsystem: subsystemCompaction,
+			Name:      "job_duration_seconds",
+			Help:      "Total time taken in seconds to finish a running compaction job.",
 			Buckets: []float64{baseDuration.Seconds(),
 				5 * baseDuration.Seconds(),
 				10 * baseDuration.Seconds(),
@@ -63,8 +65,6 @@ var (
 				20 * baseDuration.Seconds(),
 				30 * baseDuration.Seconds(),
 			},
-			Name: "job_duration_seconds",
-			Help: "Total time taken in seconds to finish a running compaction job.",
 		},
 		[]string{druidmetrics.LabelSucceeded, druidmetrics.EtcdNamespace},
 	)

--- a/controllers/compaction/metrics.go
+++ b/controllers/compaction/metrics.go
@@ -15,6 +15,8 @@
 package compaction
 
 import (
+	"time"
+
 	druidmetrics "github.com/gardener/etcd-druid/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -26,6 +28,7 @@ const (
 )
 
 var (
+	baseDuration = 60 * time.Second
 	// metricJobsTotal is the metric used to count the total number of compaction jobs initiated by compaction controller.
 	metricJobsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -53,8 +56,15 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: namespaceEtcdDruid,
 			Subsystem: subsystemCompaction,
-			Name:      "job_duration_seconds",
-			Help:      "Total time taken in seconds to finish a running compaction job.",
+			Buckets: []float64{baseDuration.Seconds(),
+				5 * baseDuration.Seconds(),
+				10 * baseDuration.Seconds(),
+				15 * baseDuration.Seconds(),
+				20 * baseDuration.Seconds(),
+				30 * baseDuration.Seconds(),
+			},
+			Name: "job_duration_seconds",
+			Help: "Total time taken in seconds to finish a running compaction job.",
 		},
 		[]string{druidmetrics.LabelSucceeded, druidmetrics.EtcdNamespace},
 	)

--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -154,6 +154,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	diff := delta - full
 	metricNumDeltaEvents.With(prometheus.Labels{druidmetrics.EtcdNamespace: etcd.Namespace}).Set(float64(diff))
 
+	// Update metrics for currently running compaction job, if any
+	job := &batchv1.Job{}
+	err = r.Get(ctx, types.NamespacedName{Name: etcd.GetCompactionJobName(), Namespace: etcd.Namespace}, job)
+	if err != nil {
+		logger.Info("Could not fetch any running compaction job")
+	}
+
+	if job != nil && job.Name != "" {
+		metricJobsCurrent.With(prometheus.Labels{druidmetrics.EtcdNamespace: etcd.Namespace}).Set(1)
+	} else {
+		metricJobsCurrent.With(prometheus.Labels{druidmetrics.EtcdNamespace: etcd.Namespace}).Set(0)
+	}
+
 	// Reconcile job only when number of accumulated revisions over the last full snapshot is more than the configured threshold value via 'events-threshold' flag
 	if diff >= r.config.EventsThreshold {
 		return r.reconcileJob(ctx, logger, etcd)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Adds some improvements for betterment of compaction dashboard.

**Which issue(s) this PR fixes**:
Fixes #
#648

**Special notes for your reviewer**:
We need to address the issue https://github.com/gardener/gardener/issues/8576 after this PR is merged

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Etcd snapshot compaction jobs will now be named `<etcd-name>-compactor` for better readability for human operators.
```
