### PR TITLE
Reconciles compaction job on job status change along with snapshot lease change

### DIFF
--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -111,18 +111,18 @@ func (r *Reconciler) reconcileJob(ctx context.Context, logger logr.Logger, etcd 
 	job := &batchv1.Job{}
 	if err := r.Get(ctx, types.NamespacedName{Name: etcd.GetCompactionJobName(), Namespace: etcd.Namespace}, job); err != nil {
 		if errors.IsNotFound(err) {
-			logger.Info("Currently, no compaction job is running")
+			logger.Info("Currently, no compaction job is running in the namespace ", etcd.Namespace)
 		} else {
 			// Error reading the object - requeue the request.
 			return ctrl.Result{
 				RequeueAfter: 10 * time.Second,
-			}, err
+			}, fmt.Errorf("error while fetching compaction job with the name %v, in the namespace %v: %v", etcd.GetCompactionJobName(), etcd.Namespace, err)
 		}
 	}
 
 	if job != nil && job.Name != "" {
 		if !job.DeletionTimestamp.IsZero() {
-			logger.Info("Job is already in deletion. A new job will be created only if the previous one has been deleted.", "namespace", job.Namespace, "name", job.Name)
+			logger.Info("Job is already in deletion. A new job will be created only if the previous one has been deleted.", "namespace: ", job.Namespace, "name: ", job.Name)
 			return ctrl.Result{
 				RequeueAfter: 10 * time.Second,
 			}, nil

--- a/controllers/compaction/register.go
+++ b/controllers/compaction/register.go
@@ -37,7 +37,7 @@ func (r *Reconciler) RegisterWithManager(mgr ctrl.Manager) error {
 		}).
 		For(&druidv1alpha1.Etcd{}).
 		WithEventFilter(predicate.
-			Or(druidpredicates.SnapshotLeaseChanged(),
+			Or(druidpredicates.SnapshotRevisionChanged(),
 				druidpredicates.JobStatusChanged())).
 		Owns(&coordinationv1.Lease{}).
 		Owns(&batchv1.Job{}).

--- a/controllers/predicate/predicate.go
+++ b/controllers/predicate/predicate.go
@@ -149,9 +149,9 @@ func EtcdReconciliationFinished(ignoreOperationAnnotation bool) predicate.Predic
 	}
 }
 
-// SnapshotLeaseChanged is a predicate that is `true` if the passed lease object is a snapshot lease and if the lease
+// SnapshotRevisionChanged is a predicate that is `true` if the passed lease object is a snapshot lease and if the lease
 // object's holderIdentity is updated.
