### PR TITLE
Add new labels to sts pods, for backward compatibility with v0.23.0, which includes #777

### DIFF
--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -462,6 +462,15 @@ func (e *Etcd) GetFullSnapshotLeaseName() string {
 	return fmt.Sprintf("%s-full-snap", e.Name)
 }
 
+// GetMemberLeaseNames returns the name of member leases for the Etcd.
+func (e *Etcd) GetMemberLeaseNames() []string {
+	leaseNames := make([]string, 0, e.Spec.Replicas)
+	for i := 0; i < int(e.Spec.Replicas); i++ {
+		leaseNames = append(leaseNames, fmt.Sprintf("%s-%d", e.Name, i))
+	}
+	return leaseNames
+}
+
 // GetDefaultLabels returns the default labels for etcd.
 func (e *Etcd) GetDefaultLabels() map[string]string {
 	return map[string]string{

--- a/api/v1alpha1/types_etcd.go
+++ b/api/v1alpha1/types_etcd.go
@@ -447,6 +447,15 @@ func (e *Etcd) GetCompactionJobName() string {
 	return fmt.Sprintf("%s-compactor", e.Name)
 }
 
+// GetAllPodNames returns the names of all pods for the Etcd.
+func (e *Etcd) GetAllPodNames(replicas int32) []string {
+	podNames := make([]string, 0, replicas)
+	for i := 0; i < int(replicas); i++ {
+		podNames = append(podNames, e.GetOrdinalPodName(i))
+	}
+	return podNames
+}
+
 // GetOrdinalPodName returns the Etcd pod name based on the ordinal.
 func (e *Etcd) GetOrdinalPodName(ordinal int) string {
 	return fmt.Sprintf("%s-%d", e.Name, ordinal)

--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -306,7 +306,7 @@ func (r *Reconciler) delete(ctx context.Context, etcd *druidv1alpha1.Etcd) (ctrl
 func (r *Reconciler) preReconcileEtcd(ctx context.Context, logger logr.Logger, etcd *druidv1alpha1.Etcd) reconcileResult {
 	statefulSetValues := componentsts.GeneratePreDeployValues(etcd)
 	stsDeployer := componentsts.New(r.Client, logger, *statefulSetValues, r.config.FeatureGates)
-	if err := stsDeployer.PreDeploy(ctx); err != nil {
+	if err := stsDeployer.PreDeploy(ctx, etcd); err != nil {
 		return reconcileResult{err: err}
 	}
 	return reconcileResult{}

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -308,7 +308,7 @@ func (c *component) waitUntilPodsUpdatedAndReady(ctx context.Context, sts *appsv
 }
 
 func (c *component) deleteWithOrphanCascade(ctx context.Context, sts *appsv1.StatefulSet) error {
-	if !utils.ContainsAllDesiredLabels(sts.Spec.Selector.MatchLabels, c.values.SelectorLabels) {
+	if !utils.ExactlyMatchesLabels(sts.Spec.Selector.MatchLabels, c.values.SelectorLabels) {
 		c.logger.Info("Deleting StatefulSet with orphan cascade", "namespace", c.values.Namespace, "name", c.values.Name)
 		return c.client.Delete(ctx, sts, client.PropagationPolicy(metav1.DeletePropagationOrphan))
 	}

--- a/pkg/component/etcd/statefulset/statefulset_test.go
+++ b/pkg/component/etcd/statefulset/statefulset_test.go
@@ -620,9 +620,13 @@ func checkStatefulset(sts *appsv1.StatefulSet, values Values) {
 						"instance": Equal(values.Name),
 					}),
 					"Labels": MatchAllKeys(Keys{
-						"foo":      Equal("bar"),
-						"name":     Equal("etcd"),
-						"instance": Equal(values.Name),
+						"foo":                          Equal("bar"),
+						"name":                         Equal("etcd"),
+						"instance":                     Equal(values.Name),
+						"app.kubernetes.io/component":  Equal("etcd-statefulset"),
+						"app.kubernetes.io/name":       Equal(values.Name),
+						"app.kubernetes.io/managed-by": Equal("etcd-druid"),
+						"app.kubernetes.io/part-of":    Equal(values.Name),
 					}),
 				}),
 				//s.Spec.Template.Spec.HostAliases

--- a/pkg/component/etcd/statefulset/values.go
+++ b/pkg/component/etcd/statefulset/values.go
@@ -39,8 +39,12 @@ type Values struct {
 
 	// Annotations is the annotation provided in ETCD spec.
 	Annotations map[string]string
-	// Labels is the labels of StatefulSet..
+	// Labels defines the labels used for the statefulset.
 	Labels map[string]string
+	// SelectorLabels defines the selector's matchLabels for the statefulset.
+	SelectorLabels map[string]string
+	// PodLabels represents the labels to be applied to the statefulset pods.
+	PodLabels map[string]string
 	// AdditionalPodLabels represents additional labels to be applied to the StatefulSet pods.
 	AdditionalPodLabels map[string]string
 	// BackupImage is the backup restore image.

--- a/pkg/utils/labels.go
+++ b/pkg/utils/labels.go
@@ -24,3 +24,11 @@ func ContainsAllDesiredLabels(actual, desired map[string]string) bool {
 	}
 	return true
 }
+
+// ExactlyMatchesLabels checks if the actual map exactly matches the desired labels.
+func ExactlyMatchesLabels(actual, desired map[string]string) bool {
+	if len(actual) != len(desired) {
+		return false
+	}
+	return ContainsAllDesiredLabels(actual, desired)
+}

--- a/pkg/utils/labels.go
+++ b/pkg/utils/labels.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+// ContainsAllDesiredLabels checks if the actual map contains all the desired labels.
+func ContainsAllDesiredLabels(actual, desired map[string]string) bool {
+	for key, desiredValue := range desired {
+		actualValue, ok := actual[key]
+		if !ok || actualValue != desiredValue {
+			return false
+		}
+	}
+	return true
+}

--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -118,10 +118,16 @@ var _ = Describe("Etcd Controller", func() {
 		It("should create and adopt statefulset", func() {
 			ctx := context.TODO()
 
+			testutils.SetStatefulSetPodsUpdated(sts)
 			testutils.SetStatefulSetReady(sts)
 			err = k8sClient.Status().Update(ctx, sts)
-			Eventually(func() (bool, error) { return testutils.IsStatefulSetCorrectlyReconciled(ctx, k8sClient, instance, sts) }, timeout, pollingInterval).Should(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() (bool, error) {
+				return testutils.IsStatefulSetCorrectlyReconciled(ctx, k8sClient, instance, sts)
+			}, timeout, pollingInterval).Should(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
 			Eventually(func() (*bool, error) {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance); err != nil {
 					return nil, err
@@ -639,9 +645,13 @@ func validateDefaultValuesForEtcd(instance *druidv1alpha1.Etcd, s *appsv1.Statef
 						"instance": Equal(instance.Name),
 					}),
 					"Labels": MatchAllKeys(Keys{
-						"app":      Equal("etcd-statefulset"),
-						"name":     Equal("etcd"),
-						"instance": Equal(instance.Name),
+						"app":                          Equal("etcd-statefulset"),
+						"name":                         Equal("etcd"),
+						"instance":                     Equal(instance.Name),
+						"app.kubernetes.io/component":  Equal("etcd-statefulset"),
+						"app.kubernetes.io/name":       Equal(instance.Name),
+						"app.kubernetes.io/managed-by": Equal("etcd-druid"),
+						"app.kubernetes.io/part-of":    Equal(instance.Name),
 					}),
 				}),
 				"Spec": MatchFields(IgnoreExtras, Fields{
@@ -993,9 +1003,13 @@ func validateEtcd(instance *druidv1alpha1.Etcd, s *appsv1.StatefulSet, cm *corev
 						"instance": Equal(instance.Name),
 					}),
 					"Labels": MatchAllKeys(Keys{
-						"app":      Equal("etcd-statefulset"),
-						"name":     Equal("etcd"),
-						"instance": Equal(instance.Name),
+						"app":                          Equal("etcd-statefulset"),
+						"name":                         Equal("etcd"),
+						"instance":                     Equal(instance.Name),
+						"app.kubernetes.io/component":  Equal("etcd-statefulset"),
+						"app.kubernetes.io/name":       Equal(instance.Name),
+						"app.kubernetes.io/managed-by": Equal("etcd-druid"),
+						"app.kubernetes.io/part-of":    Equal(instance.Name),
 					}),
 				}),
 				//s.Spec.Template.Spec.HostAliases

--- a/test/utils/statefulset.go
+++ b/test/utils/statefulset.go
@@ -51,6 +51,19 @@ func SetStatefulSetReady(s *appsv1.StatefulSet) {
 	s.Status.ReadyReplicas = replicas
 }
 
+// SetStatefulSetPodsUpdated updates the status sub-resource of the passed in StatefulSet with UpdatedReplicas, UpdateRevision and CurrentRevision
+func SetStatefulSetPodsUpdated(s *appsv1.StatefulSet) {
+	replicas := int32(1)
+	if s.Spec.Replicas != nil {
+		replicas = *s.Spec.Replicas
+	}
+	s.Status.UpdatedReplicas = replicas
+	s.Status.CurrentReplicas = replicas
+
+	s.Status.UpdateRevision = "123456"
+	s.Status.CurrentRevision = "123456"
+}
+
 // CreateStatefulSet creates a statefulset with its owner reference set to etcd.
 func CreateStatefulSet(name, namespace string, etcdUID types.UID, replicas int32) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind task

**What this PR does / why we need it**:
This PR adds new k8s-recommended labels to the etcd pods - `app.kubernetes.io/*`, as defined [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/). This is required for backward compatibility when upgrading to etcd-druid:v0.23.0, which includes #777 , which switches all component labels and selectors to the new k8s-recommended labels, such that a downgrade from v0.23.0+ to v0.22.1 will be possible.

Additionally, this PR also ensures that any new label selector set on the statefulset is replaced with old (expected) label selector, ie `{instance: <etcd-name>, name: etcd}`, to be consistent with v0.22.0.

All of this is achieved by adding support for a `preReconcileEtcd()` step for the etcd reconciler, which calls statefulset component's `PreDeploy` method, which in turn does the following:
1. If sts pod template labels don't contain old+new labels, patch the sts
2. Wait for the sts pods to be updated (rolled out) and ready
3. Delete the sts with `orphan` cascade option, so that the subsequent sts `Deploy` flow re-creates the sts with the expected (old) label selector

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Add new k8s-recommended labels to etcd pods, to support backward compatibility for etcd-druid:v0.23.0.
```
