### PR TITLE
Add missing delete permission for jobs, record events for completed compaction jobs

### DIFF
--- a/charts/druid/templates/druid-clusterrole.yaml
+++ b/charts/druid/templates/druid-clusterrole.yaml
@@ -138,7 +138,6 @@ rules:
 - apiGroups:
   - batch
   resources:
-  - cronjobs
   - jobs
   verbs:
   - get
@@ -147,3 +146,4 @@ rules:
   - create
   - patch
   - update
+  - delete

--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -138,7 +138,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		r.recorder.Eventf(
 			etcd,
 			corev1.EventTypeWarning,
-			"ReconciliationIgnored",
+			common.EventReasonReconciliationIgnored,
 			"reconciliation of %s/%s is ignored by etcd-druid due to the presence of annotation %s on the etcd resource",
 			etcd.Namespace,
 			etcd.Name,

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -63,4 +63,11 @@ const (
 	EnvECSAccessKeyID = "ECS_ACCESS_KEY_ID"
 	// EnvECSSecretAccessKey is the environment variable key for Dell ECS secret access key.
 	EnvECSSecretAccessKey = "ECS_SECRET_ACCESS_KEY"
+
+	// EventReasonReconciliationIgnored is the reason used when recording events for ignored or skipped etcd reconciliations.
+	EventReasonReconciliationIgnored = "ReconciliationIgnored"
+	// EventReasonSnapshotCompactionSucceeded is the reason used when recording events for successful snapshot compaction jobs.
+	EventReasonSnapshotCompactionSucceeded = "SnapshotCompactionSucceeded"
+	// EventReasonSnapshotCompactionFailed is the reason used when recording events for failed snapshot compaction jobs.
+	EventReasonSnapshotCompactionFailed = "SnapshotCompactionFailed"
 )

--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -357,7 +357,7 @@ var _ = Describe("Multinode ETCD", func() {
 				}
 
 				for _, event := range events.Items {
-					if event.Reason == "ReconciliationIgnored" {
+					if event.Reason == common.EventReasonReconciliationIgnored {
 						return nil
 					}
 				}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Add missing delete permission for jobs in druid helm chart, required for deleting completed/failed compaction jobs and etcdcopybackupstask jobs. Also, remove unused cronjobs permissions from clusterrole, since druid no longer uses cronjobs for snapshot compaction.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @seshachalam-yv @ishan16696 @abdasgupta 

The first iteration of this PR ([first commit](https://github.com/gardener/etcd-druid/pull/747/commits/fb47fb56481495ad60bc66c95a3791fe1717cd05)) caused a regression in e2e tests, where the test code was not able to check whether the job was successful or not, because the job resource could not be found. Upon a closer look, I realised that the compaction e2e tests used to previously succeed because of the missing delete permission for jobs, due to which druid could not delete the completed job, and hence the test could look at the job status and check whether it succeeded or failed. But once the missing permission was added, druid was able to immediately delete the completed job, hence the test code could not check the job status.

The [second commit](https://github.com/gardener/etcd-druid/pull/747/commits/d625cdb026b759cc543d19d0946aad1df8ea343b) enhances compaction controller to record events after the compaction job completes. This allows druid to simply record an event and delete the compaction job after it succeeds/fails. The e2e test now checks for this event to be present, for determining whether the compaction job succeeded or not.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Compaction controller now records events for indicating completed compaction jobs.
```
