### PR TITLE
Upgrade etcd-backup-restore from v0.24.8-> v0.24.9 and etcd-backup-restore-distroless from v0.28.0 -> v0.29.0

### DIFF
--- a/internal/images/images.yaml
+++ b/internal/images/images.yaml
@@ -4,7 +4,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.24.8"
+  tag: "v0.24.9"
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd
@@ -14,7 +14,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.28.0"
+  tag: "v0.29.0"
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper


### PR DESCRIPTION
**Release Notes**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement developer github.com/gardener/etcd-backup-restore #723 @renormalize
Added documentation to use `etcdbrctl` as a process for testing locally, for a better developer experience and faster iteration speeds.
```

```improvement developer github.com/gardener/etcd-backup-restore #699 @renormalize
Added support to use Azurite, which emulates Azure Blob Storage for local development and testing - which can be enabled by setting the `AZURE_EMULATOR_ENABLED` and  `AZURITE_STORAGE_API_ENDPOINT` environment variables.
```

```improvement developer github.com/gardener/etcd-backup-restore #710 @renormalize
Improved error handling for OpenStack Swift during deletion of objects.
```

```improvement developer github.com/gardener/etcd-backup-restore #697 @anveshreddy18
Added support for using fake-gcs-server for all etcdbr functionalities. To enable: Either 
1) Set `GOOGLE_EMULATOR_ENABLED` environment variable when running `etcdbrctl` command OR 
2) Set `emulatorEnabled: true` in GCP backup secret when deploying via Helm chart.
```

```improvement operator github.com/gardener/etcd-backup-restore #711 @anveshreddy18
Introduces periodic updates to the Full Snapshot Lease, addressing delays in lease updates during failures
```

```improvement operator github.com/gardener/etcd-backup-restore #719 @amold1
etcd-backup-restore now supports server-side encryption using customer provided keys (SSE-C) for S3-compatible providers
```

```improvement user github.com/gardener/etcd-backup-restore #680 @avestuk
Do not rely on the snapshotter state when stopping the snapshotter. The snapshotter will now always be closed when a member goes from being the leader to any other state. 
```

```improvement operator github.com/gardener/etcd-backup-restore #638 @shreyas-s-rao
Bump alpine base version for Docker build to `3.18.2`.
```

