### PR TITLE
[hotfix-v0.20] Added the alpine image used for init containers to the image vector

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -19,3 +19,6 @@ images:
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: eu.gcr.io/gardener-project/gardener/etcd-wrapper
   tag: "v0.1.0"
+- name: alpine
+  repository: eu.gcr.io/gardener-project/3rd/alpine
+  tag: "3.15.8"

--- a/controllers/compaction/reconciler.go
+++ b/controllers/compaction/reconciler.go
@@ -258,7 +258,7 @@ func (r *Reconciler) delete(ctx context.Context, logger logr.Logger, etcd *druid
 func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd) (*batchv1.Job, error) {
 	activeDeadlineSeconds := r.config.ActiveDeadlineDuration.Seconds()
 
-	_, etcdBackupImage, err := utils.GetEtcdImages(etcd, r.imageVector, r.config.FeatureGates[features.UseEtcdWrapper])
+	_, etcdBackupImage, _, err := utils.GetEtcdImages(etcd, r.imageVector, r.config.FeatureGates[features.UseEtcdWrapper])
 	if err != nil {
 		return nil, fmt.Errorf("couldn't fetch etcd backup image: %v", err)
 	}

--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -301,7 +301,7 @@ func (r *Reconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, etcd
 		return reconcileResult{err: fmt.Errorf("Spec.Replicas should not be even number: %d", etcd.Spec.Replicas)}
 	}
 
-	etcdImage, etcdBackupImage, err := druidutils.GetEtcdImages(etcd, r.imageVector, r.config.FeatureGates[features.UseEtcdWrapper])
+	etcdImage, etcdBackupImage, initContainerImage, err := druidutils.GetEtcdImages(etcd, r.imageVector, r.config.FeatureGates[features.UseEtcdWrapper])
 	if err != nil {
 		return reconcileResult{err: err}
 	}
@@ -364,6 +364,7 @@ func (r *Reconciler) reconcileEtcd(ctx context.Context, logger logr.Logger, etcd
 		&serviceValues.BackupPort,
 		*etcdImage,
 		*etcdBackupImage,
+		*initContainerImage,
 		map[string]string{
 			"checksum/etcd-configmap": configMapValues.ConfigMapChecksum,
 		}, peerUrlTLSChangedToEnabled,

--- a/controllers/etcdcopybackupstask/reconciler.go
+++ b/controllers/etcdcopybackupstask/reconciler.go
@@ -290,6 +290,11 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 		return nil, err
 	}
 
+	initContainerImage, err := druidutils.GetInitContainerImage(r.imageVector)
+	if err != nil {
+		return nil, err
+	}
+
 	targetStore := task.Spec.TargetStore
 	targetProvider, err := druidutils.StorageProviderFromInfraProvider(targetStore.Provider)
 	if err != nil {
@@ -369,7 +374,7 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 			job.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
 					Name:         "change-backup-bucket-permissions",
-					Image:        "alpine:3.18.2",
+					Image:        *initContainerImage,
 					Command:      []string{"sh", "-c", "--"},
 					Args:         []string{fmt.Sprintf("%s%s%s%s", "chown -R 65532:65532 /home/nonroot/", *targetStore.Container, " /home/nonroot/", *sourceStore.Container)},
 					VolumeMounts: volumeMounts,

--- a/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/controllers/etcdcopybackupstask/reconciler_test.go
@@ -154,11 +154,18 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 			reconciler = &Reconciler{
 				Client: fakeClient,
 				logger: logr.Discard(),
-				imageVector: imagevector.ImageVector{&imagevector.ImageSource{
-					Name:       common.BackupRestore,
-					Repository: "test-repo",
-					Tag:        pointer.String("etcd-test-tag"),
-				}},
+				imageVector: imagevector.ImageVector{
+					&imagevector.ImageSource{
+						Name:       common.BackupRestore,
+						Repository: "test-repo",
+						Tag:        pointer.String("etcd-test-tag"),
+					},
+					&imagevector.ImageSource{
+						Name:       common.Alpine,
+						Repository: "test-repo",
+						Tag:        pointer.String("init-container-test-tag"),
+					},
+				},
 				Config: &Config{
 					FeatureGates: make(map[featuregate.Feature]bool),
 				},

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -23,6 +23,8 @@ const (
 	EtcdWrapper = "etcd-wrapper"
 	// BackupRestoreDistroless is the key for the etcd-backup-restore image in the image vector.
 	BackupRestoreDistroless = "etcd-backup-restore-distroless"
+	// Alpine is the key for the alpine image in the image vector.
+	Alpine = "alpine"
 	// ChartPath is the directory containing the default image vector file.
 	ChartPath = "charts"
 	// GardenerOwnedBy is a constant for an annotation on a resource that describes the owner resource.

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -495,11 +495,12 @@ func (c *component) createOrPatch(ctx context.Context, sts *appsv1.StatefulSet, 
 			// TODO: @aaronfern add this back to sts.Spec when UseEtcdWrapper becomes GA
 			sts.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
-					Name:         "change-permissions",
-					Image:        "alpine:3.18.2",
-					Command:      []string{"sh", "-c", "--"},
-					Args:         []string{"chown -R 65532:65532 /var/etcd/data"},
-					VolumeMounts: getEtcdVolumeMounts(c.values),
+					Name:            "change-permissions",
+					Image:           c.values.InitContainerImage,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"sh", "-c", "--"},
+					Args:            []string{"chown -R 65532:65532 /var/etcd/data"},
+					VolumeMounts:    getEtcdVolumeMounts(c.values),
 					SecurityContext: &corev1.SecurityContext{
 						RunAsGroup:   pointer.Int64(0),
 						RunAsNonRoot: pointer.Bool(false),
@@ -513,11 +514,12 @@ func (c *component) createOrPatch(ctx context.Context, sts *appsv1.StatefulSet, 
 				prov, _ := utils.StorageProviderFromInfraProvider(c.values.BackupStore.Provider)
 				if prov == utils.Local {
 					sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers, corev1.Container{
-						Name:         "change-backup-bucket-permissions",
-						Image:        "alpine:3.18.2",
-						Command:      []string{"sh", "-c", "--"},
-						Args:         []string{fmt.Sprintf("chown -R 65532:65532 /home/nonroot/%s", *c.values.BackupStore.Container)},
-						VolumeMounts: getBackupRestoreVolumeMounts(c),
+						Name:            "change-backup-bucket-permissions",
+						Image:           c.values.InitContainerImage,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Command:         []string{"sh", "-c", "--"},
+						Args:            []string{fmt.Sprintf("chown -R 65532:65532 /home/nonroot/%s", *c.values.BackupStore.Container)},
+						VolumeMounts:    getBackupRestoreVolumeMounts(c),
 						SecurityContext: &corev1.SecurityContext{
 							RunAsGroup:   pointer.Int64(0),
 							RunAsNonRoot: pointer.Bool(false),

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -64,6 +64,7 @@ var (
 	uid                           = "a9b8c7d6e5f4"
 	imageEtcd                     = "eu.gcr.io/gardener-project/gardener/etcd-wrapper:v0.1.0"
 	imageBR                       = "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.25.0"
+	imageInitContainer            = "alpine:3.18.2"
 	snapshotSchedule              = "0 */24 * * *"
 	defragSchedule                = "0 */24 * * *"
 	container                     = "default.bkp"
@@ -140,6 +141,7 @@ var _ = Describe("Statefulset", func() {
 			pointer.Int32(backupPort),
 			imageEtcd,
 			imageBR,
+			imageInitContainer,
 			checkSumAnnotations,
 			false,
 			true,
@@ -398,6 +400,7 @@ var _ = Describe("Statefulset", func() {
 						pointer.Int32(backupPort),
 						imageEtcd,
 						imageBR,
+						imageInitContainer,
 						checkSumAnnotations, false, true)
 					Expect(err).ToNot(HaveOccurred())
 					fg := map[featuregate.Feature]bool{

--- a/pkg/component/etcd/statefulset/values.go
+++ b/pkg/component/etcd/statefulset/values.go
@@ -47,6 +47,8 @@ type Values struct {
 	BackupImage string
 	// EtcdImage is the etcd custom image.
 	EtcdImage string
+	// InitContainerImage is the image used in the init container in the etcd pod
+	InitContainerImage string
 	// PriorityClassName is the Priority Class name.
 	PriorityClassName *string
 	// ServiceAccountName is the service account name.

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -46,7 +46,7 @@ var defaultStorageCapacity = resource.MustParse("16Gi")
 func GenerateValues(
 	etcd *druidv1alpha1.Etcd,
 	clientPort, serverPort, backupPort *int32,
-	etcdImage, backupImage string,
+	etcdImage, backupImage, initContainerImage string,
 	checksumAnnotations map[string]string,
 	peerTLSChangedToEnabled, useEtcdWrapper bool) (*Values, error) {
 
@@ -66,6 +66,7 @@ func GenerateValues(
 		AdditionalPodLabels:       etcd.Spec.Labels,
 		EtcdImage:                 etcdImage,
 		BackupImage:               backupImage,
+		InitContainerImage:        initContainerImage,
 		PriorityClassName:         etcd.Spec.PriorityClassName,
 		ServiceAccountName:        etcd.GetServiceAccountName(),
 		Affinity:                  etcd.Spec.SchedulingConstraints.Affinity,

--- a/pkg/utils/image.go
+++ b/pkg/utils/image.go
@@ -21,7 +21,8 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func getEtcdImageKeys(useEtcdWrapper bool) (etcdImageKey string, etcdbrImageKey string) {
+func getEtcdImageKeys(useEtcdWrapper bool) (etcdImageKey string, etcdbrImageKey string, alpine string) {
+	alpine = common.Alpine
 	switch useEtcdWrapper {
 	case true:
 		etcdImageKey = common.EtcdWrapper
@@ -33,22 +34,27 @@ func getEtcdImageKeys(useEtcdWrapper bool) (etcdImageKey string, etcdbrImageKey 
 	return
 }
 
-// GetEtcdImages returns images for etcd and backup-restore by inspecting the etcd spec and the image vector.
+// GetEtcdImages returns images for etcd and backup-restore by inspecting the etcd spec and the image vector
+// and returns the image for the init container by inspecting the image vector.
 // It will give preference to images that are set in the etcd spec and only if the image is not found in it should
 // it be picked up from the image vector if it's set there.
 // A return value of nil for either of the images indicates that the image is not set.
-func GetEtcdImages(etcd *druidv1alpha1.Etcd, iv imagevector.ImageVector, useEtcdWrapper bool) (*string, *string, error) {
-	etcdImageKey, etcdbrImageKey := getEtcdImageKeys(useEtcdWrapper)
+func GetEtcdImages(etcd *druidv1alpha1.Etcd, iv imagevector.ImageVector, useEtcdWrapper bool) (*string, *string, *string, error) {
+	etcdImageKey, etcdbrImageKey, initContainerImageKey := getEtcdImageKeys(useEtcdWrapper)
 	etcdImage, err := chooseImage(etcdImageKey, etcd.Spec.Etcd.Image, iv)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	etcdBackupRestoreImage, err := chooseImage(etcdbrImageKey, etcd.Spec.Backup.Image, iv)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
+	}
+	initContainerImage, err := chooseImage(initContainerImageKey, nil, iv)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
-	return etcdImage, etcdBackupRestoreImage, nil
+	return etcdImage, etcdBackupRestoreImage, initContainerImage, nil
 }
 
 // chooseImage selects an image based on the given key, specImage, and image vector.
@@ -67,6 +73,11 @@ func chooseImage(key string, specImage *string, iv imagevector.ImageVector) (*st
 
 // GetEtcdBackupRestoreImage returns the image for backup-restore from the given image vector.
 func GetEtcdBackupRestoreImage(iv imagevector.ImageVector, useEtcdWrapper bool) (*string, error) {
-	_, etcdbrImageKey := getEtcdImageKeys(useEtcdWrapper)
+	_, etcdbrImageKey, _ := getEtcdImageKeys(useEtcdWrapper)
 	return chooseImage(etcdbrImageKey, nil, iv)
+}
+
+// GetInitContainerImage returns the image for init container from the given image vector.
+func GetInitContainerImage(iv imagevector.ImageVector) (*string, error) {
+	return chooseImage(common.Alpine, nil, iv)
 }

--- a/pkg/utils/image_test.go
+++ b/pkg/utils/image_test.go
@@ -40,12 +40,15 @@ var _ = Describe("Image retrieval tests", func() {
 	It("etcd spec defines etcd and backup-restore images", func() {
 		etcd = testutils.EtcdBuilderWithDefaults(etcdName, namespace).Build()
 		imageVector = createImageVector(true, true, false, false)
-		etcdImage, etcdBackupRestoreImage, err := GetEtcdImages(etcd, imageVector, false)
+		etcdImage, etcdBackupRestoreImage, initContainerImage, err := GetEtcdImages(etcd, imageVector, false)
 		Expect(err).To(BeNil())
 		Expect(etcdImage).ToNot(BeNil())
 		Expect(etcdImage).To(Equal(etcd.Spec.Etcd.Image))
 		Expect(etcdBackupRestoreImage).ToNot(BeNil())
 		Expect(etcdBackupRestoreImage).To(Equal(etcd.Spec.Backup.Image))
+		vectorInitContainerImage, err := imageVector.FindImage(common.Alpine)
+		Expect(err).To(BeNil())
+		Expect(*initContainerImage).To(Equal(vectorInitContainerImage.String()))
 	})
 
 	It("etcd spec has no image defined and image vector has both images set", func() {
@@ -54,7 +57,7 @@ var _ = Describe("Image retrieval tests", func() {
 		etcd.Spec.Etcd.Image = nil
 		etcd.Spec.Backup.Image = nil
 		imageVector = createImageVector(true, true, false, false)
-		etcdImage, etcdBackupRestoreImage, err := GetEtcdImages(etcd, imageVector, false)
+		etcdImage, etcdBackupRestoreImage, initContainerImage, err := GetEtcdImages(etcd, imageVector, false)
 		Expect(err).To(BeNil())
 		Expect(etcdImage).ToNot(BeNil())
 		vectorEtcdImage, err := imageVector.FindImage(common.Etcd)
@@ -64,6 +67,9 @@ var _ = Describe("Image retrieval tests", func() {
 		vectorBackupRestoreImage, err := imageVector.FindImage(common.BackupRestore)
 		Expect(err).To(BeNil())
 		Expect(*etcdBackupRestoreImage).To(Equal(vectorBackupRestoreImage.String()))
+		vectorInitContainerImage, err := imageVector.FindImage(common.Alpine)
+		Expect(err).To(BeNil())
+		Expect(*initContainerImage).To(Equal(vectorInitContainerImage.String()))
 	})
 
 	It("etcd spec only has backup-restore image and image-vector has only etcd image", func() {
@@ -71,7 +77,7 @@ var _ = Describe("Image retrieval tests", func() {
 		Expect(err).To(BeNil())
 		etcd.Spec.Etcd.Image = nil
 		imageVector = createImageVector(true, false, false, false)
-		etcdImage, etcdBackupRestoreImage, err := GetEtcdImages(etcd, imageVector, false)
+		etcdImage, etcdBackupRestoreImage, initContainerImage, err := GetEtcdImages(etcd, imageVector, false)
 		Expect(err).To(BeNil())
 		Expect(etcdImage).ToNot(BeNil())
 		vectorEtcdImage, err := imageVector.FindImage(common.Etcd)
@@ -79,6 +85,9 @@ var _ = Describe("Image retrieval tests", func() {
 		Expect(*etcdImage).To(Equal(vectorEtcdImage.String()))
 		Expect(etcdBackupRestoreImage).ToNot(BeNil())
 		Expect(etcdBackupRestoreImage).To(Equal(etcd.Spec.Backup.Image))
+		vectorInitContainerImage, err := imageVector.FindImage(common.Alpine)
+		Expect(err).To(BeNil())
+		Expect(*initContainerImage).To(Equal(vectorInitContainerImage.String()))
 	})
 
 	It("both spec and image vector do not have backup-restore image", func() {
@@ -86,10 +95,11 @@ var _ = Describe("Image retrieval tests", func() {
 		Expect(err).To(BeNil())
 		etcd.Spec.Backup.Image = nil
 		imageVector = createImageVector(true, false, false, false)
-		etcdImage, etcdBackupRestoreImage, err := GetEtcdImages(etcd, imageVector, false)
+		etcdImage, etcdBackupRestoreImage, initContainerImage, err := GetEtcdImages(etcd, imageVector, false)
 		Expect(err).ToNot(BeNil())
 		Expect(etcdImage).To(BeNil())
 		Expect(etcdBackupRestoreImage).To(BeNil())
+		Expect(initContainerImage).To(BeNil())
 	})
 
 	It("etcd spec has no images defined, image vector has all images, and UseEtcdWrapper feature gate is turned on", func() {
@@ -98,7 +108,7 @@ var _ = Describe("Image retrieval tests", func() {
 		etcd.Spec.Etcd.Image = nil
 		etcd.Spec.Backup.Image = nil
 		imageVector = createImageVector(true, true, true, true)
-		etcdImage, etcdBackupRestoreImage, err := GetEtcdImages(etcd, imageVector, true)
+		etcdImage, etcdBackupRestoreImage, initContainerImage, err := GetEtcdImages(etcd, imageVector, true)
 		Expect(err).To(BeNil())
 		Expect(etcdImage).ToNot(BeNil())
 		vectorEtcdImage, err := imageVector.FindImage(common.EtcdWrapper)
@@ -108,6 +118,9 @@ var _ = Describe("Image retrieval tests", func() {
 		vectorBackupRestoreImage, err := imageVector.FindImage(common.BackupRestoreDistroless)
 		Expect(err).To(BeNil())
 		Expect(*etcdBackupRestoreImage).To(Equal(vectorBackupRestoreImage.String()))
+		vectorInitContainerImage, err := imageVector.FindImage(common.Alpine)
+		Expect(err).To(BeNil())
+		Expect(*initContainerImage).To(Equal(vectorInitContainerImage.String()))
 	})
 })
 
@@ -119,6 +132,7 @@ func createImageVector(withEtcdImage, withBackupRestoreImage, withEtcdWrapperIma
 		etcdWrapperTag             = "etcd-wrapper-test-tag"
 		backupRestoreTag           = "backup-restore-test-tag"
 		backupRestoreDistrolessTag = "backup-restore-distroless-test-tag"
+		initContainerTag           = "init-container-test-tag"
 	)
 	if withEtcdImage {
 		imageSources = append(imageSources, &imagevector.ImageSource{
@@ -149,5 +163,10 @@ func createImageVector(withEtcdImage, withBackupRestoreImage, withEtcdWrapperIma
 			Tag:        pointer.String(backupRestoreDistrolessTag),
 		})
 	}
+	imageSources = append(imageSources, &imagevector.ImageSource{
+		Name:       common.Alpine,
+		Repository: repo,
+		Tag:        pointer.String(initContainerTag),
+	})
 	return imageSources
 }


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug enhancement

**What this PR does / why we need it**:
Cherry pick of [`227c87`](https://github.com/gardener/etcd-druid/commit/227c8765cee5fb8700ab853c79df76260ddeaf73)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator github.com/gardener/etcd-druid #714 @aaronfern  
Alpine image used in init containers is now part of the IMAGEVECTOR_OVERWRITE
```
