### PR TITLE
Adds e2e test for compaction

### DIFF
--- a/charts/druid/templates/controller-deployment.yaml
+++ b/charts/druid/templates/controller-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         - --ignore-operation-annotation={{ .Values.ignoreOperationAnnotation }}
         - --workers=3
         - --custodian-sync-period=15s
+        - --enable-backup-compaction={{ .Values.enableBackupCompaction }}
+        - --etcd-events-threshold={{ .Values.eventsThreshold }}
+        - --metrics-scrape-wait-duration={{ .Values.metricsScrapeWaitDuration }}
         {{- if .Values.featureGates }}
         {{- $featuregates := "" }}
         {{- range $feature, $value := $.Values.featureGates }}

--- a/charts/druid/templates/controller-deployment.yaml
+++ b/charts/druid/templates/controller-deployment.yaml
@@ -26,9 +26,16 @@ spec:
         - --ignore-operation-annotation={{ .Values.ignoreOperationAnnotation }}
         - --workers=3
         - --custodian-sync-period=15s
+        {{- if .Values.enableBackupCompaction }}
         - --enable-backup-compaction={{ .Values.enableBackupCompaction }}
+        {{- end }}
+        {{- if .Values.eventsThreshold }}
         - --etcd-events-threshold={{ .Values.eventsThreshold }}
+        {{- end }}
+        {{- if .Values.metricsScrapeWaitDuration }}
         - --metrics-scrape-wait-duration={{ .Values.metricsScrapeWaitDuration }}
+        {{- end }}
+
         {{- if .Values.featureGates }}
         {{- $featuregates := "" }}
         {{- range $feature, $value := $.Values.featureGates }}

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -9,5 +9,5 @@ ignoreOperationAnnotation: false
 # enableBackupCompaction: true
 # eventsThreshold: 15
 # metricsScrapeWaitDuration: "10s"
-featureGates:
-  UseEtcdWrapper: false
+# featureGates:
+#   UseEtcdWrapper: true

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -6,8 +6,8 @@ image:
   imagePullPolicy: IfNotPresent
 replicas: 1
 ignoreOperationAnnotation: false
-enableBackupCompaction: true
-eventsThreshold: 15
-metricsScrapeWaitDuration: "10s"
+# enableBackupCompaction: true
+# eventsThreshold: 15
+# metricsScrapeWaitDuration: "10s"
 featureGates:
   UseEtcdWrapper: false

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -6,5 +6,8 @@ image:
   imagePullPolicy: IfNotPresent
 replicas: 1
 ignoreOperationAnnotation: false
-# featureGates:
-#   UseEtcdWrapper: true
+enableBackupCompaction: true
+eventsThreshold: 15
+metricsScrapeWaitDuration: "10s"
+featureGates:
+  UseEtcdWrapper: false

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -21,18 +21,20 @@ deploy:
         image: eu.gcr.io/gardener-project/gardener/etcd-druid
       imageStrategy:
         helm: {}
-      # Dependency builds create new dep archives and thus circumvent Docker's build cache at the next run.
       skipBuildDependencies: true
+      setValues:
+        enableBackupCompaction: "true" # Set the default value or specify it dynamically
+        eventsThreshold: 15 # Example value, adjust as needed
+        metricsScrapeWaitDuration: "30s" # Example value, adjust as needed
 profiles:
 - name: use-feature-gates
   activation:
   - env: "USE_ETCD_DRUID_FEATURE_GATES=true"
   patches:
   - op: add
-    path: /deploy/helm/releases/0/setValues
+    path: /deploy/helm/releases/0/setValues/featureGates
     value:
-      featureGates:
-        UseEtcdWrapper: true
+      UseEtcdWrapper: true
 ---
 apiVersion: skaffold/v2beta25
 kind: Config

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -23,9 +23,9 @@ deploy:
         helm: {}
       skipBuildDependencies: true
       setValues:
-        enableBackupCompaction: "true" # Set the default value or specify it dynamically
-        eventsThreshold: 15 # Example value, adjust as needed
-        metricsScrapeWaitDuration: "30s" # Example value, adjust as needed
+        enableBackupCompaction: "true"
+        eventsThreshold: 15
+        metricsScrapeWaitDuration: "30s"
 profiles:
 - name: use-feature-gates
   activation:

