### PR TITLE
Enhance Etcd configMap to provide consistency and controllability

### DIFF
--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -446,7 +446,7 @@ func (e *Etcd) GetServiceAccountName() string {
 
 // GetConfigmapName returns the name of the configmap for the Etcd.
 func (e *Etcd) GetConfigmapName() string {
-	return fmt.Sprintf("etcd-bootstrap-%s", string(e.UID[:6]))
+	return fmt.Sprintf("%s-bootstrap-%s", e.Name, (e.UID[:6]))
 }
 
 // GetCompactionJobName returns the compaction job name for the Etcd.

--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -208,7 +208,7 @@ type EtcdConfig struct {
 	// Quota defines the etcd DB quota.
 	// +optional
 	Quota *resource.Quantity `json:"quota,omitempty"`
-	// SnapshotCount defines the number of committed transactions before a snapshot is created.
+	// SnapshotCount defines the number of committed transactions to trigger a snapshot to disk
 	// +optional
 	SnapshotCount *int `json:"snapshotCount,omitempty"`
 	// DefragmentationSchedule defines the cron standard schedule for defragmentation of etcd.

--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -208,6 +208,9 @@ type EtcdConfig struct {
 	// Quota defines the etcd DB quota.
 	// +optional
 	Quota *resource.Quantity `json:"quota,omitempty"`
+	// SnapshotCount defines the number of committed transactions before a snapshot is created.
+	// +optional
+	SnapshotCount *int `json:"snapshotCount,omitempty"`
 	// DefragmentationSchedule defines the cron standard schedule for defragmentation of etcd.
 	// +optional
 	DefragmentationSchedule *string `json:"defragmentationSchedule,omitempty"`

--- a/api/v1alpha1/types_etcd_test.go
+++ b/api/v1alpha1/types_etcd_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Etcd", func() {
 
 	Context("GetConfigmapName", func() {
 		It("should return the correct configmap name", func() {
-			Expect(created.GetConfigmapName()).To(Equal("etcd-bootstrap-123456"))
+			Expect(created.GetConfigmapName()).To(Equal(created.Name + "-bootstrap-123456"))
 		})
 	})
 

--- a/api/v1alpha1/types_etcd_test.go
+++ b/api/v1alpha1/types_etcd_test.go
@@ -156,10 +156,11 @@ var _ = Describe("Etcd", func() {
 
 func getEtcd(name, namespace string) *Etcd {
 	var (
-		clientPort  int32        = 2379
-		serverPort  int32        = 2380
-		backupPort  int32        = 8080
-		metricLevel MetricsLevel = Basic
+		clientPort    int32        = 2379
+		serverPort    int32        = 2380
+		backupPort    int32        = 8080
+		snapshotCount              = 75000
+		metricLevel   MetricsLevel = Basic
 	)
 
 	garbageCollectionPeriod := metav1.Duration{
@@ -276,10 +277,11 @@ func getEtcd(name, namespace string) *Etcd {
 						"memory": testutils.ParseQuantity("1000Mi"),
 					},
 				},
-				ClientPort:   &clientPort,
-				ServerPort:   &serverPort,
-				ClientUrlTLS: clientTlsConfig,
-				PeerUrlTLS:   peerTlsConfig,
+				ClientPort:    &clientPort,
+				ServerPort:    &serverPort,
+				SnapshotCount: &snapshotCount,
+				ClientUrlTLS:  clientTlsConfig,
+				PeerUrlTLS:    peerTlsConfig,
 			},
 		},
 	}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -246,6 +246,11 @@ func (in *EtcdConfig) DeepCopyInto(out *EtcdConfig) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.SnapshotCount != nil {
+		in, out := &in.SnapshotCount, &out.SnapshotCount
+		*out = new(int)
+		**out = **in
+	}
 	if in.DefragmentationSchedule != nil {
 		in, out := &in.DefragmentationSchedule, &out.DefragmentationSchedule
 		*out = new(string)

--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -563,6 +563,10 @@ spec:
                   serverPort:
                     format: int32
                     type: integer
+                  snapshotCount:
+                    description: SnapshotCount defines the number of committed transactions
+                      before a snapshot is created.
+                    type: integer
                 type: object
               labels:
                 additionalProperties:

--- a/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/10-crd-druid.gardener.cloud_etcds.yaml
@@ -565,7 +565,7 @@ spec:
                     type: integer
                   snapshotCount:
                     description: SnapshotCount defines the number of committed transactions
-                      before a snapshot is created.
+                      to trigger a snapshot to disk
                     type: integer
                 type: object
               labels:

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -563,6 +563,10 @@ spec:
                   serverPort:
                     format: int32
                     type: integer
+                  snapshotCount:
+                    description: SnapshotCount defines the number of committed transactions
+                      before a snapshot is created.
+                    type: integer
                 type: object
               labels:
                 additionalProperties:

--- a/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/10-crd-druid.gardener.cloud_etcds.yaml
@@ -565,7 +565,7 @@ spec:
                     type: integer
                   snapshotCount:
                     description: SnapshotCount defines the number of committed transactions
-                      before a snapshot is created.
+                      to trigger a snapshot to disk
                     type: integer
                 type: object
               labels:

--- a/docs/operations/recovery-from-permanent-quorum-loss-in-etcd-cluster.md
+++ b/docs/operations/recovery-from-permanent-quorum-loss-in-etcd-cluster.md
@@ -28,7 +28,7 @@ There are two [Etcd clusters](https://github.com/gardener/etcd-druid/tree/master
      Volumes:
       etcd-config-file:
        Type:      ConfigMap (a volume populated by a ConfigMap)
-       Name:      etcd-bootstrap-4785b0
+       Name:      etcd-main-bootstrap-4785b0
        Optional:  false
    ```
 
@@ -63,7 +63,7 @@ There are two [Etcd clusters](https://github.com/gardener/etcd-druid/tree/master
 
       Delete all `etcd-main` member leases.
 
-   6. Edit the `etcd-main` cluster's configmap (ex: `etcd-bootstrap-4785b0`) as follows:
+   6. Edit the `etcd-main` cluster's configmap (ex: `etcd-main-bootstrap-4785b0`) as follows:
 
       Find the `initial-cluster` field in the configmap. It will look like the following:
       ```

--- a/docs/proposals/03-scaling-up-an-etcd-cluster.md
+++ b/docs/proposals/03-scaling-up-an-etcd-cluster.md
@@ -24,7 +24,7 @@ Now, it is detected whether peer URL was TLS enabled or not for single node etcd
 - If peer URL was not TLS enabled then etcd-druid has to intervene and make sure peer URL should be TLS enabled first for the single node before marking the cluster for scale-up.
 
 ## Action taken by etcd-druid to enable the peerURL TLS
-1. Etcd-druid will update the `etcd-bootstrap` config-map with new config like initial-cluster,initial-advertise-peer-urls etc. Backup-restore will detect this change and update the member lease annotation to `member.etcd.gardener.cloud/tls-enabled: "true"`.
+1. Etcd-druid will update the `{etcd.Name}-bootstrap` config-map with new config like initial-cluster,initial-advertise-peer-urls etc. Backup-restore will detect this change and update the member lease annotation to `member.etcd.gardener.cloud/tls-enabled: "true"`.
 2. In case the peer URL TLS has been changed to `enabled`: Etcd-druid will add tasks to the deployment flow.
     - To ensure that the TLS enablement of peer URL is properly reflected in etcd, the existing etcd StatefulSet pods should be restarted twice. 
     - The first restart pushes a new configuration which contains Peer URL TLS configuration. Backup-restore will update the member peer url. This will result in the change of the peer url in the etcd's database, but it may not reflect in the already running etcd container. Ideally a restart of an etcd container would have been sufficient but currently k8s doesn't expose an API to force restart a single container within a pod. Therefore, we need to restart the StatefulSet pod(s) once again. When the pod(s) is restarted the second time it will now start etcd with the correct peer url which will be TLS enabled.

--- a/pkg/component/etcd/configmap/configmap.go
+++ b/pkg/component/etcd/configmap/configmap.go
@@ -48,6 +48,11 @@ func New(c client.Client, namespace string, values *Values) gardenercomponent.De
 }
 
 func (c *component) Deploy(ctx context.Context) error {
+	// Fetch and delete the old configmap if it exists
+	oldConfigMap := c.getOldConfigmap()
+	if err := c.deleteConfigmap(ctx, oldConfigMap); err != nil {
+		return err
+	}
 	cm := c.emptyConfigmap()
 	return c.syncConfigmap(ctx, cm)
 }
@@ -143,6 +148,15 @@ func (c *component) emptyConfigmap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      c.values.Name,
+			Namespace: c.namespace,
+		},
+	}
+}
+
+func (c *component) getOldConfigmap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("etcd-bootstrap-%s", string(c.values.EtcdUID[:6])),
 			Namespace: c.namespace,
 		},
 	}

