### PR TITLE
Add support for overriding storage API endpoint for GCS

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -33,18 +33,34 @@ const (
 	GardenerOwnerType = "gardener.cloud/owner-type"
 	// FinalizerName is the name of the etcd finalizer.
 	FinalizerName = "druid.gardener.cloud/etcd-druid"
-	// STORAGE_CONTAINER is the environment variable key for the storage container.
-	STORAGE_CONTAINER = "STORAGE_CONTAINER"
-	// AWS_APPLICATION_CREDENTIALS is the environment variable key for AWS application credentials.
-	AWS_APPLICATION_CREDENTIALS = "AWS_APPLICATION_CREDENTIALS"
-	// AZURE_APPLICATION_CREDENTIALS is the environment variable key for Azure application credentials.
-	AZURE_APPLICATION_CREDENTIALS = "AZURE_APPLICATION_CREDENTIALS"
-	// GOOGLE_APPLICATION_CREDENTIALS is the environment variable key for Google application credentials.
-	GOOGLE_APPLICATION_CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS"
-	// OPENSTACK_APPLICATION_CREDENTIALS is the environment variable key for OpenStack application credentials.
-	OPENSTACK_APPLICATION_CREDENTIALS = "OPENSTACK_APPLICATION_CREDENTIALS"
-	// OPENSHIFT_APPLICATION_CREDENTIALS is the environment variable key for OpenShift application credentials.
-	OPENSHIFT_APPLICATION_CREDENTIALS = "OPENSHIFT_APPLICATION_CREDENTIALS"
-	// ALICLOUD_APPLICATION_CREDENTIALS is the environment variable key for Alicloud application credentials.
-	ALICLOUD_APPLICATION_CREDENTIALS = "ALICLOUD_APPLICATION_CREDENTIALS"
+
+	// EnvPodName is the environment variable key for the pod name.
+	EnvPodName = "POD_NAME"
+	// EnvPodNamespace is the environment variable key for the pod namespace.
+	EnvPodNamespace = "POD_NAMESPACE"
+	// EnvStorageContainer is the environment variable key for the storage container.
+	EnvStorageContainer = "STORAGE_CONTAINER"
+	// EnvSourceStorageContainer is the environment variable key for the source storage container.
+	EnvSourceStorageContainer = "SOURCE_STORAGE_CONTAINER"
+
+	// EnvAWSApplicationCredentials is the environment variable key for AWS application credentials.
+	EnvAWSApplicationCredentials = "AWS_APPLICATION_CREDENTIALS"
+	// EnvAzureApplicationCredentials is the environment variable key for Azure application credentials.
+	EnvAzureApplicationCredentials = "AZURE_APPLICATION_CREDENTIALS"
+	// EnvGoogleApplicationCredentials is the environment variable key for Google application credentials.
+	EnvGoogleApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
+	// EnvGoogleStorageAPIEndpoint is the environment variable key for Google storage API endpoint override.
+	EnvGoogleStorageAPIEndpoint = "GOOGLE_STORAGE_API_ENDPOINT"
+	// EnvOpenstackApplicationCredentials is the environment variable key for OpenStack application credentials.
+	EnvOpenstackApplicationCredentials = "OPENSTACK_APPLICATION_CREDENTIALS"
+	// EnvAlicloudApplicationCredentials is the environment variable key for Alicloud application credentials.
+	EnvAlicloudApplicationCredentials = "ALICLOUD_APPLICATION_CREDENTIALS"
+	// EnvOpenshiftApplicationCredentials is the environment variable key for OpenShift application credentials.
+	EnvOpenshiftApplicationCredentials = "OPENSHIFT_APPLICATION_CREDENTIALS"
+	// EnvECSEndpoint is the environment variable key for Dell ECS endpoint.
+	EnvECSEndpoint = "ECS_ENDPOINT"
+	// EnvECSAccessKeyID is the environment variable key for Dell ECS access key ID.
+	EnvECSAccessKeyID = "ECS_ACCESS_KEY_ID"
+	// EnvECSSecretAccessKey is the environment variable key for Dell ECS secret access key.
+	EnvECSSecretAccessKey = "ECS_SECRET_ACCESS_KEY"
 )

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -555,23 +555,23 @@ func checkBackup(etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) {
 
 	switch *etcd.Spec.Backup.Store.Provider {
 	case druidutils.S3:
-		envVarName = "AWS_APPLICATION_CREDENTIALS"
+		envVarName = common.EnvAWSApplicationCredentials
 
 	case druidutils.ABS:
-		envVarName = "AZURE_APPLICATION_CREDENTIALS"
+		envVarName = common.EnvAzureApplicationCredentials
 
 	case druidutils.GCS:
-		envVarName = "GOOGLE_APPLICATION_CREDENTIALS"
+		envVarName = common.EnvGoogleApplicationCredentials
 		envVarValue = "/var/.gcp/serviceaccount.json"
 
 	case druidutils.Swift:
-		envVarName = "OPENSTACK_APPLICATION_CREDENTIALS"
+		envVarName = common.EnvOpenstackApplicationCredentials
 
 	case druidutils.OSS:
-		envVarName = "ALICLOUD_APPLICATION_CREDENTIALS"
+		envVarName = common.EnvAlicloudApplicationCredentials
 
 	case druidutils.OCS:
-		envVarName = "OPENSHIFT_APPLICATION_CREDENTIALS"
+		envVarName = common.EnvOpenshiftApplicationCredentials
 	}
 
 	// Check env var
@@ -724,28 +724,28 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 								}),
 							}),
 							"Env": MatchElements(envIterator, IgnoreExtras, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*values.BackupStore.Container),
 								}),
