### PR TITLE
Fix build information in logs

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -33,5 +33,5 @@ GIT_SHA="${GIT_SHA:-$(git rev-parse --short HEAD || echo "GitNotFound")}"
 CGO_ENABLED=0 GO111MODULE=on go build \
   -v \
   -o "${BINARY_PATH}"/etcd-druid \
-  -ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION} -X ${REPOSITORY}/pkg/version.GitSHA=${GIT_SHA}" \
+  -ldflags "-w -X ${REPOSITORY}/internal/version.Version=${VERSION} -X ${REPOSITORY}/internal/version.GitSHA=${GIT_SHA}" \
   main.go

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION             := $(shell cat VERSION)
 REPO_ROOT           := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 HACK_DIR            := $(REPO_ROOT)/hack
+VERSION             := $(shell $(HACK_DIR)/get-version.sh)
+GIT_SHA             := $(shell git rev-parse --short HEAD || echo "GitNotFound")
 REGISTRY            := europe-docker.pkg.dev/gardener-project/snapshots
 IMAGE_REPOSITORY    := $(REGISTRY)/gardener/etcd-druid
 IMAGE_BUILD_TAG     := $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -160,15 +160,15 @@ deploy-via-kustomize: manifests $(KUSTOMIZE)
 # Modify the Helm template located at charts/druid/templates if any changes are required
 .PHONY: deploy
 deploy: $(SKAFFOLD) $(HELM)
-	$(SKAFFOLD) run -m etcd-druid
+	@VERSION=$(VERSION) GIT_SHA=$(GIT_SHA) $(SKAFFOLD) run -m etcd-druid
 
 .PHONY: deploy-dev
 deploy-dev: $(SKAFFOLD) $(HELM)
-	$(SKAFFOLD) dev --cleanup=false -m etcd-druid --trigger='manual'
+	@VERSION=$(VERSION) GIT_SHA=$(GIT_SHA) $(SKAFFOLD) dev --cleanup=false -m etcd-druid --trigger='manual'
 
 .PHONY: deploy-debug
 deploy-debug: $(SKAFFOLD) $(HELM)
-	$(SKAFFOLD) debug --cleanup=false -m etcd-druid
+	@VERSION=$(VERSION) GIT_SHA=$(GIT_SHA) $(SKAFFOLD) debug --cleanup=false -m etcd-druid
 
 .PHONY: undeploy
 undeploy: $(SKAFFOLD) $(HELM)
@@ -184,7 +184,7 @@ deploy-azurite: $(KUBECTL)
 
 .PHONY: test-e2e
 test-e2e: $(KUBECTL) $(HELM) $(SKAFFOLD) $(KUSTOMIZE)
-	@$(HACK_DIR)/e2e-test/run-e2e-test.sh $(PROVIDERS)
+	@VERSION=$(VERSION) GIT_SHA=$(GIT_SHA) $(HACK_DIR)/e2e-test/run-e2e-test.sh $(PROVIDERS)
 
 .PHONY: ci-e2e-kind
 ci-e2e-kind:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,6 +17,10 @@ build:
             - VERSION
         flags:
           - -v
+        ldflags:
+          - -w
+          - -X github.com/gardener/etcd-druid/internal/version.Version={{.VERSION}}
+          - -X github.com/gardener/etcd-druid/internal/version.GitSHA={{.GIT_SHA}}
 deploy:
   helm:
     releases:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
Fix build information in logs, due to change in package structure from `pkg` to `internal`, as well as missing ldflags in skaffold KO build manifest.

I have also added 3 new Makefile targets: `docker-clean`, `clean-build-cache`, `clean-mod-cache`. The first two are helpful in cleaning up the cache created by KO builds for druid images, to make it easy to test changes in the PR (since KO reuses caches unless something in the code changes, as specified in the skaffold manifest).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Add Make target `make docker-clean` for cleaning up all docker builds related to etcd-druid.
```
```other developer
Add Make targets `make clean-build-cache` and `make clean-mod-cache` for cleaning up Go build and mod caches respectively.
```
