### PR TITLE
[hotfix-v0.21] Cherry-pick essential PRs and bug fixes

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,12 +1,12 @@
 etcd-druid:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: 'docker-buildx'
         platforms:
@@ -14,8 +14,7 @@ etcd-druid:
         - linux/arm64
         dockerimages:
           etcd-druid:
-            registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/etcd-druid'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcd-druid
             dockerfile: 'Dockerfile'
             inputs:
               repos:
@@ -46,15 +45,22 @@ etcd-druid:
     head-update:
       traits:
         draft_release: ~
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~
-        component_descriptor: ~
     release:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            etcd-druid:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
         release:
           nextversion: 'bump_minor'
           git_tags:
@@ -66,4 +72,3 @@ etcd-druid:
             internal_scp_workspace:
               channel_name: 'C0177NLL8V9' # gardener-etcd
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Image URL to use all building/pushing image targets
 VERSION             := $(shell cat VERSION)
 REPO_ROOT           := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
-REGISTRY            := europe-docker.pkg.dev/gardener-project/public
+REGISTRY            := europe-docker.pkg.dev/gardener-project/snapshots
 IMAGE_REPOSITORY    := $(REGISTRY)/gardener/etcd-druid
 IMAGE_BUILD_TAG     := $(VERSION)
 BUILD_DIR           := build

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@
 # Image URL to use all building/pushing image targets
 VERSION             := $(shell cat VERSION)
 REPO_ROOT           := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
-REGISTRY            := eu.gcr.io/gardener-project/gardener
-IMAGE_REPOSITORY    := $(REGISTRY)/etcd-druid
+REGISTRY            := europe-docker.pkg.dev/gardener-project/public
+IMAGE_REPOSITORY    := $(REGISTRY)/gardener/etcd-druid
 IMAGE_BUILD_TAG     := $(VERSION)
 BUILD_DIR           := build
 PROVIDERS           := ""
@@ -155,7 +155,7 @@ update-dependencies:
 .PHONY: add-license-headers
 add-license-headers: $(GO_ADD_LICENSE)
 	@./hack/addlicenseheaders.sh ${YEAR}
-	
+
 .PHONY: kind-up
 kind-up: $(KIND)
 	@printf "\n\033[0;33m📌 NOTE: To target the newly created KinD cluster, please run the following command:\n\n    export KUBECONFIG=$(KUBECONFIG_PATH)\n\033[0m\n"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ spec:
     fullSnapshotSchedule: 0 */24 * * *
     garbageCollectionPeriod: 43200s
     garbageCollectionPolicy: Exponential
-    imageRepository: eu.gcr.io/gardener-project/gardener/etcdbrctl
+    imageRepository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
     imageVersion: v0.25.0
     port: 8080
     resources:
@@ -67,7 +67,7 @@ spec:
     clientPort: 2379
     defragmentationSchedule: 0 */24 * * *
     enableTLS: false
-    imageRepository: eu.gcr.io/gardener-project/gardener/etcd-wrapper
+    imageRepository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
     imageVersion: v0.1.0
     initialClusterState: new
     initialClusterToken: new

