### PR TITLE
Upgrade etcd-backup-restore from `v0.24.7` -> `v0.24.8` and Upgrade etcd-backup-restore-distroless from `v0.27.0` -> `v0.28.0`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -4,7 +4,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.24.7"
+  tag: "v0.24.8"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd
@@ -14,7 +14,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.27.0"
+  tag: "v0.28.0"
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper


### PR DESCRIPTION
**Release Notes**:

```breaking operator github.com/gardener/etcd-backup-restore #688 @ccwienk 
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```

```improvement user github.com/gardener/etcd-backup-restore #703 @shreyas-s-rao 
A regression in chunk deletion behavior for openstack provider has now been fixed.
```

```improvement operator github.com/gardener/etcd-backup-restore #685 @anveshreddy18
Add unit tests for chunk deletion
```

```improvement user github.com/gardener/etcd-backup-restore #691 @shreyas-s-rao 
Add support for overriding storage API endpoint for provider GCS, by setting environment variable `GOOGLE_STORAGE_API_ENDPOINT`, with the value in the format `http[s]://host[:port]/storage/v1/`. ⚠️ Note: GCS storage API endpoint will not be overridden for `copy` subcommand, since backup buckets may reside in different regions.
```

```improvement operator github.com/gardener/etcd-backup-restore #670 @renormalize 
Dynamic loading of IaaS credentials is now optimized to make use of file system information instead of calculating a hash of the credentials to detect changes.
```

