### PR TITLE
Fix e2e Tests to Support HA Upgrade Label Changes

### DIFF
--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -150,6 +150,7 @@ var _ = Describe("Etcd", func() {
 			By("Scaling up a healthy cluster (from 1 to 3 replicas)")
 			Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
 			etcd.Spec.Replicas = 3
+			etcd.Spec.Labels["multi-node"] = "true"
 			updateAndCheckEtcd(ctx, cl, objLogger, etcd, multiNodeEtcdTimeout)
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/area high-availability
/kind bug
**What this PR does / why we need it**:
This PR updates the e2e test cases to handle scenarios where etcd clusters are upgraded from nonHA to HA, specifically addressing issues with network labeling during pre-deployment checks. The modifications ensure that tests will pass even when new labels are introduced during the upgrade process.

**Which issue(s) this PR fixes**:
Fixes #837

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated e2e tests to support label changes during HA upgrades, preventing the reconciliation process from getting stuck and ensuring smooth transitions in deployment scenarios.


```
