### PR TITLE
Compaction job shouldn't add `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotation to compaction pod.

### DIFF
--- a/internal/controller/compaction/reconciler.go
+++ b/internal/controller/compaction/reconciler.go
@@ -38,6 +38,9 @@ import (
 const (
 	// DefaultETCDQuota is the default etcd quota.
 	DefaultETCDQuota = 8 * 1024 * 1024 * 1024 // 8Gi
+
+	// SafeToEvictKey - annotation that ignores constraints to evict a pod if set to "false".
+	SafeToEvictKey = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 )
 
 // Reconciler reconciles compaction jobs for Etcd resources.
@@ -284,7 +287,7 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 			BackoffLimit:          pointer.Int32(0),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: etcd.Spec.Annotations,
+					Annotations: getEtcdCompactionAnnotations(etcd.Spec.Annotations),
 					Labels:      getLabels(etcd),
 				},
 				Spec: v1.PodSpec{
@@ -492,4 +495,17 @@ func getCompactionJobArgs(etcd *druidv1alpha1.Etcd, metricsScrapeWaitDuration st
 	}
 
 	return command
+}
+
+func getEtcdCompactionAnnotations(etcdAnnotations map[string]string) map[string]string {
+	etcdCompactionAnnotations := make(map[string]string)
+
+	for key, value := range etcdAnnotations {
+		// Do not add annotation: `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` to compaction job's pod template.
+		if key == SafeToEvictKey && value == etcdAnnotations[SafeToEvictKey] {
+			continue
+		}
+		etcdCompactionAnnotations[key] = value
+	}
+	return etcdCompactionAnnotations
 }

--- a/internal/controller/compaction/reconciler.go
+++ b/internal/controller/compaction/reconciler.go
@@ -502,7 +502,7 @@ func getEtcdCompactionAnnotations(etcdAnnotations map[string]string) map[string]
 
 	for key, value := range etcdAnnotations {
 		// Do not add annotation: `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` to compaction job's pod template.
-		if key == SafeToEvictKey && value == etcdAnnotations[SafeToEvictKey] {
+		if key == SafeToEvictKey && value == "false" {
 			continue
 		}
 		etcdCompactionAnnotations[key] = value

--- a/internal/controller/compaction/reconciler.go
+++ b/internal/controller/compaction/reconciler.go
@@ -39,7 +39,8 @@ const (
 	// DefaultETCDQuota is the default etcd quota.
 	DefaultETCDQuota = 8 * 1024 * 1024 * 1024 // 8Gi
 
-	// SafeToEvictKey - annotation that ignores constraints to evict a pod if set to "false".
+	// SafeToEvictKey - annotation that ignores constraints to evict a pod like not being replicated, being on
+	// kube-system namespace or having a local storage if set to "false".
 	SafeToEvictKey = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 )
 

--- a/internal/controller/compaction/register_test.go
+++ b/internal/controller/compaction/register_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gardener/etcd-druid/internal/utils"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -197,6 +198,20 @@ func TestJobStatusChangedForUpdateEvents(t *testing.T) {
 			g.Expect(predicate.Update(event.UpdateEvent{ObjectOld: oldObj, ObjectNew: obj})).To(Equal(test.shouldAllowUpdateEvent))
 		})
 	}
+}
+
+func TestEtcdCompactionAnnotation(t *testing.T) {
+	test1EtcdAnnotation := map[string]string{
+		"dummy-annotation": "dummy",
+	}
+
+	test2EtcdAnnotation := map[string]string{
+		SafeToEvictKey: "false",
+	}
+
+	g := NewWithT(t)
+	compactionAnnotation := getEtcdCompactionAnnotations(utils.MergeMaps(test1EtcdAnnotation, test2EtcdAnnotation))
+	g.Expect(compactionAnnotation).To(Equal(test1EtcdAnnotation))
 }
 
 func createObjectsForJobStatusChangedPredicate(g *WithT, name string, isJobObj, isStatusChanged bool) (obj client.Object, oldObj client.Object) {


### PR DESCRIPTION
/area cost
/kind enhancement

**What this PR does / why we need it**:
Right now, compaction job adds all annotation(s) present in `etcd custom resource spec` to compaction pod template. With this PR, compaction will not add annotation: `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` to compaction pod if its present to improve node utilization.

**Which issue(s) this PR fixes**:
Fixes Point1 of #766 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator|user
To improve node utilization compaction job will not add annotation: `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` to compaction pod.
```
