### PR TITLE
PDB component sets `unhealthyPodEvictionPolicy` based on annotation

### DIFF
--- a/internal/component/poddistruptionbudget/poddisruptionbudget.go
+++ b/internal/component/poddistruptionbudget/poddisruptionbudget.go
@@ -114,8 +114,7 @@ func buildResource(etcd *druidv1alpha1.Etcd, pdb *policyv1.PodDisruptionBudget) 
 		MatchLabels: druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta),
 	}
 	if metav1.HasAnnotation(etcd.ObjectMeta, annotationAllowUnhealthyPodEviction) {
-		alwaysAllow := policyv1.AlwaysAllow
-		pdb.Spec.UnhealthyPodEvictionPolicy = &alwaysAllow
+		pdb.Spec.UnhealthyPodEvictionPolicy = utils.PointerOf(policyv1.AlwaysAllow)
 	} else {
 		pdb.Spec.UnhealthyPodEvictionPolicy = nil
 	}

--- a/internal/component/poddistruptionbudget/poddisruptionbudget.go
+++ b/internal/component/poddistruptionbudget/poddisruptionbudget.go
@@ -29,6 +29,12 @@ const (
 	ErrDeletePodDisruptionBudget druidv1alpha1.ErrorCode = "ERR_DELETE_POD_DISRUPTION_BUDGET"
 )
 
+const (
+	// annotationAllowUnhealthyPodEviction is an annotation that can be set on the Etcd resource, to allow unhealthy pod eviction.
+	// WARNING: this annotation may be removed at any point of time, and is NOT meant to be generally used.
+	annotationAllowUnhealthyPodEviction = "resources.druid.gardener.cloud/allow-unhealthy-pod-eviction"
+)
+
 type _resource struct {
 	client client.Client
 }
@@ -106,6 +112,12 @@ func buildResource(etcd *druidv1alpha1.Etcd, pdb *policyv1.PodDisruptionBudget) 
 	}
 	pdb.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta),
+	}
+	if metav1.HasAnnotation(etcd.ObjectMeta, annotationAllowUnhealthyPodEviction) {
+		alwaysAllow := policyv1.AlwaysAllow
+		pdb.Spec.UnhealthyPodEvictionPolicy = &alwaysAllow
+	} else {
+		pdb.Spec.UnhealthyPodEvictionPolicy = nil
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
PDB component sets `unhealthyPodEvictionPolicy` based on annotation

**Which issue(s) this PR fixes**:
Fixes #854 

**Special notes for your reviewer**:
/cc @unmarshall @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
