### PR TITLE
Update alpine image version to 3.18.4

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -21,4 +21,4 @@ images:
   tag: "v0.1.0"
 - name: alpine
   repository: eu.gcr.io/gardener-project/3rd/alpine
-  tag: "3.15.8"
+  tag: "3.18.4"

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -64,7 +64,7 @@ var (
 	uid                           = "a9b8c7d6e5f4"
 	imageEtcd                     = "eu.gcr.io/gardener-project/gardener/etcd-wrapper:v0.1.0"
 	imageBR                       = "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.25.0"
-	imageInitContainer            = "alpine:3.18.2"
+	imageInitContainer            = "eu.gcr.io/gardener-project/3rd/alpine:3.18.4"
 	snapshotSchedule              = "0 */24 * * *"
 	defragSchedule                = "0 */24 * * *"
 	container                     = "default.bkp"

--- a/test/integration/controllers/compaction/reconciler_test.go
+++ b/test/integration/controllers/compaction/reconciler_test.go
@@ -619,7 +619,7 @@ func createCompactionJob(instance *druidv1alpha1.Etcd) *batchv1.Job {
 					Containers: []corev1.Container{
 						{
 							Name:    "compact-backup",
-							Image:   "eu.gcr.io/gardener-project/alpine:3.14",
+							Image:   "eu.gcr.io/gardener-project/3rd/alpine:3.18.4",
 							Command: []string{"sh", "-c", "tail -f /dev/null"},
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Update alpine image version to `3.18.4` (latest version as of today), to be used by the init container when `UseEtcdWrapper` feature gate is enabled. Additionally update tests to use the same image version as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/assign @aaronfern @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update alpine image version to `3.18.4`.
```