--- a/test/e2e/etcd_compaction_test.go
+++ b/test/e2e/etcd_compaction_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	brtypes "github.com/gardener/etcd-backup-restore/pkg/types"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Etcd Compaction", func() {
+	var (
+		parentCtx context.Context
+	)
+
+	BeforeEach(func() {
+		parentCtx = context.Background()
+	})
+
+	Context("when compaction is enabled for single-node etcd", func() {
+		providers, err := getProviders()
+		Expect(err).ToNot(HaveOccurred())
+
+		var (
+			cl               client.Client
+			etcdName         string
+			storageContainer string
+		)
+
+		for _, p := range providers {
+			provider := p
+			Context(fmt.Sprintf("with provider %s", provider.Name), func() {
+				BeforeEach(func() {
+					cl, err = getKubernetesClient(kubeconfigPath)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					etcdName = fmt.Sprintf("etcd-%s", provider.Name)
+
+					storageContainer = getEnvAndExpectNoError(envStorageContainer)
+
+					snapstoreProvider := provider.Storage.Provider
+					store, err := getSnapstore(string(snapstoreProvider), storageContainer, storePrefix)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// purge any existing backups in bucket
+					Expect(purgeSnapstore(store)).To(Succeed())
+
+					Expect(deployBackupSecret(parentCtx, cl, logger, provider, etcdNamespace, storageContainer))
+				})
+
+				It("Should test compaction on backup", func() {
+					ctx, cancelFunc := context.WithTimeout(parentCtx, 10*time.Minute)
+					defer cancelFunc()
+
+					etcd := getDefaultEtcd(etcdName, namespace, storageContainer, storePrefix, provider)
+					objLogger := logger.WithValues("etcd", client.ObjectKeyFromObject(etcd))
+
+					By("Create etcd")
+					createAndCheckEtcd(ctx, cl, objLogger, etcd, singleNodeEtcdTimeout)
+
+					By("Create debug pod")
+					debugPod := createDebugPod(ctx, etcd)
+
+					By("Check initial snapshot is available")
+
+					latestSnapshotsBeforePopulate, err := getLatestSnapshots(kubeconfigPath, namespace, etcdName, debugPod.Name, debugPod.Spec.Containers[0].Name, 8080)
+					Expect(err).ShouldNot(HaveOccurred())
+					// We don't expect any delta snapshot as the cluster
+					Expect(latestSnapshotsBeforePopulate.DeltaSnapshots).To(HaveLen(0))
+
+					latestSnapshotBeforePopulate := latestSnapshotsBeforePopulate.FullSnapshot
+					Expect(latestSnapshotBeforePopulate).To(Not(BeNil()))
+
+					By("Put keys into etcd")
+					logger.Info("populating etcd with sequential key-value pairs",
+						"fromKey", fmt.Sprintf("%s-1", etcdKeyPrefix), "fromValue", fmt.Sprintf("%s-1", etcdValuePrefix),
+						"toKey", fmt.Sprintf("%s-10", etcdKeyPrefix), "toValue", fmt.Sprintf("%s-10", etcdValuePrefix))
+
+					// populate 10 keys in etcd, finishing in 10 seconds
+					err = populateEtcd(logger, kubeconfigPath, namespace, etcdName, debugPod.Name, debugPod.Spec.Containers[0].Name, etcdKeyPrefix, etcdValuePrefix, 1, 10, time.Second*1)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					By("Check snapshot after putting data into etcd")
+					// allow 5 second buffer to upload full/delta snapshot
+					time.Sleep(time.Second * 5)
+
+					latestSnapshotsAfterPopulate, err := getLatestSnapshots(kubeconfigPath, namespace, etcdName, debugPod.Name, debugPod.Spec.Containers[0].Name, 8080)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					latestSnapshotAfterPopulate := latestSnapshotsAfterPopulate.FullSnapshot
+					if numDeltas := len(latestSnapshotsAfterPopulate.DeltaSnapshots); numDeltas > 0 {
+						latestSnapshotAfterPopulate = latestSnapshotsAfterPopulate.DeltaSnapshots[numDeltas-1]
+					}
+
+					Expect(latestSnapshotsAfterPopulate).To(Not(BeNil()))
+					Expect(latestSnapshotAfterPopulate.CreatedOn.After(latestSnapshotBeforePopulate.CreatedOn)).To(BeTrue())
+
+					By("Put additional data into etcd")
+					logger.Info("populating etcd with sequential key-value pairs",
+						"fromKey", fmt.Sprintf("%s-11", etcdKeyPrefix), "fromValue", fmt.Sprintf("%s-11", etcdValuePrefix),
+						"toKey", fmt.Sprintf("%s-15", etcdKeyPrefix), "toValue", fmt.Sprintf("%s-15", etcdValuePrefix))
+					// populate 5 keys in etcd, finishing in 5 seconds
+					err = populateEtcd(logger, kubeconfigPath, namespace, etcdName, debugPod.Name, debugPod.Spec.Containers[0].Name, etcdKeyPrefix, etcdValuePrefix, 11, 15, time.Second*1)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					By("Trigger on-demand delta snapshot")
+					_, err = triggerOnDemandSnapshot(kubeconfigPath, namespace, etcdName, debugPod.Name, debugPod.Spec.Containers[0].Name, 8080, brtypes.SnapshotKindDelta)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					logger.Info("waiting for compaction job to become successful")
+					Eventually(func() error {
+						ctx, cancelFunc := context.WithTimeout(context.Background(), singleNodeEtcdTimeout)
+						defer cancelFunc()
+
+						req := types.NamespacedName{
+							Name:      etcd.GetCompactionJobName(),
+							Namespace: etcd.Namespace,
+						}
+
+						j := &batchv1.Job{}
+						if err := cl.Get(ctx, req, j); err != nil {
+							return err
+						}
+
+						if j.Status.Succeeded < 1 {
+							return fmt.Errorf("compaction job started but not yet successful")
+						}
+
+						return nil
+					}, singleNodeEtcdTimeout, pollingInterval).Should(BeNil())
+					logger.Info("compaction job is successful")
+
+					// allow 5 second buffer to upload full/delta snapshot
+					time.Sleep(time.Second * 5)
+
+					By("Verify that there is no delta snapshot as compaction would trigger at first 15th revision")
+					latestSnapshotsAfterPopulate, err = getLatestSnapshots(kubeconfigPath, namespace, etcdName, debugPod.Name, debugPod.Spec.Containers[0].Name, 8080)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					Expect(len(latestSnapshotsAfterPopulate.DeltaSnapshots)).Should(BeNumerically("==", 0))
+
+					By("Put additional data into etcd")
+					logger.Info("populating etcd with sequential key-value pairs",
+						"fromKey", fmt.Sprintf("%s-16", etcdKeyPrefix), "fromValue", fmt.Sprintf("%s-16", etcdValuePrefix),
+						"toKey", fmt.Sprintf("%s-20", etcdKeyPrefix), "toValue", fmt.Sprintf("%s-20", etcdValuePrefix))
+					// populate 5 keys in etcd, finishing in 5 seconds
+					err = populateEtcd(logger, kubeconfigPath, namespace, etcdName, debugPod.Name, debugPod.Spec.Containers[0].Name, etcdKeyPrefix, etcdValuePrefix, 16, 20, time.Second*1)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					By("Trigger on-demand delta snapshot")
+					_, err = triggerOnDemandSnapshot(kubeconfigPath, namespace, etcdName, debugPod.Name, debugPod.Spec.Containers[0].Name, 8080, brtypes.SnapshotKindDelta)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					By("Verify that there are new delta snapshots as compaction is not triggered yet because delta events have not reached next 15 revision")
+					latestSnapshotsAfterPopulate, err = getLatestSnapshots(kubeconfigPath, namespace, etcdName, debugPod.Name, debugPod.Spec.Containers[0].Name, 8080)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					Expect(len(latestSnapshotsAfterPopulate.DeltaSnapshots)).Should(BeNumerically(">", 0))
+
+					By("Delete debug pod")
+					Expect(cl.Delete(ctx, debugPod)).ToNot(HaveOccurred())
+
+					By("Delete etcd")
+					deleteAndCheckEtcd(ctx, cl, objLogger, etcd, singleNodeEtcdTimeout)
+				})
+			})
+		}
+	})
+})

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/gardener/etcd-druid/api/v1alpha1"
-
 	"github.com/gardener/gardener/pkg/utils/test/matchers"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	singleNodeEtcdTimeout = time.Minute
+	singleNodeEtcdTimeout = time.Minute * 3
 	multiNodeEtcdTimeout  = time.Minute * 5
 
 	pollingInterval   = time.Second * 2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind test

**What this PR does / why we need it**:
This PR adds e2e test for compaction in druid

**Which issue(s) this PR fixes**:
Fixes #704 

**Special notes for your reviewer**:
As we don't have the new release of etcd backup-restore that supports on demand latest snapshot fetch from actual object storage, I used a custom image of etcd backup-restore that support on-demand latest snapshot from actual object storage. Please, delete the commit with the name `Uses a custom etcdbrctl image that supports latest snapshot pulled from actual storage.` from this PR, once a release is made for etcd backup-restore.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
Added e2e test for compaction.
```
