### PR TITLE
Updates the etcd-wrapper version from v0.1 -> v0.1.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -18,7 +18,7 @@ images:
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
-  tag: "v0.1.0"
+  tag: "v0.1.1"
 - name: alpine
   repository: europe-docker.pkg.dev/gardener-project/public/3rd/alpine
   tag: "3.18.4"


### PR DESCRIPTION

/area security
/kind enhancement

**What this PR does / why we need it**:
This PR bump-up the etcd-wrapper version in etcd-druid from `v0.1.0` -> `v0.1.1`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator github.com/gardener/etcd-wrapper #16 @AleksandarSavchev 
The `etcd` process now runs with umask set to `0077`, this way the files it creates have no permissions on `group` and `others` level.
```

```breaking operator [github.com/gardener/etcd-wrapper](https://github.com/gardener/etcd-wrapper/pull/19)  @ccwienk 
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```
