### PR TITLE
Add a sleep duration of 60 second through a flag to compaction job.

### DIFF
--- a/controllers/compaction/config.go
+++ b/controllers/compaction/config.go
@@ -30,15 +30,17 @@ var featureList = []featuregate.Feature{
 }
 
 const (
-	enableBackupCompactionFlagName = "enable-backup-compaction"
-	workersFlagName                = "compaction-workers"
-	eventsThresholdFlagName        = "etcd-events-threshold"
-	activeDeadlineDurationFlagName = "active-deadline-duration"
+	enableBackupCompactionFlagName    = "enable-backup-compaction"
+	workersFlagName                   = "compaction-workers"
+	eventsThresholdFlagName           = "etcd-events-threshold"
+	activeDeadlineDurationFlagName    = "active-deadline-duration"
+	metricsScrapeWaitDurationFlagname = "metrics-scrape-wait-duration"
 
-	defaultEnableBackupCompaction = false
-	defaultCompactionWorkers      = 3
-	defaultEventsThreshold        = 1000000
-	defaultActiveDeadlineDuration = 3 * time.Hour
+	defaultEnableBackupCompaction    = false
+	defaultCompactionWorkers         = 3
+	defaultEventsThreshold           = 1000000
+	defaultActiveDeadlineDuration    = 3 * time.Hour
+	defaultMetricsScrapeWaitDuration = 0
 )
 
 // Config contains configuration for the Compaction Controller.
@@ -51,6 +53,8 @@ type Config struct {
 	EventsThreshold int64
 	// ActiveDeadlineDuration is the duration after which a running compaction job will be killed.
 	ActiveDeadlineDuration time.Duration
+	// MetricsScrapeWaitDuration is the duration to wait for after compaction job is completed, to allow Prometheus metrics to be scraped
+	MetricsScrapeWaitDuration time.Duration
 	// FeatureGates contains the feature gates to be used by Compaction Controller.
 	FeatureGates map[featuregate.Feature]bool
 }
@@ -65,6 +69,9 @@ func InitFromFlags(fs *flag.FlagSet, cfg *Config) {
 		"Total number of etcd events that can be allowed before a backup compaction job is triggered.")
 	fs.DurationVar(&cfg.ActiveDeadlineDuration, activeDeadlineDurationFlagName, defaultActiveDeadlineDuration,
 		"Duration after which a running backup compaction job will be killed (Ex: \"300ms\", \"20s\" or \"2h45m\").\").")
+	fs.DurationVar(&cfg.MetricsScrapeWaitDuration, metricsScrapeWaitDurationFlagname, defaultMetricsScrapeWaitDuration,
+		"Duration to wait for after compaction job is completed, to allow Prometheus metrics to be scraped (Ex: \"300ms\", \"60s\" or \"2h45m\").\").")
+
 }
 
 // Validate validates the config.

--- a/controllers/compaction/config.go
+++ b/controllers/compaction/config.go
@@ -71,7 +71,6 @@ func InitFromFlags(fs *flag.FlagSet, cfg *Config) {
 		"Duration after which a running backup compaction job will be killed (Ex: \"300ms\", \"20s\" or \"2h45m\").\").")
 	fs.DurationVar(&cfg.MetricsScrapeWaitDuration, metricsScrapeWaitDurationFlagname, defaultMetricsScrapeWaitDuration,
 		"Duration to wait for after compaction job is completed, to allow Prometheus metrics to be scraped (Ex: \"300ms\", \"60s\" or \"2h45m\").\").")
-
 }
 
 // Validate validates the config.

