### PR TITLE
Fixes pre-deploy step having incorrect desired labels and adds a temp fix for race condition

### DIFF
--- a/controllers/custodian/reconciler.go
+++ b/controllers/custodian/reconciler.go
@@ -20,6 +20,7 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 
+	ctrlutils "github.com/gardener/etcd-druid/controllers/utils"
 	"github.com/gardener/etcd-druid/pkg/health/status"
 	"github.com/gardener/etcd-druid/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -73,6 +74,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	logger := r.logger.WithValues("etcd", kutil.Key(etcd.Namespace, etcd.Name).String())
+
+	if ctrlutils.HasOperationAnnotation(etcd) {
+		logger.Info("Skipping custodian-reconcile as etcd still has a reconcile annotation set on it.")
+		return ctrl.Result{
+			RequeueAfter: 5 * time.Second,
+		}, nil
+	}
 
 	if etcd.Status.LastError != nil && *etcd.Status.LastError != "" {
 		logger.Info("Requeue item because of last error", "namespace", etcd.Namespace, "name", etcd.Name, "lastError", *etcd.Status.LastError)

--- a/controllers/custodian/reconciler.go
+++ b/controllers/custodian/reconciler.go
@@ -76,9 +76,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	logger := r.logger.WithValues("etcd", kutil.Key(etcd.Namespace, etcd.Name).String())
 
 	if ctrlutils.HasOperationAnnotation(etcd) {
-		logger.Info("Skipping custodian-reconcile as etcd still has a reconcile annotation set on it.")
+		logger.Info("Skipping custodian-reconcile as etcd still has a reconcile annotation set on it. Will retry after 10s.")
 		return ctrl.Result{
-			RequeueAfter: 5 * time.Second,
+			RequeueAfter: 10 * time.Second,
 		}, nil
 	}
 

--- a/controllers/predicate/predicate.go
+++ b/controllers/predicate/predicate.go
@@ -18,7 +18,8 @@ import (
 	"reflect"
 	"strings"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/etcd-druid/controllers/utils"
+
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -31,21 +32,17 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 )
 
-func hasOperationAnnotation(obj client.Object) bool {
-	return obj.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile
-}
-
 // HasOperationAnnotation is a predicate for the operation annotation.
 func HasOperationAnnotation() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(event event.CreateEvent) bool {
-			return hasOperationAnnotation(event.Object)
+			return utils.HasOperationAnnotation(event.Object)
 		},
 		UpdateFunc: func(event event.UpdateEvent) bool {
-			return hasOperationAnnotation(event.ObjectNew)
+			return utils.HasOperationAnnotation(event.ObjectNew)
 		},
 		GenericFunc: func(event event.GenericEvent) bool {
-			return hasOperationAnnotation(event.Object)
+			return utils.HasOperationAnnotation(event.Object)
 		},
 		DeleteFunc: func(event event.DeleteEvent) bool {
 			return true
@@ -127,7 +124,7 @@ func EtcdReconciliationFinished(ignoreOperationAnnotation bool) predicate.Predic
 		condition := *etcd.Status.ObservedGeneration == etcd.Generation
 
 		if !ignoreOperationAnnotation {
-			condition = condition && !hasOperationAnnotation(etcd)
+			condition = condition && !utils.HasOperationAnnotation(etcd)
 		}
 
 		return condition

--- a/controllers/utils/reconciler.go
+++ b/controllers/utils/reconciler.go
@@ -17,6 +17,9 @@ package utils
 import (
 	"path/filepath"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/gardener/etcd-druid/pkg/common"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 )
@@ -40,4 +43,9 @@ func CreateImageVector() (imagevector.ImageVector, error) {
 		return nil, err
 	}
 	return imageVector, nil
+}
+
+// HasOperationAnnotation checks if the given object has the operation annotation and its value is set to Reconcile.
+func HasOperationAnnotation(obj client.Object) bool {
+	return obj.GetAnnotations()[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile
 }

--- a/pkg/component/etcd/statefulset/statefulset.go
+++ b/pkg/component/etcd/statefulset/statefulset.go
@@ -299,7 +299,7 @@ func (c *component) waitUntilPodsHaveDesiredLabels(ctx context.Context, etcd *dr
 			if err := c.client.Get(ctx, client.ObjectKey{Name: podName, Namespace: etcd.Namespace}, pod); err != nil {
 				return false, err
 			}
-			if !utils.ContainsAllDesiredLabels(pod.Labels, utils.MergeStringMaps(c.values.PodLabels, c.values.AdditionalPodLabels)) {
+			if !utils.ContainsAllDesiredLabels(pod.Labels, c.values.PodLabels) {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
In hotfix branch `PreDeploy` step was introduced to ensure that etcd-druid is backward compatible with the changes that are made in master w.r.t pod labels and statefulset label-selector. An issue was discovered when running e2e g/g tests.

Desired labels passed to [utils.ContainsAllDesiredLabels](https://github.com/gardener/etcd-druid/blob/876927637414906e86ad3f798de6641e8713d975/pkg/component/etcd/statefulset/statefulset.go#L302) contains the additional labels which are fetched from `etcd.Spec.Labels`. When g/g e2e tests are run then in case we upgrade existing etcd cluster from 1 to 3, g/g will add additional networking labels on the etcd resource. These labels will never be present on the pod in the `PreDeploy` step. This will result in the reconciliation getting stuck at this stage. `Deploy` step is never called, so the new labels that are added by g/g on the etcd resource never make it to the pods.

> NOTE: This is not caught in druid e2e tests because we do not add additional labels to etcd resource when running an upgrade test from 1 to 3 replicas. We should make this change so that these issues can be caught early and not when g/g e2e tests are run.

Additionally we now add one more safeguard in the custodian controller to skip reconciliation if the reconcile annotation is still added on the etcd resource and retry after 10s. This is done in addition to the already present predicate which also does something similar. However the predicate does not prevent requeue of requests due to error in the custodian which can still interfere with the etcd reconciler.

**Which issue(s) this PR fixes**:
Fixes #836 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes the labels comparison check done in the PreDeploy step which ensures that the pods have both the old and the new labels.
```
