### PR TITLE
Add a new configurable field `fullSnapshotLeaseUpdateInterval ` in spec.backup section of Etcd CR

### DIFF
--- a/api/v1alpha1/etcd.go
+++ b/api/v1alpha1/etcd.go
@@ -159,6 +159,9 @@ type BackupSpec struct {
 	// All full snapshots beyond this limit will be garbage collected.
 	// +optional
 	MaxBackupsLimitBasedGC *int32 `json:"maxBackupsLimitBasedGC,omitempty"`
+	// FullSnapshotLeaseUpdateInterval defines the interval for retrying to update the full snapshot lease.
+	// +optional
+	FullSnapshotLeaseUpdateInterval *metav1.Duration `json:"fullSnapshotLeaseUpdateInterval,omitempty"`
 	// GarbageCollectionPeriod defines the period for garbage collecting old backups
 	// +optional
 	GarbageCollectionPeriod *metav1.Duration `json:"garbageCollectionPeriod,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -62,6 +62,11 @@ func (in *BackupSpec) DeepCopyInto(out *BackupSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.FullSnapshotLeaseUpdateInterval != nil {
+		in, out := &in.FullSnapshotLeaseUpdateInterval, &out.FullSnapshotLeaseUpdateInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.GarbageCollectionPeriod != nil {
 		in, out := &in.GarbageCollectionPeriod, &out.GarbageCollectionPeriod
 		*out = new(v1.Duration)

--- a/charts/druid/charts/crds/templates/crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/crd-druid.gardener.cloud_etcds.yaml
@@ -162,6 +162,10 @@ spec:
                     description: EtcdSnapshotTimeout defines the timeout duration
                       for etcd FullSnapshot operation
                     type: string
+                  fullSnapshotLeaseUpdateInterval:
+                    description: FullSnapshotLeaseUpdateInterval defines the interval
+                      for retrying to update the full snapshot lease.
+                    type: string
                   fullSnapshotSchedule:
                     description: FullSnapshotSchedule defines the cron standard schedule
                       for full snapshots.

--- a/config/crd/bases/crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/crd-druid.gardener.cloud_etcds.yaml
@@ -162,6 +162,10 @@ spec:
                     description: EtcdSnapshotTimeout defines the timeout duration
                       for etcd FullSnapshot operation
                     type: string
+                  fullSnapshotLeaseUpdateInterval:
+                    description: FullSnapshotLeaseUpdateInterval defines the interval
+                      for retrying to update the full snapshot lease.
+                    type: string
                   fullSnapshotSchedule:
                     description: FullSnapshotSchedule defines the cron standard schedule
                       for full snapshots.

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -501,6 +501,9 @@ func (b *stsBuilder) getBackupStoreCommandArgs() []string {
 	if b.etcd.Spec.Backup.FullSnapshotSchedule != nil {
 		commandArgs = append(commandArgs, fmt.Sprintf("--schedule=%s", *b.etcd.Spec.Backup.FullSnapshotSchedule))
 	}
+	if b.etcd.Spec.Backup.FullSnapshotLeaseUpdateInterval != nil {
+		commandArgs = append(commandArgs, fmt.Sprintf("--full-snapshot-lease-update-interval=%s", b.etcd.Spec.Backup.FullSnapshotLeaseUpdateInterval.Duration.String()))
+	}
 
 	// Delta snapshot command line args
 	// -----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

This PR adds a new field `fullSnapshotLeaseUpdateInterval` in the `spec.backup` section of Etcd yaml and makes necessary changes, which allows to configure `full-snapshot-lease-update-interval` parameter used to configure the interval to retry updating full snapshot lease.

* The backup-restore [PR#711](https://github.com/gardener/etcd-backup-restore/pull/711) introduces a new flag `full-snapshot-lease-update-interval` to configure the retry interval for updating the full snapshot lease. Adding this new `fullSnapshotLeaseUpdateInterval` field to Etcd CR allows user to control the behaviour of retrying to update full snapshot lease 

**Note:** It will be an optional field, and when not set, backup-restore takes care of setting a default value to it. 

**Which issue(s) this PR fixes**:
Fixes #763

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enabling the configurability of `full-snapshot-lease-update-interval` flag through the etcd resource spec `.spec.backup.fullSnapshotLeaseUpdateInterval`.

```
