### PR TITLE
Add etcd team to component descriptor

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,8 +2,7 @@ etcd-druid:
   base_definition:
     traits:
       version:
-        preprocess:
-          'inject-commit-hash'
+        preprocess: 'inject-commit-hash'
         inject_effective_version: true
       component_descriptor:
         ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
@@ -30,6 +29,10 @@ etcd-druid:
                 confidentiality_requirement: 'high'
                 integrity_requirement: 'high'
                 availability_requirement: 'low'
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubTeam'
+                teamname: 'gardener/etcd-druid-maintainers'
     steps:
       check:
         image: 'golang:1.21.4'
@@ -47,7 +50,7 @@ etcd-druid:
         draft_release: ~
         component_descriptor:
           ocm_repository_mappings:
-            - repository: europe-docker.pkg.dev/gardener-project/releases
+          - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `gardener/etcd-druid-maintainers` team as responsibilities to the component descriptor. 

**Special notes for your reviewer**:
/cc @AndreasBurger 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
