### PR TITLE
Simplify `Localstack` setup by utilizing S3 endpoint support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ deploy-via-kustomize: manifests $(KUSTOMIZE)
 # Modify the Helm template located at charts/druid/templates if any changes are required
 .PHONY: deploy
 deploy: $(SKAFFOLD) 
-	$(SKAFFOLD) run -m etcd-druid
+	$(SKAFFOLD) run -m etcd-druid --kubeconfig=$(KUBECONFIG_PATH)
 
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
@@ -167,7 +167,7 @@ kind-down: $(KIND)
 
 .PHONY: deploy-localstack
 deploy-localstack: $(KUBECTL)
-	BUCKET_NAME=$(BUCKET_NAME) ./hack/deploy-localstack.sh
+	./hack/deploy-localstack.sh
 
 .PHONY: ci-e2e-kind
 ci-e2e-kind:

--- a/config/samples/druid_v1alpha1_etcd_localstack.yaml
+++ b/config/samples/druid_v1alpha1_etcd_localstack.yaml
@@ -1,0 +1,78 @@
+apiVersion: druid.gardener.cloud/v1alpha1
+kind: Etcd
+metadata:
+  name: etcd-test
+  labels:
+    app: etcd-statefulset
+    gardener.cloud/role: controlplane
+    role: test
+spec:
+  selector:
+    matchLabels:
+      app: etcd-statefulset
+      gardener.cloud/role: controlplane
+      role: test
+  annotations:
+    app: etcd-statefulset
+    gardener.cloud/role: controlplane
+    # networking.gardener.cloud/to-dns: allowed
+    # networking.gardener.cloud/to-private-networks: allowed
+    # networking.gardener.cloud/to-public-networks: allowed
+    role: test
+  labels:
+    app: etcd-statefulset
+    gardener.cloud/role: controlplane
+    # networking.gardener.cloud/to-dns: allowed
+    # networking.gardener.cloud/to-private-networks: allowed
+    # networking.gardener.cloud/to-public-networks: allowed
+    role: test
+  etcd:
+    metrics: basic
+    defragmentationSchedule: "0 */24 * * *"
+    resources:
+      limits: { cpu: 500m, memory: 1Gi }
+      requests: { cpu: 100m, memory: 200Mi }
+    clientPort: 2379
+    serverPort: 2380
+    quota: 8Gi
+    # heartbeatDuration: 10s
+  backup:
+    port: 8080
+    fullSnapshotSchedule: "0 */24 * * *"
+    resources:
+      limits: { cpu: 200m, memory: 1Gi }
+      requests: { cpu: 23m, memory: 128Mi }
+    garbageCollectionPolicy: Exponential
+    garbageCollectionPeriod: 43200s
+    deltaSnapshotPeriod: 300s
+    deltaSnapshotMemoryLimit: 1Gi
+    store:
+      container: etcd-bucket
+      prefix: etcd-test
+      provider: S3
+      secretRef:
+        name: etcd-backup-aws
+    compression:
+      enabled: false
+      policy: "gzip"
+    leaderElection:
+      reelectionPeriod: 5s
+      etcdConnectionTimeout: 5s
+
+  sharedConfig:
+    autoCompactionMode: periodic
+    autoCompactionRetention: "30m"
+  # schedulingConstraints:
+    # affinity: {}
+    # topologySpreadConstraints:
+    # - maxSkew: 1
+    #   topologyKey: topology.kubernetes.io/zone
+    #   whenUnsatisfiable: DoNotSchedule
+    #   labelSelector:
+    #     matchLabels:
+    #       app: etcd-statefulset
+
+  replicas: 3
+  # priorityClassName: priority-class-name
+  # storageClass: default
+  # storageCapacity: 10Gi

--- a/config/samples/etcd-secret-localstack.yaml
+++ b/config/samples/etcd-secret-localstack.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data:
+  accessKeyID: QUNDRVNTS0VZQVdTVVNFUg==
+  bucketName: ZXRjZC1idWNrZXQK
+  endpoint: aHR0cDovL2xvY2Fsc3RhY2suZGVmYXVsdDo0NTY2
+  region: dXMtZWFzdC0y
+  s3ForcePathStyle: dHJ1ZQ==
+  secretAccessKey: c0VjcmVUS2V5
+kind: Secret
+metadata:
+  labels:
+    garden.sapcloud.io/role: controlplane
+    role: main
+  name: etcd-backup-aws
+type: Opaque