-func SnapshotLeaseChanged() predicate.Predicate {
+func SnapshotRevisionChanged() predicate.Predicate {
 	isSnapshotLease := func(obj client.Object) bool {
 		lease, ok := obj.(*coordinationv1.Lease)
 		if !ok {
@@ -182,10 +182,10 @@ func SnapshotLeaseChanged() predicate.Predicate {
 			return isSnapshotLease(event.ObjectNew) && holderIdentityChange(event.ObjectOld, event.ObjectNew)
 		},
 		GenericFunc: func(event event.GenericEvent) bool {
-			return isSnapshotLease(event.Object)
+			return false
 		},
 		DeleteFunc: func(event event.DeleteEvent) bool {
-			return isSnapshotLease(event.Object)
+			return false
 		},
 	}
 }

--- a/controllers/predicate/predicate.go
+++ b/controllers/predicate/predicate.go
@@ -20,6 +20,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -111,37 +112,6 @@ func StatefulSetStatusChange() predicate.Predicate {
 	}
 }
 
-// LeaseHolderIdentityChange is a predicate for holderIdentity changes of `Lease` resources.
-func LeaseHolderIdentityChange() predicate.Predicate {
-	holderIdentityChange := func(objOld, objNew client.Object) bool {
-		leaseOld, ok := objOld.(*coordinationv1.Lease)
-		if !ok {
-			return false
-		}
-		leaseNew, ok := objNew.(*coordinationv1.Lease)
-		if !ok {
-			return false
-		}
-
-		return !reflect.DeepEqual(leaseOld.Spec.HolderIdentity, leaseNew.Spec.HolderIdentity)
-	}
-
-	return predicate.Funcs{
-		CreateFunc: func(event event.CreateEvent) bool {
-			return true
-		},
-		UpdateFunc: func(event event.UpdateEvent) bool {
-			return holderIdentityChange(event.ObjectOld, event.ObjectNew)
-		},
-		GenericFunc: func(event event.GenericEvent) bool {
-			return true
-		},
-		DeleteFunc: func(event event.DeleteEvent) bool {
-			return true
-		},
-	}
-}
-
 // EtcdReconciliationFinished is a predicate to use for etcd resources whose reconciliation has finished.
 func EtcdReconciliationFinished(ignoreOperationAnnotation bool) predicate.Predicate {
 	reconciliationFinished := func(obj client.Object) bool {
@@ -179,8 +149,9 @@ func EtcdReconciliationFinished(ignoreOperationAnnotation bool) predicate.Predic
 	}
 }
 
-// IsSnapshotLease is a predicate that is `true` if the passed lease object is a snapshot lease.
-func IsSnapshotLease() predicate.Predicate {
+// SnapshotLeaseChanged is a predicate that is `true` if the passed lease object is a snapshot lease and if the lease
+// object's holderIdentity is updated.
+func SnapshotLeaseChanged() predicate.Predicate {
 	isSnapshotLease := func(obj client.Object) bool {
 		lease, ok := obj.(*coordinationv1.Lease)
 		if !ok {
@@ -190,18 +161,61 @@ func IsSnapshotLease() predicate.Predicate {
 		return strings.HasSuffix(lease.Name, "full-snap") || strings.HasSuffix(lease.Name, "delta-snap")
 	}
 
+	holderIdentityChange := func(objOld, objNew client.Object) bool {
+		leaseOld, ok := objOld.(*coordinationv1.Lease)
+		if !ok {
+			return false
+		}
+		leaseNew, ok := objNew.(*coordinationv1.Lease)
+		if !ok {
+			return false
+		}
+
+		return !reflect.DeepEqual(leaseOld.Spec.HolderIdentity, leaseNew.Spec.HolderIdentity)
+	}
+
 	return predicate.Funcs{
 		CreateFunc: func(event event.CreateEvent) bool {
 			return isSnapshotLease(event.Object)
 		},
 		UpdateFunc: func(event event.UpdateEvent) bool {
-			return isSnapshotLease(event.ObjectNew)
+			return isSnapshotLease(event.ObjectNew) && holderIdentityChange(event.ObjectOld, event.ObjectNew)
 		},
 		GenericFunc: func(event event.GenericEvent) bool {
 			return isSnapshotLease(event.Object)
 		},
 		DeleteFunc: func(event event.DeleteEvent) bool {
 			return isSnapshotLease(event.Object)
+		},
+	}
+}
+
+// JobStatusChanged is a predicate that is `true` if the status of a job changes.
+func JobStatusChanged() predicate.Predicate {
+	statusChange := func(objOld, objNew client.Object) bool {
+		jobOld, ok := objOld.(*batchv1.Job)
+		if !ok {
+			return false
+		}
+		jobNew, ok := objNew.(*batchv1.Job)
+		if !ok {
+			return false
+		}
+		return !apiequality.Semantic.DeepEqual(jobOld.Status, jobNew.Status)
+	}
+
+	return predicate.Funcs{
+		CreateFunc: func(event event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(event event.UpdateEvent) bool {
+			return statusChange(event.ObjectOld, event.ObjectNew)
+		},
+		GenericFunc: func(event event.GenericEvent) bool {
+			return false
+		},
+		DeleteFunc: func(event event.DeleteEvent) bool {
+			return false
 		},
 	}
 }

--- a/controllers/predicate/predicate_test.go
+++ b/controllers/predicate/predicate_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Druid Predicate", func() {
 		var pred predicate.Predicate
 
 		JustBeforeEach(func() {
-			pred = SnapshotLeaseChanged()
+			pred = SnapshotRevisionChanged()
 		})
 
 		Context("when holder identity is nil for delta snap leases", func() {
@@ -135,8 +135,8 @@ var _ = Describe("Druid Predicate", func() {
 			It("should return false", func() {
 				gomega.Expect(pred.Create(createEvent)).To(gomega.BeTrue())
 				gomega.Expect(pred.Update(updateEvent)).To(gomega.BeFalse())
-				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeTrue())
-				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeTrue())
+				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeFalse())
+				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeFalse())
 			})
 		})
 
@@ -163,8 +163,8 @@ var _ = Describe("Druid Predicate", func() {
 			It("should return false", func() {
 				gomega.Expect(pred.Create(createEvent)).To(gomega.BeTrue())
 				gomega.Expect(pred.Update(updateEvent)).To(gomega.BeFalse())
-				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeTrue())
-				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeTrue())
+				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeFalse())
+				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeFalse())
 			})
 		})
 
@@ -191,8 +191,8 @@ var _ = Describe("Druid Predicate", func() {
 			It("should return true", func() {
 				gomega.Expect(pred.Create(createEvent)).To(gomega.BeTrue())
 				gomega.Expect(pred.Update(updateEvent)).To(gomega.BeTrue())
-				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeTrue())
-				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeTrue())
+				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeFalse())
+				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeFalse())
 			})
 		})
 