-								"POD_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAME"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.name"),
 										})),
 									})),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"AZURE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("AZURE_APPLICATION_CREDENTIALS"),
+								common.EnvAzureApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvAzureApplicationCredentials),
 									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),

--- a/pkg/utils/envvar.go
+++ b/pkg/utils/envvar.go
@@ -1,0 +1,112 @@
+package utils
+
+import (
+	"fmt"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"github.com/gardener/etcd-druid/pkg/common"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+// GetEnvVarFromValue returns environment variable object with the provided name and value
+func GetEnvVarFromValue(name, value string) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name:  name,
+		Value: value,
+	}
+}
+
+// GetEnvVarFromFieldPath returns environment variable object with provided name and value from field path
+func GetEnvVarFromFieldPath(name, fieldPath string) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: name,
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: fieldPath,
+			},
+		},
+	}
+}
+
+// GetEnvVarFromSecret returns environment variable object with provided name and optional value from secret
+func GetEnvVarFromSecret(name, secretName, secretKey string, optional bool) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: name,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: secretName,
+				},
+				Key:      secretKey,
+				Optional: pointer.Bool(optional),
+			},
+		},
+	}
+}
+
+// GetProviderEnvVars returns provider-specific environment variables for the given store
+func GetProviderEnvVars(store *druidv1alpha1.StoreSpec) ([]corev1.EnvVar, error) {
+	var envVars []corev1.EnvVar
+
+	provider, err := StorageProviderFromInfraProvider(store.Provider)
+	if err != nil {
+		return nil, fmt.Errorf("storage provider is not recognized while fetching secrets from environment variable")
+	}
+
+	const credentialsMountPath = "/var/etcd-backup"
+	switch provider {
+	case S3:
+		envVars = append(envVars, GetEnvVarFromValue(common.EnvAWSApplicationCredentials, credentialsMountPath))
+
+	case ABS:
+		envVars = append(envVars, GetEnvVarFromValue(common.EnvAzureApplicationCredentials, credentialsMountPath))
+
+	case GCS:
+		envVars = append(envVars, GetEnvVarFromValue(common.EnvGoogleApplicationCredentials, "/var/.gcp/serviceaccount.json"))
+		envVars = append(envVars, GetEnvVarFromSecret(common.EnvGoogleStorageAPIEndpoint, store.SecretRef.Name, "storageAPIEndpoint", true))
+
+	case Swift:
+		envVars = append(envVars, GetEnvVarFromValue(common.EnvOpenstackApplicationCredentials, credentialsMountPath))
+
+	case OSS:
+		envVars = append(envVars, GetEnvVarFromValue(common.EnvAlicloudApplicationCredentials, credentialsMountPath))
+
+	case ECS:
+		if store.SecretRef == nil {
+			return nil, fmt.Errorf("no secretRef could be configured for backup store of ECS")
+		}
+		envVars = append(envVars, GetEnvVarFromSecret(common.EnvECSEndpoint, store.SecretRef.Name, "endpoint", false))
+		envVars = append(envVars, GetEnvVarFromSecret(common.EnvECSAccessKeyID, store.SecretRef.Name, "accessKeyID", false))
+		envVars = append(envVars, GetEnvVarFromSecret(common.EnvECSSecretAccessKey, store.SecretRef.Name, "secretAccessKey", false))
+
+	case OCS:
+		envVars = append(envVars, GetEnvVarFromValue(common.EnvOpenshiftApplicationCredentials, credentialsMountPath))
+	}
+
+	return envVars, nil
+}
+
+// GetBackupRestoreContainerEnvVars returns backup-restore container environment variables for the given store
+func GetBackupRestoreContainerEnvVars(store *druidv1alpha1.StoreSpec) ([]corev1.EnvVar, error) {
+	var envVars []corev1.EnvVar
+
+	envVars = append(envVars, GetEnvVarFromFieldPath(common.EnvPodName, "metadata.name"))
+	envVars = append(envVars, GetEnvVarFromFieldPath(common.EnvPodNamespace, "metadata.namespace"))
+
+	if store == nil {
+		return envVars, nil
+	}
+
+	storageContainer := pointer.StringDeref(store.Container, "")
+	envVars = append(envVars, GetEnvVarFromValue(common.EnvStorageContainer, storageContainer))
+
+	providerEnvVars, err := GetProviderEnvVars(store)
+	if err != nil {
+		return nil, err
+	}
+	envVars = append(envVars, providerEnvVars...)
+
+	return envVars, nil
+}

