### PR TITLE
Map `stackit` infra provider to S3

### DIFF
--- a/pkg/utils/store.go
+++ b/pkg/utils/store.go
@@ -30,6 +30,7 @@ const (
 	openstack = "openstack"
 	dell      = "dell"
 	openshift = "openshift"
+	stackit   = "stackit"
 )
 
 const (
@@ -78,7 +79,7 @@ func StorageProviderFromInfraProvider(infra *druidv1alpha1.StorageProvider) (str
 	}
 
 	switch *infra {
-	case aws, S3:
+	case aws, stackit, S3:
 		return S3, nil
 	case azure, ABS:
 		return ABS, nil

--- a/pkg/utils/store.go
+++ b/pkg/utils/store.go
@@ -79,7 +79,10 @@ func StorageProviderFromInfraProvider(infra *druidv1alpha1.StorageProvider) (str
 	}
 
 	switch *infra {
-	case aws, stackit, S3:
+	case aws, S3:
+		return S3, nil
+	// S3 compatible providers
+	case stackit:
 		return S3, nil
 	case azure, ABS:
 		return ABS, nil


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Adds a new constant for the infrastructure provider `stackit` and maps it to the StorageProvider `S3`, since they offer S3 compatible storage, see https://www.stackit.de/de/produkt/stackit-object-storage/

**Release note**:
```feature user
Added support for new backup store provider `stackit` which is an alias for `S3`.
```