@@ -213,8 +213,8 @@ var _ = Describe("Druid Predicate", func() {
 			It("should return false", func() {
 				gomega.Expect(pred.Create(createEvent)).To(gomega.BeTrue())
 				gomega.Expect(pred.Update(updateEvent)).To(gomega.BeFalse())
-				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeTrue())
-				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeTrue())
+				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeFalse())
+				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeFalse())
 			})
 		})
 
@@ -241,8 +241,8 @@ var _ = Describe("Druid Predicate", func() {
 			It("should return false", func() {
 				gomega.Expect(pred.Create(createEvent)).To(gomega.BeTrue())
 				gomega.Expect(pred.Update(updateEvent)).To(gomega.BeFalse())
-				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeTrue())
-				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeTrue())
+				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeFalse())
+				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeFalse())
 			})
 		})
 
@@ -269,8 +269,8 @@ var _ = Describe("Druid Predicate", func() {
 			It("should return true", func() {
 				gomega.Expect(pred.Create(createEvent)).To(gomega.BeTrue())
 				gomega.Expect(pred.Update(updateEvent)).To(gomega.BeTrue())
-				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeTrue())
-				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeTrue())
+				gomega.Expect(pred.Delete(deleteEvent)).To(gomega.BeFalse())
+				gomega.Expect(pred.Generic(genericEvent)).To(gomega.BeFalse())
 			})
 		})
 

