### PR TITLE
Resolve Replica Count Updating Issue in Custodian Controller

### DIFF
--- a/controllers/custodian/reconciler.go
+++ b/controllers/custodian/reconciler.go
@@ -115,6 +115,7 @@ func (r *Reconciler) updateEtcdStatus(ctx context.Context, logger logr.Logger, e
 		etcd.Status.CurrentReplicas = sts.Status.CurrentReplicas
 		etcd.Status.ReadyReplicas = sts.Status.ReadyReplicas
 		etcd.Status.UpdatedReplicas = sts.Status.UpdatedReplicas
+		etcd.Status.Replicas = sts.Status.CurrentReplicas
 		etcd.Status.Ready = &ready
 		logger.Info("ETCD status updated for statefulset", "namespace", etcd.Namespace, "name", etcd.Name,
 			"currentReplicas", sts.Status.CurrentReplicas, "readyReplicas", sts.Status.ReadyReplicas, "updatedReplicas", sts.Status.UpdatedReplicas)


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug in the Custodian Controller which was not updating the replica count in the `etcd` status, while the `etcd` Controller in Druid was. It ensures that the `Replicas` field in the `etcd` status is accurately updated to reflect the `CurrentReplicas` from the StatefulSet status, similar to the behavior of the `etcd` Controller. This harmonizes the behavior between the `etcd` and Custodian Controllers, ensuring consistent replica count reflection in the `etcd` status.
**Which issue(s) this PR fixes**:
Fixes # (Include the issue number if there is one)

**Special notes for your reviewer**:
Please review the added line `etcd.Status.Replicas = sts.Status.CurrentReplicas` in the `updateEtcdStatus` function within the Custodian Controller, ensuring it aligns with the project's coding standards and practices.

This PR, https://github.com/gardener/etcd-druid/pull/701, has already been merged into the branch https://github.com/gardener/etcd-druid/tree/hotfix-v0.20.

**Release note**:
```bugfix operator
Resolved an issue where the Custodian Controller was not updating the `Replicas` field in the `etcd` status to reflect the `CurrentReplicas` from the StatefulSet status. This fix ensures consistent behavior with the `etcd` Controller in Druid.
````
