### PR TITLE
Minimize probability of race condition between etcd and custodian controllers for etcd status updates

### DIFF
--- a/controllers/etcd/reconciler.go
+++ b/controllers/etcd/reconciler.go
@@ -414,6 +414,10 @@ func isPeerTLSChangedToEnabled(peerTLSEnabledStatusFromMembers bool, configMapVa
 }
 
 func (r *Reconciler) updateEtcdErrorStatus(ctx context.Context, etcd *druidv1alpha1.Etcd, result reconcileResult) error {
+	if err := r.Get(ctx, client.ObjectKeyFromObject(etcd), etcd); err != nil {
+		return err
+	}
+
 	lastErrStr := result.err.Error()
 	etcd.Status.LastError = &lastErrStr
 	etcd.Status.ObservedGeneration = &etcd.Generation
@@ -427,6 +431,10 @@ func (r *Reconciler) updateEtcdErrorStatus(ctx context.Context, etcd *druidv1alp
 }
 
 func (r *Reconciler) updateEtcdStatus(ctx context.Context, etcd *druidv1alpha1.Etcd, result reconcileResult) error {
+	if err := r.Get(ctx, client.ObjectKeyFromObject(etcd), etcd); err != nil {
+		return err
+	}
+
 	if result.sts != nil {
 		ready, _ := druidutils.IsStatefulSetReady(etcd.Spec.Replicas, result.sts)
 		etcd.Status.Ready = &ready
@@ -450,6 +458,10 @@ func (r *Reconciler) removeOperationAnnotation(ctx context.Context, logger logr.
 }
 
 func (r *Reconciler) updateEtcdStatusAsNotReady(ctx context.Context, etcd *druidv1alpha1.Etcd) (*druidv1alpha1.Etcd, error) {
+	if err := r.Get(ctx, client.ObjectKeyFromObject(etcd), etcd); err != nil {
+		return nil, err
+	}
+
 	etcd.Status.Ready = nil
 	etcd.Status.ReadyReplicas = 0
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Minimize probability of race condition between etcd and custodian controllers for etcd status updates, by re-fetching the etcd resource whenever etcd controller is about to update the etcd resource status.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This fix is not required on master branch, since there is no custodian controller there, hence no race condition.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