--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -44,7 +44,8 @@ import (
 
 const (
 	// DefaultETCDQuota is the default etcd quota.
-	DefaultETCDQuota = 8 * 1024 * 1024 * 1024 // 8Gi
+	DefaultETCDQuota                 = 8 * 1024 * 1024 * 1024 // 8Gi
+	DefaultMetricsScrapeWaitDuration = "60s"
 )
 
 // Reconciler reconciles compaction jobs for Etcd resources.
@@ -487,6 +488,7 @@ func getCompactionJobArgs(etcd *druidv1alpha1.Etcd) []string {
 	command = append(command, "--data-dir=/var/etcd/data/compaction.etcd")
 	command = append(command, "--restoration-temp-snapshots-dir=/var/etcd/data/compaction.restoration.temp")
 	command = append(command, "--snapstore-temp-directory=/var/etcd/data/tmp")
+	command = append(command, "--metrics-scrape-wait-duration="+DefaultMetricsScrapeWaitDuration)
 	command = append(command, "--enable-snapshot-lease-renewal=true")
 	command = append(command, "--full-snapshot-lease-name="+etcd.GetFullSnapshotLeaseName())
 	command = append(command, "--delta-snapshot-lease-name="+etcd.GetDeltaSnapshotLeaseName())

--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -44,8 +44,7 @@ import (
 
 const (
 	// DefaultETCDQuota is the default etcd quota.
-	DefaultETCDQuota                 = 8 * 1024 * 1024 * 1024 // 8Gi
-	DefaultMetricsScrapeWaitDuration = "60s"
+	DefaultETCDQuota = 8 * 1024 * 1024 * 1024 // 8Gi
 )
 
 // Reconciler reconciles compaction jobs for Etcd resources.
@@ -298,7 +297,7 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 						Name:            "compact-backup",
 						Image:           *etcdBackupImage,
 						ImagePullPolicy: v1.PullIfNotPresent,
-						Args:            getCompactionJobArgs(etcd),
+						Args:            getCompactionJobArgs(etcd, r.config.MetricsScrapeWaitDuration.String()),
 						VolumeMounts:    getCompactionJobVolumeMounts(etcd, logger),
 						Env:             getCompactionJobEnvVar(etcd, logger),
 					}},
@@ -483,12 +482,12 @@ func getEnvVarFromSecrets(name, secretName, secretKey string) v1.EnvVar {
 	}
 }
 
