### PR TITLE
Set CPU & Memory requests for compaction job

### DIFF
--- a/internal/controller/compaction/reconciler.go
+++ b/internal/controller/compaction/reconciler.go
@@ -25,6 +25,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
@@ -296,6 +297,12 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 						Image:           etcdBackupImage,
 						ImagePullPolicy: v1.PullIfNotPresent,
 						Args:            getCompactionJobArgs(etcd, r.config.MetricsScrapeWaitDuration.String()),
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("600m"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							},
+						},
 					}},
 				},
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind enhancement

**What this PR does / why we need it**:

This PR adds CPU and Memory requests for compaction job. The requests are calculated from seed clusters and heavy load shoot clusters. This is more from a Gardener point of view. To understand why I set these numbers, you can visit the internal backlog issue 14 to know more.

Compaction Jobs originating from druid needs to have Requests & Limits ( limits can be configured after observing the landscapes with just requests set initially ) so as to allow them to get scheduled to nodes with proper resource availability. This will let the scheduler know about the consumption/expectation before hand so that it can schedule optimally so that the compaction jobs can get completed and also not interfere with resources intended for other processes.

**Which issue(s) this PR fixes**:
Fixes part of #707

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
set cpu and memory requests for compaction pods
```
