### PR TITLE
Add local provider support for compaction

### DIFF
--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -180,6 +180,7 @@ func (r *Reconciler) reconcileJob(ctx context.Context, logger logr.Logger, etcd 
 		logger.Info("Creating etcd compaction job", "namespace", etcd.Namespace, "name", etcd.GetCompactionJobName())
 		job, err = r.createCompactionJob(ctx, logger, etcd)
 		if err != nil {
+			metricJobsTotal.With(prometheus.Labels{druidmetrics.LabelSucceeded: druidmetrics.ValueSucceededFalse, druidmetrics.EtcdNamespace: etcd.Namespace}).Inc()
 			return ctrl.Result{
 				RequeueAfter: 10 * time.Second,
 			}, fmt.Errorf("error during compaction job creation: %v", err)
@@ -298,13 +299,37 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 						Image:           *etcdBackupImage,
 						ImagePullPolicy: v1.PullIfNotPresent,
 						Args:            getCompactionJobArgs(etcd, r.config.MetricsScrapeWaitDuration.String()),
-						VolumeMounts:    getCompactionJobVolumeMounts(etcd, logger),
-						Env:             getCompactionJobEnvVar(etcd, logger),
 					}},
-					Volumes: getCompactionJobVolumes(ctx, r.Client, logger, etcd),
 				},
 			},
 		},
+	}
+
+	if vms, err := getCompactionJobVolumeMounts(etcd); err != nil {
+		return nil, fmt.Errorf("error while creating compaction job in %v for %v : %v",
+			etcd.Namespace,
+			etcd.Name,
+			err)
+	} else {
+		job.Spec.Template.Spec.Containers[0].VolumeMounts = vms
+	}
+
+	if env, err := getCompactionJobEnvVar(etcd); err != nil {
+		return nil, fmt.Errorf("error while creating compaction job in %v for %v : %v",
+			etcd.Namespace,
+			etcd.Name,
+			err)
+	} else {
+		job.Spec.Template.Spec.Containers[0].Env = env
+	}
+
+	if vm, err := getCompactionJobVolumes(ctx, r.Client, r.logger, etcd); err != nil {
+		return nil, fmt.Errorf("error creating compaction job in %v for %v : %v",
+			etcd.Namespace,
+			etcd.Name,
+			err)
+	} else {
+		job.Spec.Template.Spec.Volumes = vm
 	}
 
 	if etcd.Spec.Backup.CompactionResources != nil {
@@ -331,7 +356,7 @@ func getLabels(etcd *druidv1alpha1.Etcd) map[string]string {
 		"networking.gardener.cloud/to-public-networks":  "allowed",
 	}
 }
-func getCompactionJobVolumeMounts(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.VolumeMount {
+func getCompactionJobVolumeMounts(etcd *druidv1alpha1.Etcd) ([]v1.VolumeMount, error) {
 	vms := []v1.VolumeMount{
 		{
 			Name:      "etcd-workspace-dir",
@@ -339,14 +364,9 @@ func getCompactionJobVolumeMounts(etcd *druidv1alpha1.Etcd, logger logr.Logger) 
 		},
 	}
 
-	if etcd.Spec.Backup.Store == nil {
-		return vms
-	}
-
 	provider, err := utils.StorageProviderFromInfraProvider(etcd.Spec.Backup.Store.Provider)
 	if err != nil {
-		logger.Error(err, "Storage provider is not recognized. Compaction job will not mount any volume with provider specific credentials", "namespace", etcd.Namespace, "name", etcd.Name)
-		return vms
+		return vms, fmt.Errorf("storage provider is not recognized while fetching volume mounts")
 	}
 	switch provider {
 	case utils.Local:
@@ -366,10 +386,10 @@ func getCompactionJobVolumeMounts(etcd *druidv1alpha1.Etcd, logger logr.Logger) 
 		})
 	}
 
-	return vms
+	return vms, nil
 }
 
