### PR TITLE
Upgrade etcd-backup-restore from `v0.24.6 -> v0.24.7` and Upgrade etcd-backup-restore-distroless from `v0.26.0 -> v0.27.0`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -4,7 +4,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.24.6"
+  tag: "v0.24.7"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: eu.gcr.io/gardener-project/gardener/etcd
@@ -14,7 +14,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.26.0"
+  tag: "v0.27.0"
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: eu.gcr.io/gardener-project/gardener/etcd-wrapper


### PR DESCRIPTION
**Release Notes**:
```noteworthy operator github.com/gardener/etcd-backup-restore #668 @ishan16696
Fix a restoration failure which can occurs due to an etcd database space exceeds during restoration.
```

```improvement user github.com/gardener/etcd-backup-restore #675 @abdasgupta
The snapshots are fetched from the actual backend store when queried for latest snapshots on `/snapshot/latest` endpoint.
```


```improvement operator github.com/gardener/etcd-backup-restore #673 @anveshreddy18
Enhanced Garbage Collector to garbage collect the chunks for cloud providers like GCP and OpenStack which does not automatically delete snapshot chunks after the formation of a composite object.
```

```noteworthy operator github.com/gardener/etcd-backup-restore #661 @ishan16696
Making etcd-backup-restore restart tolerant while scaling-up an etcd cluster.
```
