### PR TITLE
Configure `0640` permissions to mounted files on ETCD

### DIFF
--- a/controllers/etcdcopybackupstask/reconciler.go
+++ b/controllers/etcdcopybackupstask/reconciler.go
@@ -465,7 +465,8 @@ func (r *Reconciler) createVolumesFromStore(ctx context.Context, store *druidv1a
 			Name: getVolumeNamePrefix(prefix) + "etcd-backup",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: store.SecretRef.Name,
+					SecretName:  store.SecretRef.Name,
+					DefaultMode: pointer.Int32(0640),
 				},
 			},
 		})

--- a/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/controllers/etcdcopybackupstask/reconciler_test.go
@@ -621,7 +621,8 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 						Expect(volumeSource).NotTo(BeNil())
 						Expect(volumeSource.Secret).NotTo(BeNil())
 						Expect(*volumeSource.Secret).To(Equal(corev1.SecretVolumeSource{
-							SecretName: store.SecretRef.Name,
+							SecretName:  store.SecretRef.Name,
+							DefaultMode: pointer.Int32(0640),
 						}))
 					})
 

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/retry"
 	gardenerretry "github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -190,12 +189,12 @@ func (c *component) WaitCleanup(ctx context.Context) error {
 		err = c.client.Get(ctx, client.ObjectKeyFromObject(sts), sts)
 		switch {
 		case apierrors.IsNotFound(err):
-			return retry.Ok()
+			return gardenerretry.Ok()
 		case err == nil:
 			// StatefulSet is still available, so we should retry.
 			return false, nil
 		default:
-			return retry.SevereError(err)
+			return gardenerretry.SevereError(err)
 		}
 	})
 }
@@ -537,6 +536,7 @@ func (c *component) createOrPatch(ctx context.Context, sts *appsv1.StatefulSet, 
 				RunAsGroup:   pointer.Int64(65532),
 				RunAsNonRoot: pointer.Bool(true),
 				RunAsUser:    pointer.Int64(65532),
+				FSGroup:      pointer.Int64(65532),
 			}
 		}
 
@@ -808,7 +808,7 @@ func getVolumes(ctx context.Context, cl client.Client, logger logr.Logger, val V
 							Path: "etcd.conf.yaml",
 						},
 					},
-					DefaultMode: pointer.Int32(0644),
+					DefaultMode: pointer.Int32(0640),
 				},
 			},
 		},
@@ -819,7 +819,8 @@ func getVolumes(ctx context.Context, cl client.Client, logger logr.Logger, val V
 			Name: "client-url-ca-etcd",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: val.ClientUrlTLS.TLSCASecretRef.Name,
+					SecretName:  val.ClientUrlTLS.TLSCASecretRef.Name,
+					DefaultMode: pointer.Int32(0640),
 				},
 			},
 		},
@@ -827,7 +828,8 @@ func getVolumes(ctx context.Context, cl client.Client, logger logr.Logger, val V
 				Name: "client-url-etcd-server-tls",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: val.ClientUrlTLS.ServerTLSSecretRef.Name,
+						SecretName:  val.ClientUrlTLS.ServerTLSSecretRef.Name,
+						DefaultMode: pointer.Int32(0640),
 					},
 				},
 			},
@@ -835,7 +837,8 @@ func getVolumes(ctx context.Context, cl client.Client, logger logr.Logger, val V
 				Name: "client-url-etcd-client-tls",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: val.ClientUrlTLS.ClientTLSSecretRef.Name,
+						SecretName:  val.ClientUrlTLS.ClientTLSSecretRef.Name,
+						DefaultMode: pointer.Int32(0640),
 					},
 				},
 			})
@@ -846,7 +849,8 @@ func getVolumes(ctx context.Context, cl client.Client, logger logr.Logger, val V
 			Name: "peer-url-ca-etcd",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: val.PeerUrlTLS.TLSCASecretRef.Name,
+					SecretName:  val.PeerUrlTLS.TLSCASecretRef.Name,
+					DefaultMode: pointer.Int32(0640),
 				},
 			},
 		},
@@ -854,7 +858,8 @@ func getVolumes(ctx context.Context, cl client.Client, logger logr.Logger, val V
 				Name: "peer-url-etcd-server-tls",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: val.PeerUrlTLS.ServerTLSSecretRef.Name,
+						SecretName:  val.PeerUrlTLS.ServerTLSSecretRef.Name,
+						DefaultMode: pointer.Int32(0640),
 					},
 				},
 			})
