### PR TITLE
Fix statefulset `PreSync` to work for certain cases of unhealthy etcd clusters upon druid upgrade

### DIFF
--- a/api/v1alpha1/helper.go
+++ b/api/v1alpha1/helper.go
@@ -44,6 +44,15 @@ func GetOrdinalPodName(etcdObjMeta metav1.ObjectMeta, ordinal int) string {
 	return fmt.Sprintf("%s-%d", etcdObjMeta.Name, ordinal)
 }
 
+// GetAllPodNames returns the names of all pods for the Etcd.
+func GetAllPodNames(etcdObjMeta metav1.ObjectMeta, replicas int32) []string {
+	podNames := make([]string, 0, replicas)
+	for i := 0; i < int(replicas); i++ {
+		podNames = append(podNames, GetOrdinalPodName(etcdObjMeta, i))
+	}
+	return podNames
+}
+
 // GetMemberLeaseNames returns the name of member leases for the Etcd.
 func GetMemberLeaseNames(etcdObjMeta metav1.ObjectMeta, replicas int32) []string {
 	leaseNames := make([]string, 0, replicas)

--- a/api/v1alpha1/helper.go
+++ b/api/v1alpha1/helper.go
@@ -47,7 +47,7 @@ func GetOrdinalPodName(etcdObjMeta metav1.ObjectMeta, ordinal int) string {
 // GetAllPodNames returns the names of all pods for the Etcd.
 func GetAllPodNames(etcdObjMeta metav1.ObjectMeta, replicas int32) []string {
 	podNames := make([]string, 0, replicas)
-	for i := 0; i < int(replicas); i++ {
+	for i := range int(replicas) {
 		podNames = append(podNames, GetOrdinalPodName(etcdObjMeta, i))
 	}
 	return podNames

--- a/api/v1alpha1/helper.go
+++ b/api/v1alpha1/helper.go
@@ -46,18 +46,18 @@ func GetOrdinalPodName(etcdObjMeta metav1.ObjectMeta, ordinal int) string {
 
 // GetAllPodNames returns the names of all pods for the Etcd.
 func GetAllPodNames(etcdObjMeta metav1.ObjectMeta, replicas int32) []string {
-	podNames := make([]string, 0, replicas)
+	podNames := make([]string, replicas)
 	for i := range int(replicas) {
-		podNames = append(podNames, GetOrdinalPodName(etcdObjMeta, i))
+		podNames[i] = GetOrdinalPodName(etcdObjMeta, i)
 	}
 	return podNames
 }
 
 // GetMemberLeaseNames returns the name of member leases for the Etcd.
 func GetMemberLeaseNames(etcdObjMeta metav1.ObjectMeta, replicas int32) []string {
-	leaseNames := make([]string, 0, replicas)
-	for i := 0; i < int(replicas); i++ {
-		leaseNames = append(leaseNames, fmt.Sprintf("%s-%d", etcdObjMeta.Name, i))
+	leaseNames := make([]string, replicas)
+	for i := range int(replicas) {
+		leaseNames[i] = fmt.Sprintf("%s-%d", etcdObjMeta.Name, i)
 	}
 	return leaseNames
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR fixes statefulset `PreSync` behavior, to no longer wait for etcd pods to be updated with the latest sts spec, or to be ready. Instead, `PreSync` will now simply check whether the pods have the expected labels, and continue with the next steps. This fixes certain cases where an etcd cluster is unhealthy due to a wrong reconfiguration of the etcd configmap, causing one of the three etcd pods to fail, which causes the `PreSync` step to get stuck in the pod updated+ready check, and not allow druid to run `Sync` which reconciles and potentially fixes the issue by reverting the configmap to the correct state.

**Which issue(s) this PR fixes**:
Fixes #818 

**Special notes for your reviewer**:
While working on this fix, @unmarshall and I found certain cases where PreSync cannot succeed. Consider the following case:
1. Druid is running with old version (v0.22.0)
2. 3-node etcd cluster is deployed and ready
3. Etcd spec is updated with non-existent secret reference (TLS or backup store)
4. Etcd is reconciled, causing the rollout of the statefulset pods to start, updating pod etcd-2 to go into error state since the mentioned secret does not exist.
    1. This unhealthy pod can be caused by any other reason as well, and not necessarily a misconfiguration. We simply use this as an example to show this case.
5. Upgrade druid to v0.23.0 (or current master version)
6. Reconcile the Etcd. This causes the PreSync to get stuck since the statefulset rollout is stuck since the pod never becomes ready.
7. Druid marks the Etcd status.lastOperation as `Operation: Reconcile, State: Failed`.
8. Now, the user sees this and figures out the Etcd spec misconfiguration issue, corrects the Etcd spec with correct configuration and reconciles the Etcd again. Druid will now succeed and the etcd cluster becomes healthy and also updated with new labels.
9. Thus, misconfiguration or transient errors can be overcome by the current druid logic after this fix PR.
10. But, if before the druid upgrade, there is a data corruption in the etcd cluster, causing a quorum loss, then the new druid PreSync will not be able to handle this, and this is a current limitation of the reconciliation logic today. Druid will still mark the `Reconcile` operation as `Failed`, and an operator will need to manually look into it and fix it by performing a recovery from quorum loss using [this guide](https://github.com/gardener/etcd-druid/blob/master/docs/operations/recovery-from-permanent-quorum-loss-in-etcd-cluster.md).

/invite @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
12. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Before upgrading druid to `v0.23.0+`, please ensure that druid is running with at least `v0.22.3+`. This is required to avoid any downtime during the upgrade of the etcds by the new druid version, as well as to ensure backward compatibility of your etcds, in case you wish to downgrade back to `v0.22.3+`.
```
