### PR TITLE
Move feature:etcd-wrapper from alpha to beta feature.

### DIFF
--- a/docs/deployment/feature-gates.md
+++ b/docs/deployment/feature-gates.md
@@ -22,6 +22,7 @@ The following tables are a summary of the feature gates that you can set on etcd
 
 | Feature          | Default | Stage   | Since  | Until |
 |------------------|---------|---------|--------|-------|
+| `UseEtcdWrapper` | `false` | `Alpha` | `0.19` | `0.21`|
 | `UseEtcdWrapper` | `true`  | `Beta`  | `0.22` |       |
 
 ## Feature Gates for Graduated or Deprecated Features

--- a/docs/deployment/feature-gates.md
+++ b/docs/deployment/feature-gates.md
@@ -22,7 +22,7 @@ The following tables are a summary of the feature gates that you can set on etcd
 
 | Feature          | Default | Stage   | Since  | Until |
 |------------------|---------|---------|--------|-------|
-| `UseEtcdWrapper` | `false` | `Alpha` | `0.19` |       |
+| `UseEtcdWrapper` | `true`  | `Beta`  | `0.22` |       |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -31,11 +31,12 @@ const (
 	// changes required for the usage of the etcd-wrapper image.
 	// owner @unmarshall @aaronfern
 	// alpha: v0.19
+	// beta:  v0.22
 	UseEtcdWrapper featuregate.Feature = "UseEtcdWrapper"
 )
 
 var defaultFeatures = map[featuregate.Feature]featuregate.FeatureSpec{
-	UseEtcdWrapper: {Default: false, PreRelease: featuregate.Alpha},
+	UseEtcdWrapper: {Default: true, PreRelease: featuregate.Beta},
 }
 
 // GetDefaultFeatures returns the default feature gates known to etcd-druid.

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -27,14 +27,14 @@ deploy:
         eventsThreshold: 15
         metricsScrapeWaitDuration: "30s"
 profiles:
-- name: use-feature-gates
+- name: do-not-use-feature-gates
   activation:
-  - env: "USE_ETCD_DRUID_FEATURE_GATES=true"
+  - env: "USE_ETCD_DRUID_FEATURE_GATES=false"
   patches:
   - op: add
     path: /deploy/helm/releases/0/setValues/featureGates
     value:
-      UseEtcdWrapper: true
+      UseEtcdWrapper: false
 ---
 apiVersion: skaffold/v2beta25
 kind: Config


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
This PR moves `UseEtcdWrapper` alpha feature to beta feature by setting it as the default option in etcd-druid.


**Which issue(s) this PR fixes**:
Fixes Part1:  https://github.com/gardener/etcd-druid/issues/743

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`EtcdWrapper` has progressed from the alpha stage to the beta stage, which now allows for its default usage in etcd-druid. If you prefer to continue using the etcd-custom-image, you can disable the EtcdWrapper by adjusting the feature flag.
```
