### PR TITLE
Fix integration tests by ensuring necessary pods are created

### DIFF
--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -121,9 +120,9 @@ var _ = Describe("Etcd Controller", func() {
 
 			testutils.SetStatefulSetPodsUpdated(sts)
 			testutils.SetStatefulSetReady(sts)
-			createStsPods(ctx, k8sClient, sts)
+			testutils.CreateStsPods(ctx, k8sClient, sts)
 			DeferCleanup(func() {
-				deleteStsPods(ctx, k8sClient, sts)
+				testutils.DeleteStsPods(ctx, k8sClient, sts)
 			})
 
 			err = k8sClient.Status().Update(ctx, sts)
@@ -1677,65 +1676,3 @@ var _ = Describe("buildPredicate", func() {
 		)
 	})
 })
-
-func createStsPods(ctx context.Context, cl client.Client, sts *appsv1.StatefulSet) {
-	stsReplicas := *sts.Spec.Replicas
-	for i := 0; i < int(stsReplicas); i++ {
-		podName := fmt.Sprintf("%s-%d", sts.Name, i)
-
-		podLabels := utils.MergeStringMaps(sts.Spec.Template.Labels, map[string]string{
-			"apps.kubernetes.io/pod-index":       strconv.Itoa(i),
-			"statefulset.kubernetes.io/pod-name": podName,
-			"controller-revision-hash":           sts.Status.UpdateRevision,
-		})
-
-		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      podName,
-				Namespace: sts.Namespace,
-				Labels:    podLabels,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion:         appsv1.SchemeGroupVersion.Version,
-						Kind:               "StatefulSet",
-						BlockOwnerDeletion: pointer.Bool(true),
-						Name:               sts.Name,
-						UID:                sts.UID,
-					},
-				},
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "etcd",
-						Image: "etcd-wrapper:latest",
-					},
-				},
-			},
-		}
-
-		ExpectWithOffset(1, cl.Create(ctx, pod)).To(Succeed())
-		// Update pod status and set ready condition to true
-		pod.Status.Conditions = []corev1.PodCondition{
-			{
-				Type:   corev1.PodReady,
-				Status: corev1.ConditionTrue,
-			},
-		}
-		ExpectWithOffset(1, cl.Status().Update(ctx, pod)).To(Succeed())
-	}
-}
-
-func deleteStsPods(ctx context.Context, cl client.Client, sts *appsv1.StatefulSet) {
-	stsReplicas := *sts.Spec.Replicas
-	for i := 0; i < int(stsReplicas); i++ {
-		podName := fmt.Sprintf("%s-%d", sts.Name, i)
-		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      podName,
-				Namespace: sts.Namespace,
-			},
-		}
-		ExpectWithOffset(1, cl.Delete(ctx, pod)).To(Succeed())
-	}
-}

--- a/test/integration/controllers/etcd/reconciler_test.go
+++ b/test/integration/controllers/etcd/reconciler_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -120,6 +121,11 @@ var _ = Describe("Etcd Controller", func() {
 
 			testutils.SetStatefulSetPodsUpdated(sts)
 			testutils.SetStatefulSetReady(sts)
+			createStsPods(ctx, k8sClient, sts)
+			DeferCleanup(func() {
+				deleteStsPods(ctx, k8sClient, sts)
+			})
+
 			err = k8sClient.Status().Update(ctx, sts)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1671,3 +1677,65 @@ var _ = Describe("buildPredicate", func() {
 		)
 	})
 })