--- a/test/integration/controllers/compaction/reconciler_test.go
+++ b/test/integration/controllers/compaction/reconciler_test.go
@@ -19,16 +19,16 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/utils/test/matchers"
-
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"github.com/gardener/etcd-druid/pkg/common"
 	"github.com/gardener/etcd-druid/pkg/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
+
+	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -338,12 +338,20 @@ func validateEtcdForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.Job) 
 								}),
 							}),
 							"Env": MatchElements(testutils.EnvIterator, IgnoreExtras, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
+									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
+										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
+											"FieldPath": Equal("metadata.name"),
+										})),
+									})),
+								}),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
@@ -397,21 +405,41 @@ func validateStoreGCPForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.J
 								}),
 							}),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
+									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
+										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
+											"FieldPath": Equal("metadata.name"),
+										})),
+									})),
+								}),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"GOOGLE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("GOOGLE_APPLICATION_CREDENTIALS"),
+								common.EnvGoogleApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvGoogleApplicationCredentials),
 									"Value": Equal("/var/.gcp/serviceaccount.json"),
+								}),
+								common.EnvGoogleStorageAPIEndpoint: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvGoogleStorageAPIEndpoint),
+									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
+										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
+											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
+												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+											}),
+											"Key":      Equal("storageAPIEndpoint"),
+											"Optional": Equal(pointer.Bool(true)),
+										})),
+									})),
 								}),
 							}),
 						}),
@@ -445,20 +473,28 @@ func validateStoreAWSForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.J
 								fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container): Equal(fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container)),
 							}),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
+									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
+										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
+											"FieldPath": Equal("metadata.name"),
+										})),
+									})),
+								}),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"AWS_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("AWS_APPLICATION_CREDENTIALS"),
+								common.EnvAWSApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvAWSApplicationCredentials),
 									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