@@ -896,7 +901,8 @@ func getVolumes(ctx context.Context, cl client.Client, logger logr.Logger, val V
 			Name: "etcd-backup",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: storeValues.SecretRef.Name,
+					SecretName:  storeValues.SecretRef.Name,
+					DefaultMode: pointer.Int32(0640),
 				},
 			},
 		})

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -523,7 +523,8 @@ func checkBackup(etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) {
 		Name: "etcd-backup",
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: etcd.Spec.Backup.Store.SecretRef.Name,
+				SecretName:  etcd.Spec.Backup.Store.SecretRef.Name,
+				DefaultMode: pointer.Int32(0640),
 			},
 		},
 	}))
@@ -768,7 +769,7 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 									"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
 										"Name": Equal(fmt.Sprintf("etcd-bootstrap-%s", string(values.OwnerReference.UID[:6]))),
 									}),
-									"DefaultMode": PointTo(Equal(int32(0644))),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 									"Items": MatchAllElements(keyIterator, Elements{
 										"etcd.conf.yaml": MatchFields(IgnoreExtras, Fields{
 											"Key":  Equal("etcd.conf.yaml"),
@@ -782,7 +783,8 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 							"Name": Equal("etcd-backup"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(values.BackupStore.SecretRef.Name),
+									"SecretName":  Equal(values.BackupStore.SecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -790,7 +792,8 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 							"Name": Equal("client-url-etcd-server-tls"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(values.ClientUrlTLS.ServerTLSSecretRef.Name),
+									"SecretName":  Equal(values.ClientUrlTLS.ServerTLSSecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -798,7 +801,8 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 							"Name": Equal("client-url-etcd-client-tls"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(values.ClientUrlTLS.ClientTLSSecretRef.Name),
+									"SecretName":  Equal(values.ClientUrlTLS.ClientTLSSecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -806,7 +810,8 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 							"Name": Equal("client-url-ca-etcd"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(values.ClientUrlTLS.TLSCASecretRef.Name),
+									"SecretName":  Equal(values.ClientUrlTLS.TLSCASecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -814,7 +819,8 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 							"Name": Equal("peer-url-etcd-server-tls"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(values.PeerUrlTLS.ServerTLSSecretRef.Name),
+									"SecretName":  Equal(values.PeerUrlTLS.ServerTLSSecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -822,7 +828,8 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 							"Name": Equal("peer-url-ca-etcd"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(values.PeerUrlTLS.TLSCASecretRef.Name),
+									"SecretName":  Equal(values.PeerUrlTLS.TLSCASecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -851,7 +851,7 @@ func etcdZeroDownTimeValidatorJob(etcdSvc, testName string, tls *v1alpha1.TLSCon
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  tls.TLSCASecretRef.Name,
-							DefaultMode: pointer.Int32(420),
+							DefaultMode: pointer.Int32(416),
 						},
 					},
 				},
@@ -860,7 +860,7 @@ func etcdZeroDownTimeValidatorJob(etcdSvc, testName string, tls *v1alpha1.TLSCon
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  tls.ClientTLSSecretRef.Name,
-							DefaultMode: pointer.Int32(420),
+							DefaultMode: pointer.Int32(416),
 						},
 					},
 				},
@@ -869,7 +869,7 @@ func etcdZeroDownTimeValidatorJob(etcdSvc, testName string, tls *v1alpha1.TLSCon
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  tls.ServerTLSSecretRef.Name,
-							DefaultMode: pointer.Int32(420),
+							DefaultMode: pointer.Int32(416),
 						},
 					},
 				},
@@ -983,7 +983,7 @@ func getDebugPod(etcd *v1alpha1.Etcd) *corev1.Pod {
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  etcd.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.Name,
-							DefaultMode: pointer.Int32(420),
+							DefaultMode: pointer.Int32(416),
 						},
 					},
 				},
@@ -992,7 +992,7 @@ func getDebugPod(etcd *v1alpha1.Etcd) *corev1.Pod {
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  etcd.Spec.Etcd.ClientUrlTLS.ClientTLSSecretRef.Name,
-							DefaultMode: pointer.Int32(420),
+							DefaultMode: pointer.Int32(416),
 						},
 					},
 				},
@@ -1001,7 +1001,7 @@ func getDebugPod(etcd *v1alpha1.Etcd) *corev1.Pod {
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  etcd.Spec.Etcd.ClientUrlTLS.ServerTLSSecretRef.Name,
-							DefaultMode: pointer.Int32(420),
+							DefaultMode: pointer.Int32(416),
 						},
 					},
 				},

--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -783,7 +783,7 @@ func validateDefaultValuesForEtcd(instance *druidv1alpha1.Etcd, s *appsv1.Statef
 									"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
 										"Name": Equal(fmt.Sprintf("etcd-bootstrap-%s", string(instance.UID[:6]))),
 									}),
-									"DefaultMode": PointTo(Equal(int32(0644))),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 									"Items": MatchAllElements(testutils.KeyIterator, Elements{
 										"etcd.conf.yaml": MatchFields(IgnoreExtras, Fields{
 											"Key":  Equal("etcd.conf.yaml"),
@@ -1191,7 +1191,7 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 									"LocalObjectReference": MatchFields(IgnoreExtras, Fields{
 										"Name": Equal(fmt.Sprintf("etcd-bootstrap-%s", string(instance.UID[:6]))),
 									}),
-									"DefaultMode": PointTo(Equal(int32(0644))),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 									"Items": MatchAllElements(testutils.KeyIterator, Elements{
 										"etcd.conf.yaml": MatchFields(IgnoreExtras, Fields{
 											"Key":  Equal("etcd.conf.yaml"),
@@ -1205,7 +1205,8 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 							"Name": Equal("client-url-etcd-server-tls"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(instance.Spec.Etcd.ClientUrlTLS.ServerTLSSecretRef.Name),
+									"SecretName":  Equal(instance.Spec.Etcd.ClientUrlTLS.ServerTLSSecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -1213,7 +1214,8 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 							"Name": Equal("client-url-etcd-client-tls"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(instance.Spec.Etcd.ClientUrlTLS.ClientTLSSecretRef.Name),
+									"SecretName":  Equal(instance.Spec.Etcd.ClientUrlTLS.ClientTLSSecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -1221,7 +1223,8 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 							"Name": Equal("client-url-ca-etcd"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(instance.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.Name),
+									"SecretName":  Equal(instance.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -1229,7 +1232,8 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 							"Name": Equal("peer-url-etcd-server-tls"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(instance.Spec.Etcd.PeerUrlTLS.ServerTLSSecretRef.Name),
+									"SecretName":  Equal(instance.Spec.Etcd.PeerUrlTLS.ServerTLSSecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -1237,7 +1241,8 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 							"Name": Equal("peer-url-ca-etcd"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(instance.Spec.Etcd.PeerUrlTLS.TLSCASecretRef.Name),
+									"SecretName":  Equal(instance.Spec.Etcd.PeerUrlTLS.TLSCASecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -1330,7 +1335,8 @@ func validateStoreGCP(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *co
 							"Name": Equal("etcd-backup"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+									"SecretName":  Equal(instance.Spec.Backup.Store.SecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -1387,7 +1393,8 @@ func validateStoreAzure(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *
 							"Name": Equal("etcd-backup"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+									"SecretName":  Equal(instance.Spec.Backup.Store.SecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -1443,7 +1450,8 @@ func validateStoreOpenstack(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet,
 							"Name": Equal("etcd-backup"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+									"SecretName":  Equal(instance.Spec.Backup.Store.SecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -1501,7 +1509,8 @@ func validateStoreAlicloud(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, 
 							"Name": Equal("etcd-backup"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+									"SecretName":  Equal(instance.Spec.Backup.Store.SecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),
@@ -1559,7 +1568,8 @@ func validateStoreAWS(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, _ *co
 							"Name": Equal("etcd-backup"),
 							"VolumeSource": MatchFields(IgnoreExtras, Fields{
 								"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
-									"SecretName": Equal(instance.Spec.Backup.Store.SecretRef.Name),
+									"SecretName":  Equal(instance.Spec.Backup.Store.SecretRef.Name),
+									"DefaultMode": PointTo(Equal(int32(0640))),
 								})),
 							}),
 						}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:
This PR enhances security by revoking other groups access to mounted files on `etcd` by configuring `0640` permissions. `0640` are the minimal possible permissions  for files that `etcd` need to be able to read given that `etcd` pods run as `65532` user/group and mounted files are with owner user root (cannot be changed easily https://github.com/kubernetes/kubernetes/issues/81089) and group `65532` ( set by fsGroup). 

This PR is in sync with Kubernetes' STIG.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR is similar to g/g [PR 8790](https://github.com/gardener/gardener/pull/8790).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
ETCD pods now mount files with `DefaultMode` set to `0640`.
```