-func getCompactionJobVolumes(ctx context.Context, cl client.Client, logger logr.Logger, etcd *druidv1alpha1.Etcd) []v1.Volume {
+func getCompactionJobVolumes(ctx context.Context, cl client.Client, logger logr.Logger, etcd *druidv1alpha1.Etcd) ([]v1.Volume, error) {
 	vs := []v1.Volume{
 		{
 			Name: "etcd-workspace-dir",
@@ -379,22 +399,16 @@ func getCompactionJobVolumes(ctx context.Context, cl client.Client, logger logr.
 		},
 	}
 
-	if etcd.Spec.Backup.Store == nil {
-		return vs
-	}
-
 	storeValues := etcd.Spec.Backup.Store
 	provider, err := utils.StorageProviderFromInfraProvider(storeValues.Provider)
 	if err != nil {
-		logger.Error(err, "Storage provider is not recognized. Compaction job will fail as no storage could be configured", "namespace", etcd.Namespace, "name", etcd.Name)
-		return vs
+		return vs, fmt.Errorf("could not recognize storage provider while fetching volumes")
 	}
 	switch provider {
 	case "Local":
 		hostPath, err := utils.GetHostMountPathFromSecretRef(ctx, cl, logger, storeValues, etcd.Namespace)
 		if err != nil {
-			logger.Error(err, "host mount path could not be determined from provided secrets", "namespace", etcd.Namespace, "name", etcd.Name)
-			return vs
+			return vs, fmt.Errorf("could not determine host mount path for local provider")
 		}
 
 		hpt := v1.HostPathDirectory
@@ -409,9 +423,7 @@ func getCompactionJobVolumes(ctx context.Context, cl client.Client, logger logr.
 		})
 	case utils.GCS, utils.S3, utils.OSS, utils.ABS, utils.Swift, utils.OCS:
 		if storeValues.SecretRef == nil {
-			logger.Info("No secretRef is configured for backup store. Compaction job will fail as no storage could be configured.",
-				"namespace", etcd.Namespace, "name", etcd.Name)
-			return vs
+			return vs, fmt.Errorf("could not configure secretRef for backup store %v", provider)
 		}
 
 		vs = append(vs, v1.Volume{
@@ -424,14 +436,11 @@ func getCompactionJobVolumes(ctx context.Context, cl client.Client, logger logr.
 		})
 	}
 
-	return vs
+	return vs, nil
 }
 
-func getCompactionJobEnvVar(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.EnvVar {
+func getCompactionJobEnvVar(etcd *druidv1alpha1.Etcd) ([]v1.EnvVar, error) {
 	var env []v1.EnvVar
-	if etcd.Spec.Backup.Store == nil {
-		return env
-	}
 
 	storeValues := etcd.Spec.Backup.Store
 
@@ -440,8 +449,7 @@ func getCompactionJobEnvVar(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.E
 
 	provider, err := utils.StorageProviderFromInfraProvider(etcd.Spec.Backup.Store.Provider)
 	if err != nil {
-		logger.Error(err, "Storage provider is not recognized. Compaction job will likely fail as there is no provider specific credentials.", "namespace", etcd.Namespace, "name", etcd.Name)
-		return env
+		return env, fmt.Errorf("storage provider is not recognized while fetching secrets from environment variable")
 	}
 
 	switch provider {
@@ -457,9 +465,7 @@ func getCompactionJobEnvVar(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.E
 		env = append(env, getEnvVarFromValues("ALICLOUD_APPLICATION_CREDENTIALS", "/var/etcd-backup"))
 	case utils.ECS:
 		if storeValues.SecretRef == nil {
-			logger.Info("No secretRef is configured for backup store. Compaction job will fail as no storage could be configured.",
-				"namespace", etcd.Namespace, "name", etcd.Name)
-			return env
+			return env, fmt.Errorf("no secretRef could be configured for backup store of ECS")
 		}
 
 		env = append(env, getEnvVarFromSecrets("ECS_ENDPOINT", storeValues.SecretRef.Name, "endpoint"))
@@ -469,7 +475,7 @@ func getCompactionJobEnvVar(etcd *druidv1alpha1.Etcd, logger logr.Logger) []v1.E
 		env = append(env, getEnvVarFromValues("OPENSHIFT_APPLICATION_CREDENTIALS", "/var/etcd-backup"))
 	}
 
-	return env
+	return env, nil
 }
 
 func getEnvVarFromValues(name, value string) v1.EnvVar {

--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -301,7 +301,7 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 						VolumeMounts:    getCompactionJobVolumeMounts(etcd, logger),
 						Env:             getCompactionJobEnvVar(etcd, logger),
 					}},
-					Volumes: getCompactionJobVolumes(ctx, etcd, r.Client, logger),
+					Volumes: getCompactionJobVolumes(ctx, r.Client, logger, etcd),
 				},
 			},
 		},
@@ -369,7 +369,7 @@ func getCompactionJobVolumeMounts(etcd *druidv1alpha1.Etcd, logger logr.Logger) 
 	return vms
 }
 
-func getCompactionJobVolumes(ctx context.Context, etcd *druidv1alpha1.Etcd, cl client.Client, logger logr.Logger) []v1.Volume {
+func getCompactionJobVolumes(ctx context.Context, cl client.Client, logger logr.Logger, etcd *druidv1alpha1.Etcd) []v1.Volume {
 	vs := []v1.Volume{
 		{
 			Name: "etcd-workspace-dir",
@@ -393,7 +393,7 @@ func getCompactionJobVolumes(ctx context.Context, etcd *druidv1alpha1.Etcd, cl c
 	case "Local":
 		hostPath, err := utils.GetHostMountPathFromSecretRef(ctx, cl, logger, storeValues, etcd.Namespace)
 		if err != nil {
-			logger.Error(err, "Host mount path could not be detremined from provided secrets", "namespace", etcd.Namespace, "name", etcd.Name)
+			logger.Error(err, "host mount path could not be determined from provided secrets", "namespace", etcd.Namespace, "name", etcd.Name)
 			return vs
 		}
 

--- a/test/integration/controllers/compaction/reconciler_test.go
+++ b/test/integration/controllers/compaction/reconciler_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Compaction Controller", func() {
 
 			deleteEtcdSnapshotLeasesAndWait(k8sClient, instance)
 		},
-		Entry("if fields are set in etcd.Spec and TLS enabled, the resources should reflect the spec changes", "foo71", druidv1alpha1.StorageProvider("Local"), validateEtcdForCompactionJob),
+		Entry("if fields are set in etcd.Spec and TLS enabled, the resources should reflect the spec changes", "foo71", druidv1alpha1.StorageProvider("local"), validateEtcdForCompactionJob),
 		Entry("if the store is S3, the statefulset and compaction job should reflect the spec changes", "foo72", druidv1alpha1.StorageProvider("aws"), validateStoreAWSForCompactionJob),
 		Entry("if the store is ABS, the statefulset and compaction job should reflect the spec changes", "foo73", druidv1alpha1.StorageProvider("azure"), validateStoreAzureForCompactionJob),
 		Entry("if the store is GCS, the statefulset and compaction job should reflect the spec changes", "foo74", druidv1alpha1.StorageProvider("gcp"), validateStoreGCPForCompactionJob),
@@ -112,7 +112,7 @@ var _ = Describe("Compaction Controller", func() {
 			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 			defer cancel()
 
-			instance = testutils.EtcdBuilderWithDefaults("foo77", namespace).Build()
+			instance = testutils.EtcdBuilderWithDefaults("foo77", namespace).WithProviderLocal().Build()
 			createEtcdAndWait(k8sClient, instance)
 
 			// manually create full and delta snapshot leases since etcd controller is not running
@@ -315,6 +315,14 @@ func validateEtcdForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.Job) 
 								"HostPath": BeNil(),
 								"EmptyDir": PointTo(MatchFields(IgnoreExtras, Fields{
 									"SizeLimit": BeNil(),
+								})),
+							}),
+						}),
+						"host-storage": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal("host-storage"),
+							"VolumeSource": MatchFields(IgnoreExtras, Fields{
+								"HostPath": PointTo(MatchFields(IgnoreExtras, Fields{
+									"Path": Equal("/etc/gardener/local-backupbuckets/default.bkp"),
 								})),
 							}),
 						}),

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -166,6 +166,8 @@ func (eb *EtcdBuilder) WithStorageProvider(provider druidv1alpha1.StorageProvide
 		return eb.WithProviderGCS()
 	case "openstack":
 		return eb.WithProviderSwift()
+	case "local":
+		return eb.WithProviderLocal()
 	default:
 		return eb
 	}