@@ -493,20 +529,28 @@ func validateStoreAzureForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1
 								fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container): Equal(fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container)),
 							}),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
+									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
+										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
+											"FieldPath": Equal("metadata.name"),
+										})),
+									})),
+								}),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"AZURE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("AZURE_APPLICATION_CREDENTIALS"),
+								common.EnvAzureApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvAzureApplicationCredentials),
 									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
@@ -541,20 +585,28 @@ func validateStoreOpenstackForCompactionJob(instance *druidv1alpha1.Etcd, j *bat
 								fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container): Equal(fmt.Sprintf("%s=%s", "--store-container", *instance.Spec.Backup.Store.Container)),
 							}),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
+									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
+										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
+											"FieldPath": Equal("metadata.name"),
+										})),
+									})),
+								}),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"OPENSTACK_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("OPENSTACK_APPLICATION_CREDENTIALS"),
+								common.EnvOpenstackApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvOpenstackApplicationCredentials),
 									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
@@ -590,20 +642,28 @@ func validateStoreAlicloudForCompactionJob(instance *druidv1alpha1.Etcd, j *batc
 							}),
 							"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
+									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
+										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
+											"FieldPath": Equal("metadata.name"),
+										})),
+									})),
+								}),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"ALICLOUD_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("ALICLOUD_APPLICATION_CREDENTIALS"),
+								common.EnvAlicloudApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvAlicloudApplicationCredentials),
 									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
@@ -643,36 +703,6 @@ func jobIsCorrectlyReconciled(c client.Client, instance *druidv1alpha1.Etcd, job
 	}
 
 	return nil
-}
-
-func createCompactionJob(instance *druidv1alpha1.Etcd) *batchv1.Job {
-	j := batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.GetCompactionJobName(),
-			Namespace: instance.Namespace,
-			Labels:    instance.Labels,
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit: pointer.Int32(0),
-			Completions:  pointer.Int32(1),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: instance.Labels,
-				},
-				Spec: corev1.PodSpec{
-					RestartPolicy: "Never",
-					Containers: []corev1.Container{
-						{
-							Name:    "compact-backup",
-							Image:   "eu.gcr.io/gardener-project/3rd/alpine:3.18.4",
-							Command: []string{"sh", "-c", "tail -f /dev/null"},
-						},
-					},
-				},
-			},
-		},
-	}
-	return &j
 }
 
 func etcdSnapshotLeaseIsCorrectlyReconciled(c client.Client, instance *druidv1alpha1.Etcd, lease *coordinationv1.Lease) error {

--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -748,20 +748,16 @@ func validateDefaultValuesForEtcd(instance *druidv1alpha1.Etcd, s *appsv1.Statef
 								}),
 							}),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
-									"Value": Equal(""),
-								}),
-								"POD_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAME"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.name"),
 										})),
 									})),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
@@ -1151,20 +1147,16 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 								}),
 							}),
 							"Env": MatchElements(testutils.EnvIterator, IgnoreExtras, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
-									"Value": Equal(*instance.Spec.Backup.Store.Container),
-								}),
-								"POD_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAME"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.name"),
 										})),
 									})),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
@@ -1294,29 +1286,41 @@ func validateStoreGCP(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *co
 								}),
 							}),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAME"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.name"),
 										})),
 									})),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"GOOGLE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("GOOGLE_APPLICATION_CREDENTIALS"),
+								common.EnvGoogleApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvGoogleApplicationCredentials),
 									"Value": Equal("/var/.gcp/serviceaccount.json"),
+								}),
+								common.EnvGoogleStorageAPIEndpoint: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvGoogleStorageAPIEndpoint),
+									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
+										"SecretKeyRef": PointTo(MatchFields(IgnoreExtras, Fields{
+											"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
+												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+											}),
+											"Key":      Equal("storageAPIEndpoint"),
+											"Optional": Equal(pointer.Bool(true)),
+										})),
+									})),
 								}),
 							}),
 						}),
