### PR TITLE
Correct document detailing k8s versions supported by `etcd-druid` versions

### DIFF
--- a/docs/usage/supported_k8s_versions.md
+++ b/docs/usage/supported_k8s_versions.md
@@ -5,6 +5,6 @@ The following is a list of kubernetes versions supported by the respective `etcd
 
 | Etcd-druid version | Kubernetes version |
 |------|------|
-| >=0.20 | >=1.25 |
+| >=0.20 | >=1.21 |
 | >=0.14 && <0.20 | All versions supported |
 | <0.14 | < 1.25 |


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
This PR corrects our `supported_k8s_versions` doc that incorrectly stated supported k8s versions for `etcd-druid:0.20`

From the [PDB deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125), `PDB`s from API version `v1beta1` were deprecated from k8s `1.21` and have been removed from k8s `1.25`. However `PDB`s were available in API version `v1` from k8s `1.21` onwards. 

Since `etcd-druid:v0.20` would drop support for `PDB`s in API version `v1beta1` and only support API version `v1`, it should work with k8s versions `>=1.21`


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