-func getCompactionJobArgs(etcd *druidv1alpha1.Etcd) []string {
+func getCompactionJobArgs(etcd *druidv1alpha1.Etcd, metricsScrapeWaitDuration string) []string {
 	command := []string{"compact"}
 	command = append(command, "--data-dir=/var/etcd/data/compaction.etcd")
 	command = append(command, "--restoration-temp-snapshots-dir=/var/etcd/data/compaction.restoration.temp")
 	command = append(command, "--snapstore-temp-directory=/var/etcd/data/tmp")
-	command = append(command, "--metrics-scrape-wait-duration="+DefaultMetricsScrapeWaitDuration)
+	command = append(command, "--metrics-scrape-wait-duration="+metricsScrapeWaitDuration)
 	command = append(command, "--enable-snapshot-lease-renewal=true")
 	command = append(command, "--full-snapshot-lease-name="+etcd.GetFullSnapshotLeaseName())
 	command = append(command, "--delta-snapshot-lease-name="+etcd.GetDeltaSnapshotLeaseName())

--- a/test/integration/controllers/compaction/compaction_suite_test.go
+++ b/test/integration/controllers/compaction/compaction_suite_test.go
@@ -15,9 +15,10 @@
 package compaction
 
 import (
-	"github.com/gardener/etcd-druid/test/integration/controllers/assets"
 	"testing"
 	"time"
+
+	"github.com/gardener/etcd-druid/test/integration/controllers/assets"
 
 	"github.com/gardener/etcd-druid/controllers/compaction"
 	"github.com/gardener/etcd-druid/test/integration/setup"
@@ -53,10 +54,11 @@ var _ = BeforeSuite(func() {
 	intTestEnv = setup.NewIntegrationTestEnv(testNamespacePrefix, "compaction-int-tests", crdPaths)
 	intTestEnv.RegisterReconcilers(func(mgr manager.Manager) {
 		reconciler := compaction.NewReconcilerWithImageVector(mgr, &compaction.Config{
-			EnableBackupCompaction: true,
-			Workers:                5,
-			EventsThreshold:        100,
-			ActiveDeadlineDuration: 2 * time.Minute,
+			EnableBackupCompaction:    true,
+			Workers:                   5,
+			EventsThreshold:           100,
+			ActiveDeadlineDuration:    2 * time.Minute,
+			MetricsScrapeWaitDuration: 60 * time.Second,
 		}, imageVector)
 		Expect(reconciler.RegisterWithManager(mgr)).To(Succeed())
 	}).StartManager()

--- a/test/integration/controllers/compaction/reconciler_test.go
+++ b/test/integration/controllers/compaction/reconciler_test.go
@@ -273,7 +273,7 @@ func validateEtcdForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.Job) 
 								"--data-dir=/var/etcd/data/compaction.etcd":                                                                 Equal("--data-dir=/var/etcd/data/compaction.etcd"),
 								"--restoration-temp-snapshots-dir=/var/etcd/data/compaction.restoration.temp":                               Equal("--restoration-temp-snapshots-dir=/var/etcd/data/compaction.restoration.temp"),
 								"--snapstore-temp-directory=/var/etcd/data/tmp":                                                             Equal("--snapstore-temp-directory=/var/etcd/data/tmp"),
-								"--metrics-scrape-wait-duration=60s":                                                                        Equal("--metrics-scrape-wait-duration=60s"),
+								"--metrics-scrape-wait-duration=1m0s":                                                                       Equal("--metrics-scrape-wait-duration=1m0s"),
 								"--enable-snapshot-lease-renewal=true":                                                                      Equal("--enable-snapshot-lease-renewal=true"),
 								fmt.Sprintf("%s=%s", "--full-snapshot-lease-name", instance.GetFullSnapshotLeaseName()):                     Equal(fmt.Sprintf("%s=%s", "--full-snapshot-lease-name", instance.GetFullSnapshotLeaseName())),
 								fmt.Sprintf("%s=%s", "--delta-snapshot-lease-name", instance.GetDeltaSnapshotLeaseName()):                   Equal(fmt.Sprintf("%s=%s", "--delta-snapshot-lease-name", instance.GetDeltaSnapshotLeaseName())),

--- a/test/integration/controllers/compaction/reconciler_test.go
+++ b/test/integration/controllers/compaction/reconciler_test.go
@@ -273,6 +273,7 @@ func validateEtcdForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.Job) 
 								"--data-dir=/var/etcd/data/compaction.etcd":                                                                 Equal("--data-dir=/var/etcd/data/compaction.etcd"),
 								"--restoration-temp-snapshots-dir=/var/etcd/data/compaction.restoration.temp":                               Equal("--restoration-temp-snapshots-dir=/var/etcd/data/compaction.restoration.temp"),
 								"--snapstore-temp-directory=/var/etcd/data/tmp":                                                             Equal("--snapstore-temp-directory=/var/etcd/data/tmp"),
+								"--metrics-scrape-wait-duration=60s":                                                                        Equal("--metrics-scrape-wait-duration=60s"),
 								"--enable-snapshot-lease-renewal=true":                                                                      Equal("--enable-snapshot-lease-renewal=true"),
 								fmt.Sprintf("%s=%s", "--full-snapshot-lease-name", instance.GetFullSnapshotLeaseName()):                     Equal(fmt.Sprintf("%s=%s", "--full-snapshot-lease-name", instance.GetFullSnapshotLeaseName())),
 								fmt.Sprintf("%s=%s", "--delta-snapshot-lease-name", instance.GetDeltaSnapshotLeaseName()):                   Equal(fmt.Sprintf("%s=%s", "--delta-snapshot-lease-name", instance.GetDeltaSnapshotLeaseName())),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR makes the provision of `MetricsScrapeWaitDuration` through Config for compaction controller. `MetricsScrapeWaitDuration` actually supplies `--metrics-scrape-wait-duration` to `compact` subcommand of `etcdbr` command. This duration is needed as prometheus is required to collect necessary metrics for network activity after a fast full snapshot upload at the end of compaction job. Please check https://github.com/gardener/etcd-backup-restore/pull/660 and https://github.com/gardener/etcd-druid/issues/648 for more details.

**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/etcd-druid/issues/648

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Add new flag `metrics-scrape-wait-duration` for compaction controller to set a wait duration at the end of every compaction job, to allow for metrics to be scraped by a Prometheus instance.
```
