### PR TITLE
Make `max-backups` configurable in LimitBased GC from etcd yaml with a new field `maxBackupsLimitBasedGC` in Etcd CR

### DIFF
--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -169,6 +169,10 @@ type BackupSpec struct {
 	// GarbageCollectionPolicy defines the policy for garbage collecting old backups
 	// +optional
 	GarbageCollectionPolicy *GarbageCollectionPolicy `json:"garbageCollectionPolicy,omitempty"`
+	// MaxBackupsLimitBased defines the maximum number of Full snapshots to retain in Limit Based GC.
+	// All full snapshots beyond this limit are removed
+	// +optional
+	MaxBackupsLimitBased *int32 `json:"maxBackupsLimitBased,omitempty"`
 	// GarbageCollectionPeriod defines the period for garbage collecting old backups
 	// +optional
 	GarbageCollectionPeriod *metav1.Duration `json:"garbageCollectionPeriod,omitempty"`

--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -169,10 +169,10 @@ type BackupSpec struct {
 	// GarbageCollectionPolicy defines the policy for garbage collecting old backups
 	// +optional
 	GarbageCollectionPolicy *GarbageCollectionPolicy `json:"garbageCollectionPolicy,omitempty"`
-	// MaxBackupsLimitBased defines the maximum number of Full snapshots to retain in Limit Based GC.
+	// MaxBackupsLimitBasedGC defines the maximum number of Full snapshots to retain in Limit Based GC.
 	// All full snapshots beyond this limit are removed
 	// +optional
-	MaxBackupsLimitBased *int32 `json:"maxBackupsLimitBased,omitempty"`
+	MaxBackupsLimitBasedGC *int32 `json:"maxBackupsLimitBasedGC,omitempty"`
 	// GarbageCollectionPeriod defines the period for garbage collecting old backups
 	// +optional
 	GarbageCollectionPeriod *metav1.Duration `json:"garbageCollectionPeriod,omitempty"`

--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -169,8 +169,8 @@ type BackupSpec struct {
 	// GarbageCollectionPolicy defines the policy for garbage collecting old backups
 	// +optional
 	GarbageCollectionPolicy *GarbageCollectionPolicy `json:"garbageCollectionPolicy,omitempty"`
-	// MaxBackupsLimitBasedGC defines the maximum number of Full snapshots to retain in Limit Based GC.
-	// All full snapshots beyond this limit are removed
+	// MaxBackupsLimitBasedGC defines the maximum number of Full snapshots to retain in Limit Based GarbageCollectionPolicy
+	// All full snapshots beyond this limit will be garbage collected.
 	// +optional
 	MaxBackupsLimitBasedGC *int32 `json:"maxBackupsLimitBasedGC,omitempty"`
 	// GarbageCollectionPeriod defines the period for garbage collecting old backups

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -68,6 +68,11 @@ func (in *BackupSpec) DeepCopyInto(out *BackupSpec) {
 		*out = new(GarbageCollectionPolicy)
 		**out = **in
 	}
+	if in.MaxBackupsLimitBased != nil {
+		in, out := &in.MaxBackupsLimitBased, &out.MaxBackupsLimitBased
+		*out = new(int32)
+		**out = **in
+	}
 	if in.GarbageCollectionPeriod != nil {
 		in, out := &in.GarbageCollectionPeriod, &out.GarbageCollectionPeriod
 		*out = new(metav1.Duration)

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -68,8 +68,8 @@ func (in *BackupSpec) DeepCopyInto(out *BackupSpec) {
 		*out = new(GarbageCollectionPolicy)
 		**out = **in
 	}
-	if in.MaxBackupsLimitBased != nil {
-		in, out := &in.MaxBackupsLimitBased, &out.MaxBackupsLimitBased
+	if in.MaxBackupsLimitBasedGC != nil {
+		in, out := &in.MaxBackupsLimitBasedGC, &out.MaxBackupsLimitBasedGC
 		*out = new(int32)
 		**out = **in
 	}

--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -177,6 +177,10 @@ spec:
                     - Exponential
                     - LimitBased
                     type: string
+                  maxBackupsLimitBased:
+                    description: MaxBackupsLimitBased defines the no.of full snaps to retain in LimitBased GC
+                    format: int32
+                    type: integer
                   image:
                     description: Image defines the etcd container image and tag
                     type: string

--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -193,9 +193,9 @@ spec:
                           leadership status of corresponding etcd is checked.
                         type: string
                     type: object
-                  maxBackupsLimitBased:
-                    description: MaxBackupsLimitBased defines the maximum number of
-                      Full snapshots to retain in Limit Based GC. All full snapshots
+                  maxBackupsLimitBasedGC:
+                    description: MaxBackupsLimitBasedGC defines the maximum number
+                      of Full snapshots to retain in Limit Based GC. All full snapshots
                       beyond this limit are removed
                     format: int32
                     type: integer

--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -177,10 +177,6 @@ spec:
                     - Exponential
                     - LimitBased
                     type: string
-                  maxBackupsLimitBased:
-                    description: MaxBackupsLimitBased defines the no.of full snaps to retain in LimitBased GC
-                    format: int32
-                    type: integer
                   image:
                     description: Image defines the etcd container image and tag
                     type: string
@@ -197,6 +193,12 @@ spec:
                           leadership status of corresponding etcd is checked.
                         type: string
                     type: object
+                  maxBackupsLimitBased:
+                    description: MaxBackupsLimitBased defines the maximum number of
+                      Full snapshots to retain in Limit Based GC. All full snapshots
+                      beyond this limit are removed
+                    format: int32
+                    type: integer
                   port:
                     description: Port define the port on which etcd-backup-restore
                       server will be exposed.

--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -195,8 +195,8 @@ spec:
                     type: object
                   maxBackupsLimitBasedGC:
                     description: MaxBackupsLimitBasedGC defines the maximum number
-                      of Full snapshots to retain in Limit Based GC. All full snapshots
-                      beyond this limit are removed
+                      of Full snapshots to retain in Limit Based GarbageCollectionPolicy
+                      All full snapshots beyond this limit will be garbage collected.
                     format: int32
                     type: integer
                   port:

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -177,6 +177,10 @@ spec:
                     - Exponential
                     - LimitBased
                     type: string
+                  maxBackupsLimitBased:
+                    description: MaxBackupsLimitBased defines the no.of full snaps to retain in LimitBased GC
+                    format: int32
+                    type: integer
                   image:
                     description: Image defines the etcd container image and tag
                     type: string

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -193,9 +193,9 @@ spec:
                           leadership status of corresponding etcd is checked.
                         type: string
                     type: object
-                  maxBackupsLimitBased:
-                    description: MaxBackupsLimitBased defines the maximum number of
-                      Full snapshots to retain in Limit Based GC. All full snapshots
+                  maxBackupsLimitBasedGC:
+                    description: MaxBackupsLimitBasedGC defines the maximum number
+                      of Full snapshots to retain in Limit Based GC. All full snapshots
                       beyond this limit are removed
                     format: int32
                     type: integer

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -177,10 +177,6 @@ spec:
                     - Exponential
                     - LimitBased
                     type: string
-                  maxBackupsLimitBased:
-                    description: MaxBackupsLimitBased defines the no.of full snaps to retain in LimitBased GC
-                    format: int32
-                    type: integer
                   image:
                     description: Image defines the etcd container image and tag
                     type: string
@@ -197,6 +193,12 @@ spec:
                           leadership status of corresponding etcd is checked.
                         type: string
                     type: object
+                  maxBackupsLimitBased:
+                    description: MaxBackupsLimitBased defines the maximum number of
+                      Full snapshots to retain in Limit Based GC. All full snapshots
+                      beyond this limit are removed
+                    format: int32
+                    type: integer
                   port:
                     description: Port define the port on which etcd-backup-restore
                       server will be exposed.

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -195,8 +195,8 @@ spec:
                     type: object
                   maxBackupsLimitBasedGC:
                     description: MaxBackupsLimitBasedGC defines the maximum number
-                      of Full snapshots to retain in Limit Based GC. All full snapshots
-                      beyond this limit are removed
+                      of Full snapshots to retain in Limit Based GarbageCollectionPolicy
+                      All full snapshots beyond this limit will be garbage collected.
                     format: int32
                     type: integer
                   port:

--- a/pkg/component/etcd/statefulset/values.go
+++ b/pkg/component/etcd/statefulset/values.go
@@ -84,7 +84,7 @@ type Values struct {
 	DeltaSnapshotMemoryLimit *resource.Quantity
 
 	GarbageCollectionPolicy *druidv1alpha1.GarbageCollectionPolicy
-	MaxBackupsLimitBased    *int32
+	MaxBackupsLimitBasedGC  *int32
 	GarbageCollectionPeriod *metav1.Duration
 
 	LeaderElection *druidv1alpha1.LeaderElectionSpec

--- a/pkg/component/etcd/statefulset/values.go
+++ b/pkg/component/etcd/statefulset/values.go
@@ -84,6 +84,7 @@ type Values struct {
 	DeltaSnapshotMemoryLimit *resource.Quantity
 
 	GarbageCollectionPolicy *druidv1alpha1.GarbageCollectionPolicy
+	MaxBackupsLimitBased    *int32
 	GarbageCollectionPeriod *metav1.Duration
 
 	LeaderElection *druidv1alpha1.LeaderElectionSpec

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -16,6 +16,7 @@ package statefulset
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
@@ -29,6 +30,7 @@ const (
 	defaultServerPort              int32 = 2380
 	defaultClientPort              int32 = 2379
 	defaultWrapperPort             int32 = 9095
+	defaultMaxBackupsLimitBased    int32 = 7
 	defaultQuota                   int64 = 8 * 1024 * 1024 * 1024 // 8Gi
 	defaultSnapshotMemoryLimit     int64 = 100 * 1024 * 1024      // 100Mi
 	defaultHeartbeatDuration             = "10s"
@@ -103,6 +105,7 @@ func GenerateValues(
 		EtcdDefragTimeout:   etcd.Spec.Etcd.EtcdDefragTimeout,
 
 		GarbageCollectionPolicy: etcd.Spec.Backup.GarbageCollectionPolicy,
+		MaxBackupsLimitBased:    etcd.Spec.Backup.MaxBackupsLimitBased,
 		GarbageCollectionPeriod: etcd.Spec.Backup.GarbageCollectionPeriod,
 
 		SnapshotCompression: etcd.Spec.Backup.SnapshotCompression,
@@ -233,7 +236,7 @@ func getBackupRestoreCommandArgs(val Values) ([]string, error) {
 
 	command = append(command, "--garbage-collection-policy="+garbageCollectionPolicy)
 	if garbageCollectionPolicy == "LimitBased" {
-		command = append(command, "--max-backups=7")
+		command = append(command, "--max-backups="+strconv.Itoa(int(pointer.Int32Deref(val.MaxBackupsLimitBased, defaultMaxBackupsLimitBased))))
 	}
 
 	command = append(command, "--data-dir=/var/etcd/data/new.etcd")

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -30,7 +30,7 @@ const (
 	defaultServerPort              int32 = 2380
 	defaultClientPort              int32 = 2379
 	defaultWrapperPort             int32 = 9095
-	defaultMaxBackupsLimitBased    int32 = 7
+	defaultMaxBackupsLimitBasedGC  int32 = 7
 	defaultQuota                   int64 = 8 * 1024 * 1024 * 1024 // 8Gi
 	defaultSnapshotMemoryLimit     int64 = 100 * 1024 * 1024      // 100Mi
 	defaultHeartbeatDuration             = "10s"
@@ -236,7 +236,7 @@ func getBackupRestoreCommandArgs(val Values) ([]string, error) {
 
 	command = append(command, "--garbage-collection-policy="+garbageCollectionPolicy)
 	if garbageCollectionPolicy == "LimitBased" {
-		command = append(command, "--max-backups="+strconv.Itoa(int(pointer.Int32Deref(val.MaxBackupsLimitBasedGC, defaultMaxBackupsLimitBased))))
+		command = append(command, "--max-backups="+strconv.Itoa(int(pointer.Int32Deref(val.MaxBackupsLimitBasedGC, defaultMaxBackupsLimitBasedGC))))
 	}
 
 	command = append(command, "--data-dir=/var/etcd/data/new.etcd")

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -105,7 +105,7 @@ func GenerateValues(
 		EtcdDefragTimeout:   etcd.Spec.Etcd.EtcdDefragTimeout,
 
 		GarbageCollectionPolicy: etcd.Spec.Backup.GarbageCollectionPolicy,
-		MaxBackupsLimitBased:    etcd.Spec.Backup.MaxBackupsLimitBased,
+		MaxBackupsLimitBasedGC:  etcd.Spec.Backup.MaxBackupsLimitBasedGC,
 		GarbageCollectionPeriod: etcd.Spec.Backup.GarbageCollectionPeriod,
 
 		SnapshotCompression: etcd.Spec.Backup.SnapshotCompression,
@@ -236,7 +236,7 @@ func getBackupRestoreCommandArgs(val Values) ([]string, error) {
 
 	command = append(command, "--garbage-collection-policy="+garbageCollectionPolicy)
 	if garbageCollectionPolicy == "LimitBased" {
-		command = append(command, "--max-backups="+strconv.Itoa(int(pointer.Int32Deref(val.MaxBackupsLimitBased, defaultMaxBackupsLimitBased))))
+		command = append(command, "--max-backups="+strconv.Itoa(int(pointer.Int32Deref(val.MaxBackupsLimitBasedGC, defaultMaxBackupsLimitBased))))
 	}
 
 	command = append(command, "--data-dir=/var/etcd/data/new.etcd")

--- a/pkg/component/etcd/statefulset/values_helper.go
+++ b/pkg/component/etcd/statefulset/values_helper.go
@@ -16,7 +16,6 @@ package statefulset
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
@@ -236,7 +235,7 @@ func getBackupRestoreCommandArgs(val Values) ([]string, error) {
 
 	command = append(command, "--garbage-collection-policy="+garbageCollectionPolicy)
 	if garbageCollectionPolicy == "LimitBased" {
-		command = append(command, "--max-backups="+strconv.Itoa(int(pointer.Int32Deref(val.MaxBackupsLimitBasedGC, defaultMaxBackupsLimitBasedGC))))
+		command = append(command, "--max-backups="+fmt.Sprint(pointer.Int32Deref(val.MaxBackupsLimitBasedGC, defaultMaxBackupsLimitBasedGC)))
 	}
 
 	command = append(command, "--data-dir=/var/etcd/data/new.etcd")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

This PR adds a new field `maxBackupsLimitBasedGC` in the `spec.backup` section of Etcd yaml and makes necessary changes, which allows to configure `max-backups` parameter used for LimitBased GC. 

- At present, there is no way to configure the number of full snapshots to retain in a limitBased GC policy as a default value of `7` is set in the code.
- This change will allow the user to configure the `--max-backups` flag of the etcd-statefulset thus allowing them to control the behaviour of Limit Based GC. 

**Note:** It will be an optional field, when not set, `max-backups` will defaul to `7`


**Which issue(s) this PR fixes**:
Fixes #754

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enabling the configurability of `--max-backups` for LimitBasedGC through the etcd resource spec `.spec.backup.maxBackupsLimitBasedGC`.
```