+
+func createStsPods(ctx context.Context, cl client.Client, sts *appsv1.StatefulSet) {
+	stsReplicas := *sts.Spec.Replicas
+	for i := 0; i < int(stsReplicas); i++ {
+		podName := fmt.Sprintf("%s-%d", sts.Name, i)
+
+		podLabels := utils.MergeStringMaps(sts.Spec.Template.Labels, map[string]string{
+			"apps.kubernetes.io/pod-index":       strconv.Itoa(i),
+			"statefulset.kubernetes.io/pod-name": podName,
+			"controller-revision-hash":           sts.Status.UpdateRevision,
+		})
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: sts.Namespace,
+				Labels:    podLabels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         appsv1.SchemeGroupVersion.Version,
+						Kind:               "StatefulSet",
+						BlockOwnerDeletion: pointer.Bool(true),
+						Name:               sts.Name,
+						UID:                sts.UID,
+					},
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "etcd",
+						Image: "etcd-wrapper:latest",
+					},
+				},
+			},
+		}
+
+		ExpectWithOffset(1, cl.Create(ctx, pod)).To(Succeed())
+		// Update pod status and set ready condition to true
+		pod.Status.Conditions = []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			},
+		}
+		ExpectWithOffset(1, cl.Status().Update(ctx, pod)).To(Succeed())
+	}
+}
+
+func deleteStsPods(ctx context.Context, cl client.Client, sts *appsv1.StatefulSet) {
+	stsReplicas := *sts.Spec.Replicas
+	for i := 0; i < int(stsReplicas); i++ {
+		podName := fmt.Sprintf("%s-%d", sts.Name, i)
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: sts.Namespace,
+			},
+		}
+		ExpectWithOffset(1, cl.Delete(ctx, pod)).To(Succeed())
+	}
+}

--- a/test/utils/misc.go
+++ b/test/utils/misc.go
@@ -15,11 +15,12 @@
 package utils
 
 import (
+	"os"
+
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"os"
 )
 
 func MatchFinalizer(finalizer string) gomegatypes.GomegaMatcher {
@@ -57,4 +58,29 @@ func SwitchDirectory(path string) func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 	}
+}
+
+// mergeStringMaps merges the content of the newMaps with the oldMap. If a key already exists then
+// it gets overwritten by the last value with the same key.
+func mergeStringMaps(oldMap map[string]string, newMaps ...map[string]string) map[string]string {
+	var out map[string]string
+
+	if oldMap != nil {
+		out = make(map[string]string)
+	}
+	for k, v := range oldMap {
+		out[k] = v
+	}
+
+	for _, newMap := range newMaps {
+		if newMap != nil && out == nil {
+			out = make(map[string]string)
+		}
+
+		for k, v := range newMap {
+			out[k] = v
+		}
+	}
+
+	return out
 }

--- a/test/utils/statefulset.go
+++ b/test/utils/statefulset.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	"github.com/gardener/etcd-druid/pkg/utils"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -137,7 +136,7 @@ func CreateStsPods(ctx context.Context, cl client.Client, sts *appsv1.StatefulSe
 	for i := 0; i < int(stsReplicas); i++ {
 		podName := fmt.Sprintf("%s-%d", sts.Name, i)
 
-		podLabels := utils.MergeStringMaps(sts.Spec.Template.Labels, map[string]string{
+		podLabels := mergeStringMaps(sts.Spec.Template.Labels, map[string]string{
 			"apps.kubernetes.io/pod-index":       strconv.Itoa(i),
 			"statefulset.kubernetes.io/pod-name": podName,
 			"controller-revision-hash":           sts.Status.UpdateRevision,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:

This PR fixes integration test failures observed after merging PR [#804](https://github.com/gardener/etcd-druid/pull/804), which added new Kubernetes-recommended labels to etcd pods. The existing tests failed because they expected these pods to be present to [verify the labels](https://github.com/gardener/etcd-druid/blob/876927637414906e86ad3f798de6641e8713d975/pkg/component/etcd/statefulset/statefulset.go#L290-L308), but the pods were not created in the test environment. This PR resolves the issue by ensuring that the necessary StatefulSet pods are created and subsequently cleaned up within the integration tests.


**Which issue(s) this PR fixes**:
Fixes #831

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes integration test failures by ensuring necessary StatefulSet pods are created and deleted appropriately during tests to align with updates made in PR [#804](https://github.com/gardener/etcd-druid/pull/804).
```
