### PR TITLE
Add the `vendor` directory to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /dev
 /vendor
 *.test
+default.etcd*
+default.bkp*
 
 *.coverprofile
 /cover.out

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.kube-secrets
 /tmp/*
 /dev
+/vendor
 *.test
 
 *.coverprofile
@@ -13,6 +14,7 @@
 .vscode
 .idea
 .DS_Store
+.ignore
 *~
 
 ./etcd-druid
@@ -23,6 +25,7 @@ config.img
 config.vmdk
 
 hack/e2e-test/infrastructure/overlays/gcp/common/assets
+hack/e2e-test/infrastructure/kind/kubeconfig
 
 /test/integration/resources/charts/*
 /test/integration/resources/repository/cache
@@ -34,6 +37,3 @@ hack/e2e-test/infrastructure/overlays/gcp/common/assets
 
 .cache_ggshield
 .gitguardian.yaml
-
-hack/e2e-test/infrastructure/kind/kubeconfig
-


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
#748 removed the `vendor` directory from `etcd-druid` and makes the project rely on the module cache set up by the `go` tool for finding dependencies.

However, there are use cases where for better developer experience, it would make sense to have the dependencies reside in the same project folder as `etcd-druid`, so that tokens can be searched for, using project wide search in any text editor. Results can be fetched from the dependencies, without having to rely on the LSP. For example, this would make looking at all usages of a constant that is defined by a dependency easier.

The developer can simply run `go mod vendor` without it affecting the modified build process which doesn't use `vendor`, as defined in #748.

However, to not break the current build process which doesn't use the `vendor` directory anymore, rename the `vendor` directory to anything else while running `make run` or `make docker-build` (`mv vendor .vendor` for example).

**Special notes for your reviewer**:
/hold till #777 merges.

```other developer
NONE
```