### PR TITLE
Bump etcd-backup-restore `v0.24.6` and etcd-custom-image `v3.4.26-3`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -4,11 +4,11 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.24.5"
+  tag: "v0.24.6"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd
-  tag: "v3.4.26-2"
+  tag: "v3.4.26-3"
 - name: etcd-backup-restore-distroless
   resourceId:
     name: 'etcdbrctl'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the image tags

- eu.gcr.io/gardener-project/gardener/etcdbrctl `v0.24.5` -> `v0.24.6`
- eu.gcr.io/gardener-project/gardener/etcd `v3.4.26-2` -> `v3.4.26-3`

**Release note**:
```improvement operator github.com/gardener/etcd-backup-restore #669 @seshachalam-yv
Introduced `delta-snapshot-retention-period` CLI flag to extend the configurable retention period for delta snapshots in `etcd-backup-restore`, enhancing flexibility for backup retention.
```
```improvement operator github.com/gardener/etcd-backup-restore #666 @shreyas-s-rao
Update alpine base image version to 3.18.4.
```
```improvement operator github.com/gardener/etcd-custom-image #41 @shreyas-s-rao
Update alpine base image version to 3.18.4.
```