### PR TITLE
Upgrade etcd-backup-restore-distroless from v0.28.0 -> v0.28.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -14,7 +14,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.28.0"
+  tag: "v0.28.1"
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper


### PR DESCRIPTION
**Release Notes**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator github.com/gardener/etcd-backup-restore #747@anveshreddy18
Introduces periodic updates to the Full Snapshot Lease, addressing delays in lease updates during failures
```