### PR TITLE
Use localstack-s3 image instead of localstack

### DIFF
--- a/hack/e2e-test/infrastructure/localstack/localstack.yaml
+++ b/hack/e2e-test/infrastructure/localstack/localstack.yaml
@@ -24,7 +24,8 @@ spec:
               value: "1"
             - name: SERVICES
               value: s3
-          image: localstack/localstack
+          image: localstack/localstack:s3-latest
+          imagePullPolicy: IfNotPresent
           name: localstack-service
           ports:
             - containerPort: 4566


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area storage
/kind test

**What this PR does / why we need it**:

This PR modifies the localstack image used for performing tests in druid. The current `localstack` image contains a lot of other services provided by `AWS` apart from `S3` such as Lambda, DynamoDB, etc and has a compressed size of ~450 MB

The change proposes to use a much light weight version of this which provides only S3 services and has a compressed size of ~100 MB, which is a drastic reduction in size. This helps in faster setup for tests both locally and on pipelines as well. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
use `localstack:s3-latest` image instead of `localstack:latest` in tests for faster setup
```