--- a/api/v1alpha1/types_etcd_test.go
+++ b/api/v1alpha1/types_etcd_test.go
@@ -168,8 +168,8 @@ func getEtcd(name, namespace string) *Etcd {
 	deltaSnapshotPeriod := metav1.Duration{
 		Duration: 300 * time.Second,
 	}
-	imageEtcd := "eu.gcr.io/gardener-project/gardener/etcd-wrapper:v0.1.0"
-	imageBR := "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.25.0"
+	imageEtcd := "europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:v0.1.0"
+	imageBR := "europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:v0.25.0"
 	snapshotSchedule := "0 */24 * * *"
 	defragSchedule := "0 */24 * * *"
 	container := "my-object-storage-container-name"

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -1,7 +1,7 @@
 crds:
   enabled: true
 image:
-  repository: eu.gcr.io/gardener-project/gardener/etcd-druid
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-druid
   tag: latest
   imagePullPolicy: IfNotPresent
 replicas: 1

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -4,7 +4,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.24.7"
+  tag: "v0.24.8"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd
@@ -14,7 +14,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.27.0"
+  tag: "v0.28.0"
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -3,22 +3,22 @@ images:
   resourceId:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
-  repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
   tag: "v0.24.7"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
-  repository: eu.gcr.io/gardener-project/gardener/etcd
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd
   tag: "v3.4.26-3"
 - name: etcd-backup-restore-distroless
   resourceId:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
-  repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
   tag: "v0.27.0"
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
-  repository: eu.gcr.io/gardener-project/gardener/etcd-wrapper
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
   tag: "v0.1.0"
 - name: alpine
-  repository: eu.gcr.io/gardener-project/3rd/alpine
+  repository: europe-docker.pkg.dev/gardener-project/public/3rd/alpine
   tag: "3.18.4"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         # Change the value of image field below to your controller image URL
-        - image: eu.gcr.io/gardener-project/gardener/etcd-druid:v0.21.0
+        - image: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-druid:v0.21.0
           name: druid

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -62,9 +62,9 @@ var (
 	backupPort              int32 = 8080
 	wrapperPort             int32 = 9095
 	uid                           = "a9b8c7d6e5f4"
-	imageEtcd                     = "eu.gcr.io/gardener-project/gardener/etcd-wrapper:v0.1.0"
-	imageBR                       = "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.25.0"
-	imageInitContainer            = "eu.gcr.io/gardener-project/3rd/alpine:3.18.4"
+	imageEtcd                     = "europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-wrapper:v0.1.0"
+	imageBR                       = "europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl:v0.25.0"
+	imageInitContainer            = "europe-docker.pkg.dev/gardener-project/releases/3rd/alpine:3.18.4"
 	snapshotSchedule              = "0 */24 * * *"
 	defragSchedule                = "0 */24 * * *"
 	container                     = "default.bkp"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,7 +7,7 @@ build:
   local:
     useBuildkit: true
   artifacts:
-  - image: eu.gcr.io/gardener-project/gardener/etcd-druid
+  - image: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-druid
     docker:
       dockerfile: Dockerfile
       target: druid
@@ -18,7 +18,7 @@ deploy:
       chartPath: charts/druid
       namespace: default
       artifactOverrides:
-        image: eu.gcr.io/gardener-project/gardener/etcd-druid
+        image: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-druid
       imageStrategy:
         helm: {}
       skipBuildDependencies: true

--- a/test/integration/controllers/compaction/reconciler_test.go
+++ b/test/integration/controllers/compaction/reconciler_test.go
@@ -664,7 +664,7 @@ func createCompactionJob(instance *druidv1alpha1.Etcd) *batchv1.Job {
 					Containers: []corev1.Container{
 						{
 							Name:    "compact-backup",
-							Image:   "eu.gcr.io/gardener-project/3rd/alpine:3.18.4",
+							Image:   "europe-docker.pkg.dev/gardener-project/releases/3rd/alpine:3.18.4",
 							Command: []string{"sh", "-c", "tail -f /dev/null"},
 						},
 					},

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -40,8 +40,8 @@ var (
 	clientPort              int32 = 2379
 	serverPort              int32 = 2380
 	backupPort              int32 = 8080
-	imageEtcd                     = "eu.gcr.io/gardener-project/gardener/etcd-wrapper:v0.1.0"
-	imageBR                       = "eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.25.0"
+	imageEtcd                     = "europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:v0.1.0"
+	imageBR                       = "europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:v0.25.0"
 	snapshotSchedule              = "0 */24 * * *"
 	defragSchedule                = "0 */24 * * *"
 	container                     = "default.bkp"

--- a/test/utils/etcdcopybackupstask.go
+++ b/test/utils/etcdcopybackupstask.go
@@ -102,7 +102,7 @@ func CreateEtcdCopyBackupsJob(taskName, namespace string) *batchv1.Job {
 					Containers: []corev1.Container{
 						{
 							Name:            "copy-backups",
-							Image:           "eu.gcr.io/gardener-project/gardener/etcdbrctl",
+							Image:           "europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl",
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args:            []string{"copy"}, // since this is only used for testing the command here is not complete.
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind bug

**What this PR does / why we need it**:
Cherry-picks of PRs:
- #735 
- #745 
- #752 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```

```breaking operator github.com/gardener/etcd-backup-restore #688 @ccwienk 
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```

```improvement operator github.com/gardener/etcd-backup-restore #703 @shreyas-s-rao 
A regression in chunk deletion behavior for openstack provider has now been fixed.
```

```improvement operator github.com/gardener/etcd-backup-restore #685 @anveshreddy18
Add unit tests for chunk deletion
```

```improvement user github.com/gardener/etcd-backup-restore #691 @shreyas-s-rao 
Add support for overriding storage API endpoint for provider GCS, by setting environment variable `GOOGLE_STORAGE_API_ENDPOINT`, with the value in the format `http[s]://host[:port]/storage/v1/`. ⚠️ Note: GCS storage API endpoint will not be overridden for `copy` subcommand, since backup buckets may reside in different regions.
```

```improvement operator github.com/gardener/etcd-backup-restore #670 @renormalize 
Dynamic loading of IaaS credentials is now optimized to make use of file system information instead of calculating a hash of the credentials to detect changes.
```

