### PR TITLE
Upgrade etcd-backup-restore-distroless image from `v0.28.2` to `v0.28.3`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -14,7 +14,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.28.2"
+  tag: "v0.28.3"
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates etcd-backup-restore-distroless image from `v0.28.2` to `v0.28.3`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement user #756 @renormalize 
The Azure Blob Storage domain can now be overridden by providing the overriding domain as a field in the Secret which provides credentials to etcd-backup-restore
```