@@ -1351,28 +1355,28 @@ func validateStoreAzure(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix): Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 							}),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAME"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.name"),
 										})),
 									})),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"AZURE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("AZURE_APPLICATION_CREDENTIALS"),
+								common.EnvAzureApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvAzureApplicationCredentials),
 									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
@@ -1407,28 +1411,28 @@ func validateStoreOpenstack(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet,
 								fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix): Equal(fmt.Sprintf("%s=%s", "--store-prefix", instance.Spec.Backup.Store.Prefix)),
 							}),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAME"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.name"),
 										})),
 									})),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"OPENSTACK_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("OPENSTACK_APPLICATION_CREDENTIALS"),
+								common.EnvOpenstackApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvOpenstackApplicationCredentials),
 									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
@@ -1465,28 +1469,28 @@ func validateStoreAlicloud(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, 
 							}),
 							"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAME"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.name"),
 										})),
 									})),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"ALICLOUD_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("ALICLOUD_APPLICATION_CREDENTIALS"),
+								common.EnvAlicloudApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvAlicloudApplicationCredentials),
 									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),
@@ -1523,28 +1527,28 @@ func validateStoreAWS(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *co
 							}),
 							"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
 							"Env": MatchAllElements(testutils.EnvIterator, Elements{
-								"STORAGE_CONTAINER": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("STORAGE_CONTAINER"),
+								common.EnvStorageContainer: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvStorageContainer),
 									"Value": Equal(*instance.Spec.Backup.Store.Container),
 								}),
-								"POD_NAME": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAME"),
+								common.EnvPodName: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodName),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.name"),
 										})),
 									})),
 								}),
-								"POD_NAMESPACE": MatchFields(IgnoreExtras, Fields{
-									"Name": Equal("POD_NAMESPACE"),
+								common.EnvPodNamespace: MatchFields(IgnoreExtras, Fields{
+									"Name": Equal(common.EnvPodNamespace),
 									"ValueFrom": PointTo(MatchFields(IgnoreExtras, Fields{
 										"FieldRef": PointTo(MatchFields(IgnoreExtras, Fields{
 											"FieldPath": Equal("metadata.namespace"),
 										})),
 									})),
 								}),
-								"AWS_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-									"Name":  Equal("AWS_APPLICATION_CREDENTIALS"),
+								common.EnvAWSApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+									"Name":  Equal(common.EnvAWSApplicationCredentials),
 									"Value": Equal("/var/etcd-backup"),
 								}),
 							}),