--- a/test/integration/controllers/compaction/reconciler_test.go
+++ b/test/integration/controllers/compaction/reconciler_test.go
@@ -119,14 +119,8 @@ var _ = Describe("Compaction Controller", func() {
 			fullSnapLease, deltaSnapLease = createEtcdSnapshotLeasesAndWait(k8sClient, instance)
 
 			// manually create compaction job
-			j = createCompactionJob(instance)
-			Expect(k8sClient.Create(ctx, j)).To(Succeed())
-
-			Eventually(func() error { return jobIsCorrectlyReconciled(k8sClient, instance, j) }, timeout, pollingInterval).Should(BeNil())
-
-			// Update job status as failed
-			j.Status.Failed = 1
-			Expect(k8sClient.Status().Update(ctx, j)).To(Succeed())
+			// j = createCompactionJob(instance)
+			// Expect(k8sClient.Create(ctx, j)).To(Succeed())
 
 			// Deliberately update the full lease
 			fullSnapLease.Spec.HolderIdentity = pointer.String("0")
@@ -137,6 +131,15 @@ var _ = Describe("Compaction Controller", func() {
 			deltaSnapLease.Spec.HolderIdentity = pointer.String("101")
 			deltaSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), deltaSnapLease)).To(Succeed())
+
+			j = &batchv1.Job{}
+			Eventually(func() error {
+				return jobIsCorrectlyReconciled(k8sClient, instance, j)
+			}, timeout, pollingInterval).Should(BeNil())
+
+			// Update job status as failed
+			j.Status.Failed = 1
+			Expect(k8sClient.Status().Update(ctx, j)).To(Succeed())
 
 			// Wait until the job gets the "foregroundDeletion" finalizer and remove it
 			Eventually(func() (*batchv1.Job, error) {
@@ -161,21 +164,11 @@ var _ = Describe("Compaction Controller", func() {
 			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 			defer cancel()
 
-			instance = testutils.EtcdBuilderWithDefaults("foo78", "default").Build()
+			instance = testutils.EtcdBuilderWithDefaults("foo78", "default").WithProviderLocal().Build()
 			createEtcdAndWait(k8sClient, instance)
 
 			// manually create full and delta snapshot leases since etcd controller is not running
 			fullSnapLease, deltaSnapLease = createEtcdSnapshotLeasesAndWait(k8sClient, instance)
-
-			// create compaction job
-			j := createCompactionJob(instance)
-			Expect(k8sClient.Create(ctx, j)).To(Succeed())
-
-			Eventually(func() error { return jobIsCorrectlyReconciled(k8sClient, instance, j) }, timeout, pollingInterval).Should(BeNil())
-
-			// Update job status as succeeded
-			j.Status.Succeeded = 1
-			Expect(k8sClient.Status().Update(context.TODO(), j)).To(Succeed())
 
 			// Deliberately update the full lease
 			fullSnapLease.Spec.HolderIdentity = pointer.String("0")
@@ -186,6 +179,15 @@ var _ = Describe("Compaction Controller", func() {
 			deltaSnapLease.Spec.HolderIdentity = pointer.String("101")
 			deltaSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), deltaSnapLease)).To(Succeed())
+
+			j = &batchv1.Job{}
+			Eventually(func() error {
+				return jobIsCorrectlyReconciled(k8sClient, instance, j)
+			}, timeout, pollingInterval).Should(BeNil())
+
+			// Update job status as succeeded
+			j.Status.Succeeded = 1
+			Expect(k8sClient.Status().Update(context.TODO(), j)).To(Succeed())
 
 			// Wait until the job gets the "foregroundDeletion" finalizer and remove it
 			Eventually(func() (*batchv1.Job, error) {
@@ -206,26 +208,30 @@ var _ = Describe("Compaction Controller", func() {
 			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 			defer cancel()
 
-			instance = testutils.EtcdBuilderWithDefaults("foo79", "default").Build()
+			instance = testutils.EtcdBuilderWithDefaults("foo79", "default").WithProviderLocal().Build()
 			createEtcdAndWait(k8sClient, instance)
 
 			// manually create full and delta snapshot leases since etcd controller is not running
 			fullSnapLease, deltaSnapLease = createEtcdSnapshotLeasesAndWait(k8sClient, instance)
 
-			// create compaction job
-			j := createCompactionJob(instance)
-			Expect(k8sClient.Create(ctx, j)).To(Succeed())
+			// Deliberately update the full lease
+			fullSnapLease.Spec.HolderIdentity = pointer.String("0")
+			fullSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+			Expect(k8sClient.Update(context.TODO(), fullSnapLease)).To(Succeed())
 
-			Eventually(func() error { return jobIsCorrectlyReconciled(k8sClient, instance, j) }, timeout, pollingInterval).Should(BeNil())
+			// Deliberately update the delta lease
+			deltaSnapLease.Spec.HolderIdentity = pointer.String("101")
+			deltaSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+			Expect(k8sClient.Update(context.TODO(), deltaSnapLease)).To(Succeed())
+
+			j = &batchv1.Job{}
+			Eventually(func() error {
+				return jobIsCorrectlyReconciled(k8sClient, instance, j)
+			}, timeout, pollingInterval).Should(BeNil())
 
 			// Update job status as active
 			j.Status.Active = 1
 			Expect(k8sClient.Status().Update(ctx, j)).To(Succeed())
-
-			// Deliberately update the delta lease
-			deltaSnapLease.Spec.HolderIdentity = pointer.String("100")
-			deltaSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
-			Expect(k8sClient.Update(context.TODO(), deltaSnapLease)).To(Succeed())
 
 			// The active job should exist
 			Eventually(func() error {
@@ -239,8 +245,47 @@ var _ = Describe("Compaction Controller", func() {
 			}, timeout, pollingInterval).Should(BeNil())
 		})
 
-	})
+		It("should let the existing job run even without any lease update", func() {
+			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+			defer cancel()
 
+			instance = testutils.EtcdBuilderWithDefaults("foo80", "default").WithProviderLocal().Build()
+			createEtcdAndWait(k8sClient, instance)
+
+			// manually create full and delta snapshot leases since etcd controller is not running
+			fullSnapLease, deltaSnapLease = createEtcdSnapshotLeasesAndWait(k8sClient, instance)
+
+			// Deliberately update the full lease
+			fullSnapLease.Spec.HolderIdentity = pointer.String("0")
+			fullSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+			Expect(k8sClient.Update(context.TODO(), fullSnapLease)).To(Succeed())
+
+			// Deliberately update the delta lease
+			deltaSnapLease.Spec.HolderIdentity = pointer.String("101")
+			deltaSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+			Expect(k8sClient.Update(context.TODO(), deltaSnapLease)).To(Succeed())
+
+			j = &batchv1.Job{}
+			Eventually(func() error {
+				return jobIsCorrectlyReconciled(k8sClient, instance, j)
+			}, timeout, pollingInterval).Should(BeNil())
+
+			// Update job status as active
+			j.Status.Active = 1
+			Expect(k8sClient.Status().Update(ctx, j)).To(Succeed())
+
+			// The active job should exist
+			Eventually(func() error {
+				if err := jobIsCorrectlyReconciled(k8sClient, instance, j); err != nil {
+					return err
+				}
+				if j.Status.Active != 1 {
+					return fmt.Errorf("compaction job is not currently active")
+				}
+				return nil
+			}, timeout, pollingInterval).Should(BeNil())
+		})
+	})
 })
 
 func validateEtcdForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.Job) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR solves a bug due to which compaction job related metrics were not having exactly accurate values. This PR actually reconciles compaction job on job status changes along with the holder identity changes in snapshot leases.

**Which issue(s) this PR fixes**:
Fixes #685 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Compaction job now reconciles on Job Status changes along with the holder identity changes in snapshot leases.
```