--- a/pkg/component/etcd/configmap/configmap.go
+++ b/pkg/component/etcd/configmap/configmap.go
@@ -97,8 +97,8 @@ func (c *component) syncConfigmap(ctx context.Context, cm *corev1.ConfigMap) err
 
 		ListenPeerUrls:      fmt.Sprintf("%s://0.0.0.0:%d", peerScheme, pointer.Int32Deref(c.values.ServerPort, defaultServerPort)),
 		ListenClientUrls:    fmt.Sprintf("%s://0.0.0.0:%d", clientScheme, pointer.Int32Deref(c.values.ClientPort, defaultClientPort)),
-		AdvertisePeerUrls:   fmt.Sprintf("%s@%s@%s@%d", peerScheme, c.values.PeerServiceName, c.namespace, pointer.Int32Deref(c.values.ServerPort, defaultServerPort)),
-		AdvertiseClientUrls: fmt.Sprintf("%s@%s@%s@%d", clientScheme, c.values.PeerServiceName, c.namespace, pointer.Int32Deref(c.values.ClientPort, defaultClientPort)),
+		AdvertisePeerUrls:   fmt.Sprintf("%s://%s.%s:%d", peerScheme, c.values.PeerServiceName, c.namespace, pointer.Int32Deref(c.values.ServerPort, defaultServerPort)),
+		AdvertiseClientUrls: fmt.Sprintf("%s://%s.%s:%d", clientScheme, c.values.PeerServiceName, c.namespace, pointer.Int32Deref(c.values.ClientPort, defaultClientPort)),
 	}
 
 	if clientSecurity != nil {

--- a/pkg/component/etcd/configmap/configmap.go
+++ b/pkg/component/etcd/configmap/configmap.go
@@ -86,7 +86,7 @@ func (c *component) syncConfigmap(ctx context.Context, cm *corev1.ConfigMap) err
 		Name:                    fmt.Sprintf("etcd-%s", c.values.EtcdUID[:6]),
 		DataDir:                 "/var/etcd/data/new.etcd",
 		Metrics:                 string(druidv1alpha1.Basic),
-		SnapshotCount:           defaultSnapshotCount,
+		SnapshotCount:           pointer.IntDeref(c.values.SnapshotCount, defaultSnapshotCount),
 		EnableV2:                false,
 		QuotaBackendBytes:       quota,
 		InitialClusterToken:     defaultInitialClusterToken,

--- a/pkg/component/etcd/configmap/configmap_test.go
+++ b/pkg/component/etcd/configmap/configmap_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Configmap", func() {
 		metricsLevel            druidv1alpha1.MetricsLevel
 		quota                   resource.Quantity
 		clientPort, serverPort  int32
+		snapshotCount           int
 		autoCompactionMode      druidv1alpha1.CompactionMode
 		autoCompactionRetention string
 		labels                  map[string]string
@@ -76,6 +77,7 @@ var _ = Describe("Configmap", func() {
 		quota = resource.MustParse("8Gi")
 		clientPort = 2222
 		serverPort = 3333
+		snapshotCount = 75000
 		autoCompactionMode = "periodic"
 		autoCompactionRetention = "30m"
 
@@ -122,8 +124,9 @@ var _ = Describe("Configmap", func() {
 							Name: "peer-url-etcd-server-tls",
 						},
 					},
-					ClientPort: &clientPort,
-					ServerPort: &serverPort,
+					ClientPort:    &clientPort,
+					ServerPort:    &serverPort,
+					SnapshotCount: &snapshotCount,
 				},
 				Common: druidv1alpha1.SharedConfig{
 					AutoCompactionMode:      &autoCompactionMode,
@@ -136,7 +139,7 @@ var _ = Describe("Configmap", func() {
 
 		cm = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("etcd-bootstrap-%s", string(values.EtcdUID[:6])),
+				Name:      fmt.Sprintf("%s-bootstrap-%s", etcd.Name, string(values.EtcdUID[:6])),
 				Namespace: namespace,
 			},
 		}

--- a/pkg/component/etcd/configmap/configmap_test.go
+++ b/pkg/component/etcd/configmap/configmap_test.go
@@ -205,7 +205,7 @@ func checkConfigMap(cm *corev1.ConfigMap, values *Values, namespace string) {
 		"name":                Equal(fmt.Sprintf("etcd-%s", values.EtcdUID[:6])),
 		"data-dir":            Equal("/var/etcd/data/new.etcd"),
 		"metrics":             Equal(string(druidv1alpha1.Basic)),
-		"snapshot-count":      Equal(float64(75000)),
+		"snapshot-count":      Equal(float64(*values.SnapshotCount)),
 		"enable-v2":           Equal(false),
 		"quota-backend-bytes": Equal(float64(values.Quota.Value())),
 

--- a/pkg/component/etcd/configmap/configmap_test.go
+++ b/pkg/component/etcd/configmap/configmap_test.go
@@ -217,7 +217,7 @@ func checkConfigMap(cm *corev1.ConfigMap, values *Values, namespace string) {
 			"auto-tls":         Equal(false),
 		}),
 		"listen-client-urls":    Equal(fmt.Sprintf("https://0.0.0.0:%d", *values.ClientPort)),
-		"advertise-client-urls": Equal(fmt.Sprintf("%s@%s@%s@%d", "https", values.PeerServiceName, namespace, *values.ClientPort)),
+		"advertise-client-urls": Equal(fmt.Sprintf("%s://%s.%s:%d", "https", values.PeerServiceName, namespace, *values.ClientPort)),
 
 		"peer-transport-security": MatchKeys(IgnoreExtras, Keys{
 			"cert-file":        Equal("/var/etcd/ssl/peer/server/tls.crt"),
@@ -227,7 +227,7 @@ func checkConfigMap(cm *corev1.ConfigMap, values *Values, namespace string) {
 			"auto-tls":         Equal(false),
 		}),
 		"listen-peer-urls":            Equal(fmt.Sprintf("https://0.0.0.0:%d", *values.ServerPort)),
-		"initial-advertise-peer-urls": Equal(fmt.Sprintf("%s@%s@%s@%d", "https", values.PeerServiceName, namespace, *values.ServerPort)),
+		"initial-advertise-peer-urls": Equal(fmt.Sprintf("%s://%s.%s:%d", "https", values.PeerServiceName, namespace, *values.ServerPort)),
 
 		"initial-cluster-token":     Equal("etcd-cluster"),
 		"initial-cluster-state":     Equal("new"),

--- a/pkg/component/etcd/configmap/values.go
+++ b/pkg/component/etcd/configmap/values.go
@@ -37,6 +37,8 @@ type Values struct {
 	Metrics *druidv1alpha1.MetricsLevel
 	// Quota defines the etcd DB quota.
 	Quota *resource.Quantity
+	// SnapshotCount defines the number of committed transactions before a snapshot is created.
+	SnapshotCount *int
 	// InitialCluster is the initial cluster value to bootstrap ETCD.
 	InitialCluster string
 	// ClientUrlTLS hold the TLS configuration details for Client Communication

--- a/pkg/component/etcd/configmap/values.go
+++ b/pkg/component/etcd/configmap/values.go
@@ -37,7 +37,7 @@ type Values struct {
 	Metrics *druidv1alpha1.MetricsLevel
 	// Quota defines the etcd DB quota.
 	Quota *resource.Quantity
-	// SnapshotCount defines the number of committed transactions before a snapshot is created.
+	// SnapshotCount defines the number of committed transactions to trigger a snapshot to disk
 	SnapshotCount *int
 	// InitialCluster is the initial cluster value to bootstrap ETCD.
 	InitialCluster string

--- a/pkg/component/etcd/configmap/values_helper.go
+++ b/pkg/component/etcd/configmap/values_helper.go
@@ -31,6 +31,7 @@ func GenerateValues(etcd *druidv1alpha1.Etcd) *Values {
 		EtcdUID:                 etcd.UID,
 		Metrics:                 etcd.Spec.Etcd.Metrics,
 		Quota:                   etcd.Spec.Etcd.Quota,
+		SnapshotCount:           etcd.Spec.Etcd.SnapshotCount,
 		InitialCluster:          initialCluster,
 		ClientUrlTLS:            etcd.Spec.Etcd.ClientUrlTLS,
 		PeerUrlTLS:              etcd.Spec.Etcd.PeerUrlTLS,

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -766,7 +766,7 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"ConfigMap": PointTo(MatchFields(IgnoreExtras, Fields{
 									"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-										"Name": Equal(fmt.Sprintf("etcd-bootstrap-%s", string(values.OwnerReference.UID[:6]))),
+										"Name": Equal(values.ConfigMapName),
 									}),
 									"DefaultMode": PointTo(Equal(int32(0644))),
 									"Items": MatchAllElements(keyIterator, Elements{

--- a/test/e2e/etcd_backup_test.go
+++ b/test/e2e/etcd_backup_test.go
@@ -260,7 +260,7 @@ func checkEtcdReady(ctx context.Context, cl client.Client, logger logr.Logger, e
 
 	logger.Info("Checking configmap")
 	cm := &corev1.ConfigMap{}
-	ExpectWithOffset(2, cl.Get(ctx, client.ObjectKey{Name: "etcd-bootstrap-" + string(etcd.UID[:6]), Namespace: etcd.Namespace}, cm)).To(Succeed())
+	ExpectWithOffset(2, cl.Get(ctx, client.ObjectKey{Name: etcd.Name + "-bootstrap-" + string(etcd.UID[:6]), Namespace: etcd.Namespace}, cm)).To(Succeed())
 
 	logger.Info("Checking client service")
 	svc := &corev1.Service{}
@@ -293,7 +293,7 @@ func deleteAndCheckEtcd(ctx context.Context, cl client.Client, logger logr.Logge
 	ExpectWithOffset(1,
 		cl.Get(
 			ctx,
-			client.ObjectKey{Name: "etcd-bootstrap-" + string(etcd.UID[:6]), Namespace: etcd.Namespace},
+			client.ObjectKey{Name: etcd.Name + "-bootstrap-" + string(etcd.UID[:6]), Namespace: etcd.Namespace},
 			&corev1.ConfigMap{},
 		),
 	).Should(matchers.BeNotFoundError())

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -122,8 +122,9 @@ var (
 			"memory": resource.MustParse("1Gi"),
 		},
 	}
-	etcdClientPort = int32(2379)
-	etcdServerPort = int32(2380)
+	etcdClientPort    = int32(2379)
+	etcdServerPort    = int32(2380)
+	etcdSnapshotCount = 75000
 
 	backupPort                 = int32(8080)
 	backupFullSnapshotSchedule = "0 */1 * * *"
@@ -204,6 +205,7 @@ func getDefaultEtcd(name, namespace, container, prefix string, provider TestProv
 		Resources:               &etcdResources,
 		ClientPort:              &etcdClientPort,
 		ServerPort:              &etcdServerPort,
+		SnapshotCount:           &etcdSnapshotCount,
 		ClientUrlTLS:            &etcdTLS,
 	}
 

--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -538,9 +538,9 @@ func validateDefaultValuesForEtcd(instance *druidv1alpha1.Etcd, s *appsv1.Statef
 		"enable-v2":                   Equal(false),
 		"quota-backend-bytes":         Equal(float64(8589934592)),
 		"listen-client-urls":          Equal(fmt.Sprintf("http://0.0.0.0:%d", clientPort)),
-		"advertise-client-urls":       Equal(fmt.Sprintf("%s@%s@%s@%d", "http", prSvc.Name, instance.Namespace, clientPort)),
+		"advertise-client-urls":       Equal(fmt.Sprintf("%s://%s.%s:%d", "http", prSvc.Name, instance.Namespace, clientPort)),
 		"listen-peer-urls":            Equal(fmt.Sprintf("http://0.0.0.0:%d", serverPort)),
-		"initial-advertise-peer-urls": Equal(fmt.Sprintf("%s@%s@%s@%d", "http", prSvc.Name, instance.Namespace, serverPort)),
+		"initial-advertise-peer-urls": Equal(fmt.Sprintf("%s://%s.%s:%d", "http", prSvc.Name, instance.Namespace, serverPort)),
 		"initial-cluster-token":       Equal("etcd-cluster"),
 		"initial-cluster-state":       Equal("new"),
 		"auto-compaction-mode":        Equal(string(druidv1alpha1.Periodic)),
@@ -882,7 +882,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 			"auto-tls":         Equal(false),
 		}),
 		"listen-client-urls":    Equal(fmt.Sprintf("https://0.0.0.0:%d", *instance.Spec.Etcd.ClientPort)),
-		"advertise-client-urls": Equal(fmt.Sprintf("%s@%s@%s@%d", "https", prSvc.Name, instance.Namespace, *instance.Spec.Etcd.ClientPort)),
+		"advertise-client-urls": Equal(fmt.Sprintf("%s://%s.%s:%d", "https", prSvc.Name, instance.Namespace, *instance.Spec.Etcd.ClientPort)),
 
 		"peer-transport-security": MatchKeys(IgnoreExtras, Keys{
 			"cert-file":        Equal("/var/etcd/ssl/peer/server/tls.crt"),
@@ -892,7 +892,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 			"auto-tls":         Equal(false),
 		}),
 		"listen-peer-urls":            Equal(fmt.Sprintf("https://0.0.0.0:%d", *instance.Spec.Etcd.ServerPort)),
-		"initial-advertise-peer-urls": Equal(fmt.Sprintf("%s@%s@%s@%d", "https", prSvc.Name, instance.Namespace, *instance.Spec.Etcd.ServerPort)),
+		"initial-advertise-peer-urls": Equal(fmt.Sprintf("%s://%s.%s:%d", "https", prSvc.Name, instance.Namespace, *instance.Spec.Etcd.ServerPort)),
 
 		"initial-cluster-token":     Equal("etcd-cluster"),
 		"initial-cluster-state":     Equal("new"),

--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -782,7 +782,7 @@ func validateDefaultValuesForEtcd(instance *druidv1alpha1.Etcd, s *appsv1.Statef
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"ConfigMap": PointTo(MatchFields(IgnoreExtras, Fields{
 									"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-										"Name": Equal(fmt.Sprintf("etcd-bootstrap-%s", string(instance.UID[:6]))),
+										"Name": Equal(fmt.Sprintf("%s-bootstrap-%s", instance.Name, string(instance.UID[:6]))),
 									}),
 									"DefaultMode": PointTo(Equal(int32(0644))),
 									"Items": MatchAllElements(testutils.KeyIterator, Elements{
@@ -847,7 +847,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 
 	Expect(*cm).To(MatchFields(IgnoreExtras, Fields{
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-			"Name":      Equal(fmt.Sprintf("etcd-bootstrap-%s", string(instance.UID[:6]))),
+			"Name":      Equal(fmt.Sprintf("%s-bootstrap-%s", instance.Name, string(instance.UID[:6]))),
 			"Namespace": Equal(instance.Namespace),
 			"Labels": MatchAllKeys(Keys{
 				"name":     Equal("etcd"),
@@ -1190,7 +1190,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"ConfigMap": PointTo(MatchFields(IgnoreExtras, Fields{
 									"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
-										"Name": Equal(fmt.Sprintf("etcd-bootstrap-%s", string(instance.UID[:6]))),
+										"Name": Equal(fmt.Sprintf("%s-bootstrap-%s", instance.Name, string(instance.UID[:6]))),
 									}),
 									"DefaultMode": PointTo(Equal(int32(0644))),
 									"Items": MatchAllElements(testutils.KeyIterator, Elements{

--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -63,6 +63,7 @@ var (
 	clientPort              int32 = 2379
 	serverPort              int32 = 2380
 	backupPort              int32 = 8080
+	snapshotCount                 = 75000
 	defaultStorageCapacity        = resource.MustParse("16Gi")
 	deltaSnapShotMemLimit         = resource.MustParse("100Mi")
 	autoCompactionMode            = druidv1alpha1.Periodic
@@ -533,7 +534,7 @@ func validateDefaultValuesForEtcd(instance *druidv1alpha1.Etcd, s *appsv1.Statef
 		"name":                        Equal(fmt.Sprintf("etcd-%s", instance.UID[:6])),
 		"data-dir":                    Equal("/var/etcd/data/new.etcd"),
 		"metrics":                     Equal(string(druidv1alpha1.Basic)),
-		"snapshot-count":              Equal(float64(75000)),
+		"snapshot-count":              Equal(float64(snapshotCount)),
 		"enable-v2":                   Equal(false),
 		"quota-backend-bytes":         Equal(float64(8589934592)),
 		"listen-client-urls":          Equal(fmt.Sprintf("http://0.0.0.0:%d", clientPort)),
@@ -869,7 +870,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 		"name":                Equal(fmt.Sprintf("etcd-%s", instance.UID[:6])),
 		"data-dir":            Equal("/var/etcd/data/new.etcd"),
 		"metrics":             Equal(string(*instance.Spec.Etcd.Metrics)),
-		"snapshot-count":      Equal(float64(75000)),
+		"snapshot-count":      Equal(float64(snapshotCount)),
 		"enable-v2":           Equal(false),
 		"quota-backend-bytes": Equal(float64(instance.Spec.Etcd.Quota.Value())),
 

--- a/test/utils/configmap.go
+++ b/test/utils/configmap.go
@@ -30,7 +30,7 @@ func ConfigMapIsCorrectlyReconciled(c client.Client, timeout time.Duration, inst
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	req := types.NamespacedName{
-		Name:      fmt.Sprintf("etcd-bootstrap-%s", string(instance.UID[:6])),
+		Name:      fmt.Sprintf("%s-bootstrap-%s", instance.Name, string(instance.UID[:6])),
 		Namespace: instance.Namespace,
 	}
 

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -40,6 +40,7 @@ var (
 	clientPort              int32 = 2379
 	serverPort              int32 = 2380
 	backupPort              int32 = 8080
+	snapshotCount                 = 75000
 	imageEtcd                     = "europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:v0.1.0"
 	imageBR                       = "europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:v0.25.0"
 	snapshotSchedule              = "0 */24 * * *"
@@ -351,8 +352,9 @@ func getDefaultEtcd(name, namespace string) *druidv1alpha1.Etcd {
 						"memory": ParseQuantity("1000Mi"),
 					},
 				},
-				ClientPort: &clientPort,
-				ServerPort: &serverPort,
+				ClientPort:    &clientPort,
+				ServerPort:    &serverPort,
+				SnapshotCount: &snapshotCount,
 			},
 			Common: druidv1alpha1.SharedConfig{
 				AutoCompactionMode:      &autoCompactionMode,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/kind enhancement

**What this PR does / why we need it**:

This PR is to cleanup the Etcd ConfigMap to :

- [ ] Rename the configMap with the prefix of `etcd.Name` instead of just having `etcd`. This is in consistent with the other resources that gets created as part of Etcd Reconciliation, like leases, role, rolebinding, etc. This also involves cleanup logic for the existing configMap with older name. 
- [ ] Make `snapshot-count` configurable with the flag `snapshotCount` from `spec.etcd` section of etcd CR thus the operator is able to control the no.of transactions before committing a snapshot to disk if they want to.
- [ ] Use proper URLs for `initial-advertise-peer-urls` and `advertise-client-urls` properties of the configMap and thereby fixing #476

**Which issue(s) this PR fixes**:
Fixes #717

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enhances Etcd configuration by organizing ConfigMap naming convention, enabling snapshot-count configuration, and rectifying URL issues for improved functionality and consistency
```