--- a/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
@@ -228,14 +228,14 @@ func getArgElements(task *druidv1alpha1.EtcdCopyBackupsTask, sourceProvider, tar
 func getEnvElements(task *druidv1alpha1.EtcdCopyBackupsTask) Elements {
 	elements := Elements{}
 	if task.Spec.TargetStore.Container != nil && *task.Spec.TargetStore.Container != "" {
-		elements["STORAGE_CONTAINER"] = MatchFields(IgnoreExtras, Fields{
-			"Name":  Equal("STORAGE_CONTAINER"),
+		elements[common.EnvStorageContainer] = MatchFields(IgnoreExtras, Fields{
+			"Name":  Equal(common.EnvStorageContainer),
 			"Value": Equal(*task.Spec.TargetStore.Container),
 		})
 	}
 	if task.Spec.SourceStore.Container != nil && *task.Spec.SourceStore.Container != "" {
-		elements["SOURCE_STORAGE_CONTAINER"] = MatchFields(IgnoreExtras, Fields{
-			"Name":  Equal("SOURCE_STORAGE_CONTAINER"),
+		elements[common.EnvSourceStorageContainer] = MatchFields(IgnoreExtras, Fields{
+			"Name":  Equal(common.EnvSourceStorageContainer),
 			"Value": Equal(*task.Spec.SourceStore.Container),
 		})
 	}
@@ -289,43 +289,43 @@ func getProviderEnvElements(storeProvider, prefix, volumePrefix string) Elements
 	switch storeProvider {
 	case "S3":
 		return Elements{
-			prefix + "AWS_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-				"Name":  Equal(prefix + "AWS_APPLICATION_CREDENTIALS"),
+			prefix + common.EnvAWSApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+				"Name":  Equal(prefix + common.EnvAWSApplicationCredentials),
 				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "ABS":
 		return Elements{
-			prefix + "AZURE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-				"Name":  Equal(prefix + "AZURE_APPLICATION_CREDENTIALS"),
+			prefix + common.EnvAzureApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+				"Name":  Equal(prefix + common.EnvAzureApplicationCredentials),
 				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "GCS":
 		return Elements{
-			prefix + "GOOGLE_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-				"Name":  Equal(prefix + "GOOGLE_APPLICATION_CREDENTIALS"),
+			prefix + common.EnvGoogleApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+				"Name":  Equal(prefix + common.EnvGoogleApplicationCredentials),
 				"Value": Equal(fmt.Sprintf("/var/.%sgcp/serviceaccount.json", volumePrefix)),
 			}),
 		}
 	case "Swift":
 		return Elements{
-			prefix + "OPENSTACK_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-				"Name":  Equal(prefix + "OPENSTACK_APPLICATION_CREDENTIALS"),
+			prefix + common.EnvOpenstackApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+				"Name":  Equal(prefix + common.EnvOpenstackApplicationCredentials),
 				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "OSS":
 		return Elements{
-			prefix + "ALICLOUD_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-				"Name":  Equal(prefix + "ALICLOUD_APPLICATION_CREDENTIALS"),
+			prefix + common.EnvAlicloudApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+				"Name":  Equal(prefix + common.EnvAlicloudApplicationCredentials),
 				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}
 	case "OCS":
 		return Elements{
-			prefix + "OPENSHIFT_APPLICATION_CREDENTIALS": MatchFields(IgnoreExtras, Fields{
-				"Name":  Equal(prefix + "OPENSHIFT_APPLICATION_CREDENTIALS"),
+			prefix + common.EnvOpenshiftApplicationCredentials: MatchFields(IgnoreExtras, Fields{
+				"Name":  Equal(prefix + common.EnvOpenshiftApplicationCredentials),
 				"Value": Equal(fmt.Sprintf("/var/%setcd-backup", volumePrefix)),
 			}),
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Add support for overriding storage API endpoint for Google GCS provider. This allows users to specify their own storage API [endpoint override](https://pkg.go.dev/cloud.google.com/go#hdr-Endpoint_Override), such as a [regional endpoint](https://cloud.google.com/storage/docs/regional-endpoints), or even a local GCS emulator endpoint. Users need to add a new field `storageAPIEndpoint` in their GCS backup secret, with the value in the format `http[s]://host[:port]/storage/v1/`, to utilise this feature.

Additionally, clean up some of the code and reduce duplicate code:
- combine `controllers/compaction.getCompactionJobEnvVar()` and `pkg/component/etcd/statefulset.getBackupRestoreEnvVars()` into `pkg/utils.GetBackupRestoreContainerEnvVars()` under `pkg/utils/envvar.go`, along with associated helper functions
- rename env var constants from `pkg/common/constants.go` to the format `Env*` with correct camel casing, and use in `pkg/utils.GetBackupRestoreContainerEnvVars()`

**Which issue(s) this PR fixes**:
Fixes #736 

**Special notes for your reviewer**:
/cc @dguendisch @anveshreddy18 
/invite @ishan16696 @seshachalam-yv 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add support for overriding storage API endpoint for provider GCS, by adding new field `storageAPIEndpoint` in the GCP/GCS backup secret, with the value in the format `http[s]://host[:port]/storage/v1/`. ⚠️ Note: GCS storage API endpoint will not be overridden for `EtcdCopyBackupsTask`s, since backup buckets may reside in different regions.
```
