### PR TITLE
github.com/gardener/etcd-backup-restore:v0.24.4->v0.24.5

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -4,7 +4,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.24.4"
+  tag: "v0.24.5"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd


### PR DESCRIPTION
**Release Notes**:
```noteworthy user [github.com/gardener/etcd-backup-restore](http://github.com/gardener/etcd-backup-restore) #667 @abdasgupta
Introduce flag `metrics-scrape-wait-duration` to `etcdbrctl compact` command, that specifies a wait duration at the end of a snapshot compaction, to allow Prometheus to scrape metrics related to compaction before the `etcdbrctl` process exits.
```