### PR TITLE
Upgrade `github.com/gardener/etcd-backup-restore` dependency from 0.26.0 to 0.29.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gardener/etcd-druid
 go 1.22
 
 require (
-	github.com/gardener/etcd-backup-restore v0.26.0
+	github.com/gardener/etcd-backup-restore v0.29.0
 	github.com/gardener/gardener v1.86.4
 	github.com/go-logr/logr v1.2.4
 	github.com/golang-jwt/jwt/v5 v5.2.1

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
-github.com/gardener/etcd-backup-restore v0.26.0 h1:ux0U5OT6IwtFiGbx4d3q+KYGRg6dTxBULPm8DL73E98=
-github.com/gardener/etcd-backup-restore v0.26.0/go.mod h1:cAY12PXK6oJgh5X/V6AuQ8eCpJspPNlnbNSwwjToj18=
+github.com/gardener/etcd-backup-restore v0.29.0 h1:awzXySrK8GBMiMigdi9dEfqyulas2FEwnBWxzheULtA=
+github.com/gardener/etcd-backup-restore v0.29.0/go.mod h1:cAY12PXK6oJgh5X/V6AuQ8eCpJspPNlnbNSwwjToj18=
 github.com/gardener/gardener v1.86.4 h1:uxMalw67jddMXliPhv5vs1nOB7G8hbFE1XKoyZjIMlE=
 github.com/gardener/gardener v1.86.4/go.mod h1:8eHlXs2EkaghrgQwK8qEiVw3dZGpNJaq+I9IkPpReA4=
 github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287JjjUiUL18OqPLyAA=


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:

This PR updates the `github.com/gardener/etcd-backup-restore` dependency version from `0.26.0` to `0.29.0`. 

This is required to run the e2e tests using [`FakeGCS`](https://github.com/gardener/etcd-druid/pull/741) and [`Azurite`](https://github.com/gardener/etcd-druid/pull/753) emulators as storage providers. As the support for these were released as part of `etcdbr v0.29.0`. The respective `etcdbr` PR's are : [etcdbr#697](https://github.com/gardener/etcd-backup-restore/pull/697) & [etcdbr#699](https://github.com/gardener/etcd-backup-restore/pull/699). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrade `github.com/gardener/etcd-backup-restore` dependency from `0.26.0` to `0.29.0`
```