--- a/docs/development/getting-started-locally-localstack.md
+++ b/docs/development/getting-started-locally-localstack.md
@@ -1,0 +1,81 @@
+# Getting Started with etcd-druid, LocalStack, and Kind
+
+This guide provides step-by-step instructions on how to set up etcd-druid with [LocalStack](https://localstack.cloud/) and Kind on your local machine. LocalStack emulates AWS services locally, which allows the etcd cluster to interact with AWS S3 without the need for an actual AWS connection. This setup is ideal for local development and testing.
+
+## Prerequisites
+
+- Docker (installed and running)
+- AWS CLI (version `>=1.29.0` or `>=2.13.0`)
+
+## Environment Setup
+
+### Step 1: Provision the Kind Cluster
+
+Execute the command below to provision a `kind` cluster. This command also forwards port `4566` from the [kind cluster](hack/e2e-test/infrastructure/kind/cluster.yaml) to your local machine, enabling LocalStack access:
+
+```bash
+make kind-up
+```
+
+### Step 2: Deploy LocalStack
+
+Deploy LocalStack onto the Kubernetes cluster using the command below:
+
+```bash
+make deploy-localstack
+```
+
+### Step 3: Establish an S3 Bucket
+
+1. Specify the AWS endpoint URL for `S3` interactions to utilize the AWS CLI with LocalStack:
+
+```bash
+export AWS_ENDPOINT_URL_S3="http://localhost:4566"
+```
+
+2. Create an S3 bucket for etcd-druid backup purposes:
+
+```bash
+aws s3api create-bucket --bucket etcd-bucket --region us-east-2 --create-bucket-configuration LocationConstraint=us-east-2 --acl private
+```
+
+### Step 4: Deploy etcd-druid
+
+Deploy etcd-druid onto the Kind cluster using the command below:
+
+```bash
+make deploy
+```
+
+### Step 5: Configure etcd with LocalStack Store
+
+Apply the required Kubernetes manifests to create an etcd custom resource (CR) and a secret for AWS credentials, facilitating LocalStack access:
+
+```bash
+export KUBECONFIG=hack/e2e-test/infrastructure/kind/kubeconfig
+kubectl apply -f config/samples/druid_v1alpha1_etcd_localstack.yaml -f config/samples/etcd-secret-localstack.yaml
+```
+
+### Step 6: Reconcile the etcd
+
+Initiate etcd reconciliation by annotating the etcd resource with the `gardener.cloud/operation=reconcile` annotation:
+
+```bash
+kubectl annotate etcd etcd-test gardener.cloud/operation=reconcile
+```
+
+Congratulations! You have successfully configured `etcd-druid`, `LocalStack`, and `kind` on your local machine. Inspect the etcd-druid logs and LocalStack to ensure the setup operates as anticipated.
+
+To validate the buckets, execute the following command:
+
+```bash
+aws s3 ls etcd-bucket/etcd-test/v2/
+```
+
+### Cleanup
+
+To dismantle the setup, execute the following command:
+
+```bash
+make kind-down
+```

--- a/docs/development/getting-started-locally-localstack.md
+++ b/docs/development/getting-started-locally-localstack.md
@@ -25,12 +25,15 @@ Deploy LocalStack onto the Kubernetes cluster using the command below:
 make deploy-localstack
 ```
 
-### Step 3: Establish an S3 Bucket
+### Step 3: Set up an S3 Bucket
 
-1. Specify the AWS endpoint URL for `S3` interactions to utilize the AWS CLI with LocalStack:
+1. Set up the AWS CLI to interact with LocalStack by setting the necessary environment variables. This configuration redirects S3 commands to the LocalStack endpoint and provides the required credentials for authentication:
 
 ```bash
 export AWS_ENDPOINT_URL_S3="http://localhost:4566"
+export AWS_ACCESS_KEY_ID=ACCESSKEYAWSUSER
+export AWS_SECRET_ACCESS_KEY=sEcreTKey
+export AWS_DEFAULT_REGION=us-east-2
 ```
 
 2. Create an S3 bucket for etcd-druid backup purposes:
@@ -77,5 +80,7 @@ aws s3 ls etcd-bucket/etcd-test/v2/
 To dismantle the setup, execute the following command:
 
 ```bash
-make kind-down && unset AWS_ENDPOINT_URL_S3
+make kind-down
+unset AWS_ENDPOINT_URL_S3 AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION KUBECONFIG
+
 ```

--- a/docs/development/getting-started-locally-localstack.md
+++ b/docs/development/getting-started-locally-localstack.md
@@ -77,5 +77,5 @@ aws s3 ls etcd-bucket/etcd-test/v2/
 To dismantle the setup, execute the following command:
 
 ```bash
-make kind-down
+make kind-down && unset AWS_ENDPOINT_URL_S3
 ```

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -27,7 +27,7 @@ kubectl wait --for=condition=ready node --all
 export AWS_APPLICATION_CREDENTIALS_JSON="/tmp/aws.json"
 echo "{ \"accessKeyID\": \"ACCESSKEYAWSUSER\", \"secretAccessKey\": \"sEcreTKey\", \"region\": \"us-east-2\", \"endpoint\": \"http://127.0.0.1:4566\", \"s3ForcePathStyle\": true, \"bucketName\": \"${BUCKET_NAME}\" }" >/tmp/aws.json
 
-make deploy-localstack BUCKET_NAME="$BUCKET_NAME"
+make deploy-localstack
 make LOCALSTACK_HOST="localstack.default:4566" \
   AWS_ACCESS_KEY_ID="ACCESSKEYAWSUSER" \
   AWS_SECRET_ACCESS_KEY="sEcreTKey" \

--- a/hack/deploy-localstack.sh
+++ b/hack/deploy-localstack.sh
@@ -18,40 +18,5 @@ set -o nounset
 set -o pipefail
 
 kubectl apply -f ./hack/e2e-test/infrastructure/localstack/localstack.yaml
-
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-data:
-  Corefile: |
-    .:53 {
-        errors
-        health {
-           lameduck 5s
-        }
-        ready
-        rewrite name $BUCKET_NAME.localstack.default localstack.default.svc.cluster.local
-        
-        kubernetes cluster.local in-addr.arpa ip6.arpa {
-           pods insecure
-           fallthrough in-addr.arpa ip6.arpa
-           ttl 30
-        }
-        prometheus :9153
-        forward . /etc/resolv.conf {
-           max_concurrent 1000
-        }
-        cache 30
-        loop
-        reload
-        loadbalance
-    }
-kind: ConfigMap
-metadata:
-  name: coredns
-  namespace: kube-system
-EOF
-
-kubectl delete pods -n kube-system -l k8s-app=kube-dns
-kubectl delete pods -n kube-system -l k8s-app=kube-dns
-kubectl wait --for=condition=ready pod -n kube-system -l k8s-app=kube-dns --timeout=120s
+kubectl rollout status deploy/localstack
 kubectl wait --for=condition=ready pod -l app=localstack --timeout=240s


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR simplifies the setup of LocalStack by leveraging the [recent support for passing the endpoint to S3](https://github.com/aws/aws-cli/issues/4012#issuecomment-1626114865). The changes include modifications to the configuration files and scripts to accommodate this latest support, making it easier to set up and use Localstack.

Previously, the AWS CLI didn't provide support to pass an endpoint for the S3 service, requiring a workaround of rewriting the DNS from CoreDNS. With the [recent support for passing the endpoint to S3](https://github.com/aws/aws-cli/issues/4012#issuecomment-1626114865), able to simplify the setup steps and remove the old workarounds.

- Added documentation on setting up `etcd-druid` with Localstack locally on a Kind cluster.
- Introduced new sample `druid_v1alpha1_etcd_localstack.yaml` for `etcd` CR with a Localstack store.
- Added new sample AWS secret `etcd-secret-localstack.yaml` for Localstack.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Added documentation and sample configurations for simplifying Localstack setup, making it easier for developers to create a local testing environment using a Kind cluster.
```