@@ -222,6 +224,16 @@ func (eb *EtcdBuilder) WithProviderOSS() *EtcdBuilder {
 	eb.etcd.Spec.Backup.Store = getBackupStore(
 		eb.etcd.Name,
 		"alicloud",
+	)
+	return eb
+}
+
+func (eb *EtcdBuilder) WithProviderLocal() *EtcdBuilder {
+	if eb == nil || eb.etcd == nil {
+		return nil
+	}
+	eb.etcd.Spec.Backup.Store = getBackupStoreForLocal(
+		eb.etcd.Name,
 	)
 	return eb
 }
@@ -358,6 +370,15 @@ func getBackupStore(name string, provider druidv1alpha1.StorageProvider) *druidv
 		SecretRef: &corev1.SecretReference{
 			Name: "etcd-backup",
 		},
+	}
+}
+
+func getBackupStoreForLocal(name string) *druidv1alpha1.StoreSpec {
+	provider := druidv1alpha1.StorageProvider("local")
+	return &druidv1alpha1.StoreSpec{
+		Container: &container,
+		Prefix:    name,
+		Provider:  &provider,
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes the bug that was not letting the compaction job use local storage. Without this PR, compaction jobs were not running for gardener local setup with local provider.

**Which issue(s) this PR fixes**:
Fixes gardener/etcd-druid#709

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Local storage provider for backups is now supported for snapshot compaction jobs.
```
