### PR TITLE
Fix issue(s) in config/samples/druid_v1alpha_etcd.yaml for kind setup.

### DIFF
--- a/config/samples/druid_v1alpha1_etcd.yaml
+++ b/config/samples/druid_v1alpha1_etcd.yaml
@@ -64,15 +64,15 @@ spec:
     autoCompactionRetention: "30m"
   schedulingConstraints:
     affinity: {}
-    topologySpreadConstraints:
-    - maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: DoNotSchedule
-      labelSelector:
-        matchLabels:
-          app: etcd-statefulset
+    # topologySpreadConstraints:
+    # - maxSkew: 1
+    #   topologyKey: topology.kubernetes.io/zone
+    #   whenUnsatisfiable: DoNotSchedule
+    #   labelSelector:
+    #     matchLabels:
+    #       app: etcd-statefulset
 
-  replicas: 3
+  replicas: 1
   # priorityClassName: priority-class-name
-  storageClass: default
-  storageCapacity: 10Gi
+  # storageClass: default
+  # storageCapacity: 10Gi


### PR DESCRIPTION
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Fixes the issues in config/samples/druid_v1alpha_etcd.yaml file for a local kind setup.
* Default storage class for a kind v0.20.0 cluster is `standard`. `storageClass` specified in druid_v1alpha_etcd.yaml is `default`. Fix: `storageClass` commented out. `storageCapacity` commented out.

* Number of `replicas` changed to 1.

* `topologySpreadConstraints` commented out.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
