### PR TITLE
Fix component descriptor script

### DIFF
--- a/.ci/hack/component_descriptor
+++ b/.ci/hack/component_descriptor
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
+# Derived from https://github.com/gardener/gardener/blob/v1.86.0/hack/.ci/component_descriptor
+
 # Configuration Options:
 #
 # COMPONENT_PREFIXES: Set the image prefix that should be used to
 #                     determine if an image is defined by another component.
-#                     Defaults to "eu.gcr.io/gardener-project/gardener,europe-docker.pkg.dev/gardener-project"
+#                     Defaults to "europe-docker.pkg.dev/gardener-project/public/gardener"
 #
 # COMPONENT_CLI_ARGS: Set all component-cli arguments.
 #                     This should be used with care as all defaults are overwritten.
@@ -55,7 +57,9 @@ fi
 if [[ ! -z "$image_vector_path" ]]; then
   # default environment variables
   if [[ -z "${COMPONENT_PREFIXES}" ]]; then
-    COMPONENT_PREFIXES="eu.gcr.io/gardener-project/gardener,europe-docker.pkg.dev/gardener-project"
+    # Match only images with OCM component references, ie, images created from gardener org repositories.
+    # In other words, don't match external images like europe-docker.pkg.dev/gardener-project/public/3rd/alpine.
+    COMPONENT_PREFIXES="europe-docker.pkg.dev/gardener-project/public/gardener"
   fi
 
   if [[ -z "${COMPONENT_CLI_ARGS}" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ include $(GARDENER_HACK_DIR)/tools.mk
 .PHONY: tidy
 tidy:
 	@env GO111MODULE=on go mod tidy
-	@mkdir -p $(REPO_ROOT)/.ci/hack && cp $(GARDENER_HACK_DIR)/.ci/* $(REPO_ROOT)/.ci/hack/ && chmod +xw $(REPO_ROOT)/.ci/hack/*
 	@GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) bash $(HACK_DIR)/update-github-templates.sh
 	@cp $(GARDENER_HACK_DIR)/cherry-pick-pull.sh $(HACK_DIR)/cherry-pick-pull.sh && chmod +xw $(HACK_DIR)/cherry-pick-pull.sh
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
Druid head update job fails on [latest master branch](https://concourse.ci.gardener.cloud/teams/gardener/pipelines/etcd-druid-master/jobs/master-head-update-job/builds/123), due to a change in component descriptor script. This PR fixes that.

<details>
<summary> Previous and fixed component descriptors</summary>

Previous component descriptor:
```yaml
component:
  componentReferences:
  - componentName: github.com/gardener/etcd-backup-restore
    extraIdentity: {}
    labels:
    - name: imagevector.gardener.cloud/images
      value:
        images:
        - name: etcd-backup-restore
          repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
          resourceId:
            name: etcdbrctl
          sourceRepository: github.com/gardener/etcd-backup-restore
          tag: v0.24.8
    name: etcd-backup-restore
    version: v0.24.8
  - componentName: github.com/gardener/etcd-custom-image
    extraIdentity: {}
    labels:
    - name: imagevector.gardener.cloud/images
      value:
        images:
        - name: etcd
          repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd
          resourceId:
            name: etcd
          sourceRepository: github.com/gardener/etcd-custom-image
          tag: v3.4.26-3
    name: etcd
    version: v3.4.26-3
  - componentName: github.com/gardener/etcd-backup-restore
    extraIdentity: {}
    labels:
    - name: imagevector.gardener.cloud/images
      value:
        images:
        - name: etcd-backup-restore-distroless
          repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
          resourceId:
            name: etcdbrctl
          sourceRepository: github.com/gardener/etcd-backup-restore
          tag: v0.28.0
    name: etcd-backup-restore-distroless
    version: v0.28.0
  - componentName: github.com/gardener/etcd-wrapper
    extraIdentity: {}
    labels:
    - name: imagevector.gardener.cloud/images
      value:
        images:
        - name: etcd-wrapper
          repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
          resourceId:
            name: etcd-wrapper
          sourceRepository: github.com/gardener/etcd-wrapper
          tag: v0.1.1
    name: etcd-wrapper
    version: v0.1.1
  - componentName: null
    extraIdentity: {}
    labels:
    - name: imagevector.gardener.cloud/images
      value:
        images:
        - name: alpine
          repository: europe-docker.pkg.dev/gardener-project/public/3rd/alpine
          resourceId:
            name: alpine
          tag: 3.18.4
    name: alpine
    version: 3.18.4
  labels:
  - name: cloud.gardener/ocm/creation-date
    value: '2024-04-16T09:08:11.229957+00:00'
  name: github.com/gardener/etcd-druid
  provider: internal
  repositoryContexts:
  - baseUrl: europe-docker.pkg.dev/gardener-project/snapshots
    subPath: null
    type: ociRegistry
  resources:
  - access:
      imageReference: europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcd-druid:v0.23.0-dev-637da10c12b8df72e46532e04a0fd4768ced60d9
      type: ociRegistry
    labels:
    - name: gardener.cloud/cve-categorisation
      value:
        authentication_enforced: false
        availability_requirement: low
        confidentiality_requirement: high
        integrity_requirement: high
        network_exposure: private
        user_interaction: gardener-operator
    - name: cloud.gardener.cnudie/responsibles
      value:
      - teamname: gardener/etcd-druid-maintainers
        type: githubTeam
    name: etcd-druid
    relation: local
    type: ociImage
    version: v0.23.0-dev-637da10c12b8df72e46532e04a0fd4768ced60d9
  sources:
  - access:
      commit: 637da10c12b8df72e46532e04a0fd4768ced60d9
      ref: dev-637da10c12b8df72e46532e04a0fd4768ced60d9
      repoUrl: github.com/gardener/etcd-druid
      type: github
    labels:
    - name: cloud.gardener/cicd/source
      value:
        repository-classification: main
    name: github_com_gardener_etcd-druid
    type: git
    version: v0.23.0-dev-637da10c12b8df72e46532e04a0fd4768ced60d9
  version: v0.23.0-dev-637da10c12b8df72e46532e04a0fd4768ced60d9
meta:
  schemaVersion: v2
signatures: []

#generated by cc-utils
```
Notice that `component.componentReferences.componentName` is `null` for alpine image.

Fixed component descriptor:
```yaml
component:
  componentReferences:
  - componentName: github.com/gardener/etcd-backup-restore
    extraIdentity: {}
    labels:
    - name: imagevector.gardener.cloud/images
      value:
        images:
        - name: etcd-backup-restore
          repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
          resourceId:
            name: etcdbrctl
          sourceRepository: github.com/gardener/etcd-backup-restore
          tag: v0.24.8
    name: etcd-backup-restore
    version: v0.24.8
  - componentName: github.com/gardener/etcd-custom-image
    extraIdentity: {}
    labels:
    - name: imagevector.gardener.cloud/images
      value:
        images:
        - name: etcd
          repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd
          resourceId:
            name: etcd
          sourceRepository: github.com/gardener/etcd-custom-image
          tag: v3.4.26-3
    name: etcd
    version: v3.4.26-3
  - componentName: github.com/gardener/etcd-backup-restore
    extraIdentity: {}
    labels:
    - name: imagevector.gardener.cloud/images
      value:
        images:
        - name: etcd-backup-restore-distroless
          repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
          resourceId:
            name: etcdbrctl
          sourceRepository: github.com/gardener/etcd-backup-restore
          tag: v0.28.0
    name: etcd-backup-restore-distroless
    version: v0.28.0
  - componentName: github.com/gardener/etcd-wrapper
    extraIdentity: {}
    labels:
    - name: imagevector.gardener.cloud/images
      value:
        images:
        - name: etcd-wrapper
          repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
          resourceId:
            name: etcd-wrapper
          sourceRepository: github.com/gardener/etcd-wrapper
          tag: v0.1.1
    name: etcd-wrapper
    version: v0.1.1
  labels:
  - name: cloud.gardener/ocm/creation-date
    value: '2024-04-16T09:08:11.229957+00:00'
  name: github.com/gardener/etcd-druid
  provider: internal
  repositoryContexts:
  - baseUrl: europe-docker.pkg.dev/gardener-project/snapshots
    subPath: null
    type: ociRegistry
  resources:
  - access:
      imageReference: europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcd-druid:v0.23.0-dev-637da10c12b8df72e46532e04a0fd4768ced60d9
      type: ociRegistry
    labels:
    - name: gardener.cloud/cve-categorisation
      value:
        authentication_enforced: false
        availability_requirement: low
        confidentiality_requirement: high
        integrity_requirement: high
        network_exposure: private
        user_interaction: gardener-operator
    - name: cloud.gardener.cnudie/responsibles
      value:
      - teamname: gardener/etcd-druid-maintainers
        type: githubTeam
    name: etcd-druid
    relation: local
    type: ociImage
    version: v0.23.0-dev-637da10c12b8df72e46532e04a0fd4768ced60d9
  - access:
      imageReference: europe-docker.pkg.dev/gardener-project/public/3rd/alpine:3.18.4
      type: ociRegistry
    labels:
    - name: imagevector.gardener.cloud/name
      value: alpine
    - name: imagevector.gardener.cloud/repository
      value: europe-docker.pkg.dev/gardener-project/public/3rd/alpine
    name: alpine
    relation: external
    type: ociImage
    version: 3.18.4
  sources:
  - access:
      commit: 637da10c12b8df72e46532e04a0fd4768ced60d9
      ref: dev-637da10c12b8df72e46532e04a0fd4768ced60d9
      repoUrl: github.com/gardener/etcd-druid
      type: github
    labels:
    - name: cloud.gardener/cicd/source
      value:
        repository-classification: main
    name: github_com_gardener_etcd-druid
    type: git
    version: v0.23.0-dev-637da10c12b8df72e46532e04a0fd4768ced60d9
  version: v0.23.0-dev-637da10c12b8df72e46532e04a0fd4768ced60d9
meta:
  schemaVersion: v2
signatures: []

#generated by cc-utils
```

</details>

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
