### PR TITLE
Switch from deprecated pkg `k8s.io/utils/pointer` to recommended `k8s.io/utils/ptr` for pointer operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,14 +87,14 @@ check-apidiff: $(GO_APIDIFF)
 .PHONY: test-unit
 test-unit: $(GINKGO) $(GOTESTFMT)
 	# run ginkgo unit tests. These will be ported to golang native tests over a period of time.
-	TEST_COVER=$(TEST_COVER) "$(HACK_DIR)/test.sh" ./internal/controller/etcdcopybackupstask/... \
+	@TEST_COVER=$(TEST_COVER) "$(HACK_DIR)/test.sh" ./internal/controller/etcdcopybackupstask/... \
 	./internal/controller/secret/... \
 	./internal/controller/utils/... \
 	./internal/mapper/... \
 	./internal/metrics/... \
 	./internal/health/...
 	# run the golang native unit tests.
-	TEST_COVER=$(TEST_COVER) "$(HACK_DIR)/test-go.sh" ./api/... \
+	@TEST_COVER=$(TEST_COVER) "$(HACK_DIR)/test-go.sh" ./api/... \
 	./internal/controller/etcd/... \
 	./internal/controller/compaction/... \
 	./internal/component/... \

--- a/api/v1alpha1/helper.go
+++ b/api/v1alpha1/helper.go
@@ -9,7 +9,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // --------------- Helper functions for Etcd resource names ---------------
@@ -106,10 +106,10 @@ func GetNamespaceName(etcdObjMeta metav1.ObjectMeta) types.NamespacedName {
 // to suspend spec reconciliation for this Etcd resource. If no annotation is set then it will return nil.
 func GetSuspendEtcdSpecReconcileAnnotationKey(etcdObjMeta metav1.ObjectMeta) *string {
 	if metav1.HasAnnotation(etcdObjMeta, SuspendEtcdSpecReconcileAnnotation) {
-		return pointer.String(SuspendEtcdSpecReconcileAnnotation)
+		return ptr.To(SuspendEtcdSpecReconcileAnnotation)
 	}
 	if metav1.HasAnnotation(etcdObjMeta, IgnoreReconciliationAnnotation) {
-		return pointer.String(IgnoreReconciliationAnnotation)
+		return ptr.To(IgnoreReconciliationAnnotation)
 	}
 	return nil
 }
@@ -135,8 +135,8 @@ func GetAsOwnerReference(etcdObjMeta metav1.ObjectMeta) metav1.OwnerReference {
 		Kind:               "Etcd",
 		Name:               etcdObjMeta.Name,
 		UID:                etcdObjMeta.UID,
-		Controller:         pointer.Bool(true),
-		BlockOwnerDeletion: pointer.Bool(true),
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
 	}
 }
 

--- a/api/v1alpha1/helper_test.go
+++ b/api/v1alpha1/helper_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/gomega"
 )
@@ -127,17 +127,17 @@ func TestGetSuspendEtcdSpecReconcileAnnotationKey(t *testing.T) {
 		{
 			name:                  "SuspendEtcdSpecReconcileAnnotation is set",
 			annotations:           map[string]string{SuspendEtcdSpecReconcileAnnotation: ""},
-			expectedAnnotationKey: pointer.String(SuspendEtcdSpecReconcileAnnotation),
+			expectedAnnotationKey: ptr.To(SuspendEtcdSpecReconcileAnnotation),
 		},
 		{
 			name:                  "IgnoreReconciliationAnnotation is set",
 			annotations:           map[string]string{IgnoreReconciliationAnnotation: ""},
-			expectedAnnotationKey: pointer.String(IgnoreReconciliationAnnotation),
+			expectedAnnotationKey: ptr.To(IgnoreReconciliationAnnotation),
 		},
 		{
 			name:                  "Both annotations (SuspendEtcdSpecReconcileAnnotation and IgnoreReconciliationAnnotation) are set",
 			annotations:           map[string]string{SuspendEtcdSpecReconcileAnnotation: "", IgnoreReconciliationAnnotation: ""},
-			expectedAnnotationKey: pointer.String(SuspendEtcdSpecReconcileAnnotation),
+			expectedAnnotationKey: ptr.To(SuspendEtcdSpecReconcileAnnotation),
 		},
 	}
 	g := NewWithT(t)
@@ -201,8 +201,8 @@ func TestGetAsOwnerReference(t *testing.T) {
 		Kind:               "Etcd",
 		Name:               etcdName,
 		UID:                uid,
-		Controller:         pointer.Bool(true),
-		BlockOwnerDeletion: pointer.Bool(true),
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
 	}))
 }
 

--- a/api/validation/etcd_test.go
+++ b/api/validation/etcd_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,7 +40,7 @@ var _ = Describe("Etcd validation tests", func() {
 				Backup: v1alpha1.BackupSpec{
 					Store: &v1alpha1.StoreSpec{
 						Prefix:   fmt.Sprintf("%s--%s/%s", namespace, uuid, name),
-						Provider: (*v1alpha1.StorageProvider)(pointer.String(provider)),
+						Provider: (*v1alpha1.StorageProvider)(ptr.To(provider)),
 					},
 				},
 			},
@@ -68,7 +68,7 @@ var _ = Describe("Etcd validation tests", func() {
 
 			Entry("should forbid invalid spec.backup.store", &v1alpha1.StoreSpec{
 				Prefix:   "invalid",
-				Provider: (*v1alpha1.StorageProvider)(pointer.String("invalid")),
+				Provider: (*v1alpha1.StorageProvider)(ptr.To("invalid")),
 			}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("spec.backup.store.prefix"),
@@ -79,7 +79,7 @@ var _ = Describe("Etcd validation tests", func() {
 
 			Entry("should allow valid spec.backup.store", &v1alpha1.StoreSpec{
 				Prefix:   fmt.Sprintf("%s--%s/%s", namespace, uuid, name),
-				Provider: (*v1alpha1.StorageProvider)(pointer.String(provider)),
+				Provider: (*v1alpha1.StorageProvider)(ptr.To(provider)),
 			}, BeNil()),
 
 			Entry("should allow nil spec.backup.store", nil, BeNil()),
@@ -94,7 +94,7 @@ var _ = Describe("Etcd validation tests", func() {
 
 			newEtcd := etcd.DeepCopy()
 			newEtcd.ResourceVersion = "2"
-			newEtcd.Spec.Backup.Port = pointer.Int32(42)
+			newEtcd.Spec.Backup.Port = ptr.To[int32](42)
 
 			errList := validation.ValidateEtcdUpdate(newEtcd, etcd)
 
@@ -125,8 +125,8 @@ var _ = Describe("Etcd validation tests", func() {
 			newEtcd := etcd.DeepCopy()
 			newEtcd.ResourceVersion = "2"
 			newEtcd.Spec.Replicas = 42
-			newEtcd.Spec.Backup.Store.Container = pointer.String("foo")
-			newEtcd.Spec.Backup.Store.Provider = (*v1alpha1.StorageProvider)(pointer.String("gcp"))
+			newEtcd.Spec.Backup.Store.Container = ptr.To("foo")
+			newEtcd.Spec.Backup.Store.Provider = (*v1alpha1.StorageProvider)(ptr.To("gcp"))
 
 			errList := validation.ValidateEtcdUpdate(newEtcd, etcd)
 

--- a/api/validation/etcdcopybackupstask_test.go
+++ b/api/validation/etcdcopybackupstask_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,11 +32,11 @@ var _ = Describe("Etcd validation tests", func() {
 			Spec: v1alpha1.EtcdCopyBackupsTaskSpec{
 				SourceStore: v1alpha1.StoreSpec{
 					Prefix:   fmt.Sprintf("%s--%s/%s", namespace, uuid, name),
-					Provider: (*v1alpha1.StorageProvider)(pointer.String(provider)),
+					Provider: (*v1alpha1.StorageProvider)(ptr.To(provider)),
 				},
 				TargetStore: v1alpha1.StoreSpec{
 					Prefix:   fmt.Sprintf("%s--%s/%s", namespace, uuid, name),
-					Provider: (*v1alpha1.StorageProvider)(pointer.String(provider)),
+					Provider: (*v1alpha1.StorageProvider)(ptr.To(provider)),
 				},
 			},
 		}
@@ -64,10 +64,10 @@ var _ = Describe("Etcd validation tests", func() {
 
 			Entry("should forbid invalid spec.sourceStore and spec.targetStore", &v1alpha1.StoreSpec{
 				Prefix:   "invalid",
-				Provider: (*v1alpha1.StorageProvider)(pointer.String("invalid")),
+				Provider: (*v1alpha1.StorageProvider)(ptr.To("invalid")),
 			}, &v1alpha1.StoreSpec{
 				Prefix:   "invalid",
-				Provider: (*v1alpha1.StorageProvider)(pointer.String("invalid")),
+				Provider: (*v1alpha1.StorageProvider)(ptr.To("invalid")),
 			}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("spec.sourceStore.prefix"),
@@ -84,10 +84,10 @@ var _ = Describe("Etcd validation tests", func() {
 
 			Entry("should allow valid spec.sourceStore and spec.targetStore", &v1alpha1.StoreSpec{
 				Prefix:   fmt.Sprintf("%s--%s/%s", namespace, uuid, name),
-				Provider: (*v1alpha1.StorageProvider)(pointer.String(provider)),
+				Provider: (*v1alpha1.StorageProvider)(ptr.To(provider)),
 			}, &v1alpha1.StoreSpec{
 				Prefix:   fmt.Sprintf("%s--%s/%s", namespace, uuid, name),
-				Provider: (*v1alpha1.StorageProvider)(pointer.String(provider)),
+				Provider: (*v1alpha1.StorageProvider)(ptr.To(provider)),
 			}, BeNil()),
 		)
 	})
@@ -100,7 +100,7 @@ var _ = Describe("Etcd validation tests", func() {
 
 			newTask := task.DeepCopy()
 			newTask.ResourceVersion = "2"
-			newTask.Spec.SourceStore.Container = pointer.String("foo")
+			newTask.Spec.SourceStore.Container = ptr.To("foo")
 
 			errList := validation.ValidateEtcdCopyBackupsTaskUpdate(newTask, task)
 
@@ -134,10 +134,10 @@ var _ = Describe("Etcd validation tests", func() {
 
 			newTask := task.DeepCopy()
 			newTask.ResourceVersion = "2"
-			newTask.Spec.SourceStore.Container = pointer.String("foo")
-			newTask.Spec.SourceStore.Provider = (*v1alpha1.StorageProvider)(pointer.String("gcp"))
-			newTask.Spec.TargetStore.Container = pointer.String("bar")
-			newTask.Spec.TargetStore.Provider = (*v1alpha1.StorageProvider)(pointer.String("gcp"))
+			newTask.Spec.SourceStore.Container = ptr.To("foo")
+			newTask.Spec.SourceStore.Provider = (*v1alpha1.StorageProvider)(ptr.To("gcp"))
+			newTask.Spec.TargetStore.Container = ptr.To("bar")
+			newTask.Spec.TargetStore.Provider = (*v1alpha1.StorageProvider)(ptr.To("gcp"))
 
 			errList := validation.ValidateEtcdCopyBackupsTaskUpdate(newTask, task)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 
 ## Development
 
+* [Testing(Unit, Integration and E2E Tests)](development/testing.md)
 * [etcd Network Latency](development/etcd-network-latency.md)
 * [Getting started locally using azurite emulator](development/getting-started-locally-azurite.md)
 * [Getting started locally using localstack emulator](development/getting-started-locally-localstack.md)

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -27,7 +27,7 @@ GOIMPORTS_REVISER          := $(TOOLS_BIN_DIR)/goimports-reviser
 # default tool versions
 SKAFFOLD_VERSION := v2.13.0
 KUSTOMIZE_VERSION := v4.5.7
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v1.60.3
 CONTROLLER_GEN_VERSION ?= $(call version_gomod,sigs.k8s.io/controller-tools)
 GINKGO_VERSION ?= $(call version_gomod,github.com/onsi/ginkgo/v2)
 MOCKGEN_VERSION ?= $(call version_gomod,go.uber.org/mock)

--- a/internal/component/clientservice/clientservice.go
+++ b/internal/component/clientservice/clientservice.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -151,9 +152,9 @@ func emptyClientService(objectKey client.ObjectKey) *corev1.Service {
 }
 
 func getPorts(etcd *druidv1alpha1.Etcd) []corev1.ServicePort {
-	backupPort := utils.TypeDeref(etcd.Spec.Backup.Port, common.DefaultPortEtcdBackupRestore)
-	clientPort := utils.TypeDeref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient)
-	peerPort := utils.TypeDeref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)
+	backupPort := ptr.Deref(etcd.Spec.Backup.Port, common.DefaultPortEtcdBackupRestore)
+	clientPort := ptr.Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient)
+	peerPort := ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)
 
 	return []corev1.ServicePort{
 		{

--- a/internal/component/clientservice/clientservice_test.go
+++ b/internal/component/clientservice/clientservice_test.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
@@ -96,9 +96,9 @@ func TestSyncWhenNoServiceExists(t *testing.T) {
 		},
 		{
 			name:       "create client service with custom ports",
-			clientPort: pointer.Int32(2222),
-			backupPort: pointer.Int32(3333),
-			peerPort:   pointer.Int32(4444),
+			clientPort: ptr.To[int32](2222),
+			backupPort: ptr.To[int32](3333),
+			peerPort:   ptr.To[int32](4444),
 		},
 		{
 			name:      "create fails when there is a create error",
@@ -134,11 +134,11 @@ func TestSyncWhenNoServiceExists(t *testing.T) {
 
 func TestSyncWhenServiceExists(t *testing.T) {
 	const (
-		originalClientPort = 2379
-		originalServerPort = 2380
-		originalBackupPort = 8080
+		originalClientPort int32 = 2379
+		originalServerPort int32 = 2380
+		originalBackupPort int32 = 8080
 	)
-	existingEtcd := buildEtcd(pointer.Int32(originalClientPort), pointer.Int32(originalServerPort), pointer.Int32(originalBackupPort))
+	existingEtcd := buildEtcd(ptr.To(originalClientPort), ptr.To(originalServerPort), ptr.To(originalBackupPort))
 	testCases := []struct {
 		name          string
 		clientPort    *int32
@@ -149,12 +149,12 @@ func TestSyncWhenServiceExists(t *testing.T) {
 	}{
 		{
 			name:       "update peer service with new server port",
-			clientPort: pointer.Int32(2222),
-			peerPort:   pointer.Int32(3333),
+			clientPort: ptr.To[int32](2222),
+			peerPort:   ptr.To[int32](3333),
 		},
 		{
 			name:       "update fails when there is a patch error",
-			clientPort: pointer.Int32(2222),
+			clientPort: ptr.To[int32](2222),
 			patchErr:   testutils.TestAPIInternalErr,
 			expectedError: &druiderr.DruidError{
 				Code:      ErrSyncClientService,

--- a/internal/component/clientservice/clientservice_test.go
+++ b/internal/component/clientservice/clientservice_test.go
@@ -262,9 +262,9 @@ func buildEtcd(clientPort, peerPort, backupPort *int32) *druidv1alpha1.Etcd {
 }
 
 func matchClientService(g *WithT, etcd *druidv1alpha1.Etcd, actualSvc corev1.Service) {
-	clientPort := utils.TypeDeref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient)
-	backupPort := utils.TypeDeref(etcd.Spec.Backup.Port, common.DefaultPortEtcdBackupRestore)
-	peerPort := utils.TypeDeref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)
+	clientPort := ptr.Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient)
+	backupPort := ptr.Deref(etcd.Spec.Backup.Port, common.DefaultPortEtcdBackupRestore)
+	peerPort := ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)
 	etcdObjMeta := etcd.ObjectMeta
 	expectedLabels := druidv1alpha1.GetDefaultLabels(etcdObjMeta)
 	var expectedAnnotations map[string]string

--- a/internal/component/configmap/configmap_test.go
+++ b/internal/component/configmap/configmap_test.go
@@ -349,8 +349,8 @@ func matchConfigMap(g *WithT, etcd *druidv1alpha1.Etcd, actualConfigMap corev1.C
 		"quota-backend-bytes":       Equal(etcd.Spec.Etcd.Quota.Value()),
 		"initial-cluster-token":     Equal("etcd-cluster"),
 		"initial-cluster-state":     Equal("new"),
-		"auto-compaction-mode":      Equal(string(utils.TypeDeref(etcd.Spec.Common.AutoCompactionMode, druidv1alpha1.Periodic))),
-		"auto-compaction-retention": Equal(utils.TypeDeref(etcd.Spec.Common.AutoCompactionRetention, defaultAutoCompactionRetention)),
+		"auto-compaction-mode":      Equal(string(ptr.Deref(etcd.Spec.Common.AutoCompactionMode, druidv1alpha1.Periodic))),
+		"auto-compaction-retention": Equal(ptr.Deref(etcd.Spec.Common.AutoCompactionRetention, defaultAutoCompactionRetention)),
 	}))
 	matchClientTLSRelatedConfiguration(g, etcd, actualETCDConfig)
 	matchPeerTLSRelatedConfiguration(g, etcd, actualETCDConfig)
@@ -359,8 +359,8 @@ func matchConfigMap(g *WithT, etcd *druidv1alpha1.Etcd, actualConfigMap corev1.C
 func matchClientTLSRelatedConfiguration(g *WithT, etcd *druidv1alpha1.Etcd, actualETCDConfig map[string]interface{}) {
 	if etcd.Spec.Etcd.ClientUrlTLS != nil {
 		g.Expect(actualETCDConfig).To(MatchKeys(IgnoreExtras|IgnoreMissing, Keys{
-			"listen-client-urls":    Equal(fmt.Sprintf("https://0.0.0.0:%d", utils.TypeDeref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient))),
-			"advertise-client-urls": Equal(fmt.Sprintf("https@%s@%s@%d", druidv1alpha1.GetPeerServiceName(etcd.ObjectMeta), etcd.Namespace, utils.TypeDeref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient))),
+			"listen-client-urls":    Equal(fmt.Sprintf("https://0.0.0.0:%d", ptr.Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient))),
+			"advertise-client-urls": Equal(fmt.Sprintf("https@%s@%s@%d", druidv1alpha1.GetPeerServiceName(etcd.ObjectMeta), etcd.Namespace, ptr.Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient))),
 			"client-transport-security": MatchKeys(IgnoreExtras, Keys{
 				"cert-file":        Equal("/var/etcd/ssl/server/tls.crt"),
 				"key-file":         Equal("/var/etcd/ssl/server/tls.key"),
@@ -371,7 +371,7 @@ func matchClientTLSRelatedConfiguration(g *WithT, etcd *druidv1alpha1.Etcd, actu
 		}))
 	} else {
 		g.Expect(actualETCDConfig).To(MatchKeys(IgnoreExtras|IgnoreMissing, Keys{
-			"listen-client-urls": Equal(fmt.Sprintf("http://0.0.0.0:%d", utils.TypeDeref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient))),
+			"listen-client-urls": Equal(fmt.Sprintf("http://0.0.0.0:%d", ptr.Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient))),
 		}))
 		g.Expect(actualETCDConfig).ToNot(HaveKey("client-transport-security"))
 	}
@@ -388,12 +388,12 @@ func matchPeerTLSRelatedConfiguration(g *WithT, etcd *druidv1alpha1.Etcd, actual
 				"trusted-ca-file":  Equal("/var/etcd/ssl/peer/ca/ca.crt"),
 				"auto-tls":         Equal(false),
 			}),
-			"listen-peer-urls":            Equal(fmt.Sprintf("https://0.0.0.0:%d", utils.TypeDeref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))),
+			"listen-peer-urls":            Equal(fmt.Sprintf("https://0.0.0.0:%d", ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))),
 			"initial-advertise-peer-urls": Equal(fmt.Sprintf("https@%s@%s@%s", peerSvcName, etcd.Namespace, strconv.Itoa(int(ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))))),
 		}))
 	} else {
 		g.Expect(actualETCDConfig).To(MatchKeys(IgnoreExtras|IgnoreMissing, Keys{
-			"listen-peer-urls":            Equal(fmt.Sprintf("http://0.0.0.0:%d", utils.TypeDeref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))),
+			"listen-peer-urls":            Equal(fmt.Sprintf("http://0.0.0.0:%d", ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))),
 			"initial-advertise-peer-urls": Equal(fmt.Sprintf("http@%s@%s@%s", peerSvcName, etcd.Namespace, strconv.Itoa(int(ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))))),
 		}))
 		g.Expect(actualETCDConfig).ToNot(HaveKey("peer-transport-security"))

--- a/internal/component/configmap/configmap_test.go
+++ b/internal/component/configmap/configmap_test.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
@@ -154,7 +154,7 @@ func TestPrepareInitialCluster(t *testing.T) {
 			name:                   "should create initial cluster for single node etcd cluster when peer TLS is enabled",
 			etcdReplicas:           1,
 			peerTLSEnabled:         true,
-			etcdSpecServerPort:     pointer.Int32(2222),
+			etcdSpecServerPort:     ptr.To[int32](2222),
 			expectedInitialCluster: "etcd-test-0=https://etcd-test-0.etcd-test-peer.test-ns.svc:2222",
 		},
 		{
@@ -167,7 +167,7 @@ func TestPrepareInitialCluster(t *testing.T) {
 			name:                   "should create initial cluster for multi node etcd cluster when peer TLS is enabled",
 			etcdReplicas:           3,
 			peerTLSEnabled:         true,
-			etcdSpecServerPort:     pointer.Int32(2333),
+			etcdSpecServerPort:     ptr.To[int32](2333),
 			expectedInitialCluster: "etcd-test-0=https://etcd-test-0.etcd-test-peer.test-ns.svc:2333,etcd-test-1=https://etcd-test-1.etcd-test-peer.test-ns.svc:2333,etcd-test-2=https://etcd-test-2.etcd-test-peer.test-ns.svc:2333",
 		},
 	}
@@ -389,12 +389,12 @@ func matchPeerTLSRelatedConfiguration(g *WithT, etcd *druidv1alpha1.Etcd, actual
 				"auto-tls":         Equal(false),
 			}),
 			"listen-peer-urls":            Equal(fmt.Sprintf("https://0.0.0.0:%d", utils.TypeDeref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))),
-			"initial-advertise-peer-urls": Equal(fmt.Sprintf("https@%s@%s@%s", peerSvcName, etcd.Namespace, strconv.Itoa(int(pointer.Int32Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))))),
+			"initial-advertise-peer-urls": Equal(fmt.Sprintf("https@%s@%s@%s", peerSvcName, etcd.Namespace, strconv.Itoa(int(ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))))),
 		}))
 	} else {
 		g.Expect(actualETCDConfig).To(MatchKeys(IgnoreExtras|IgnoreMissing, Keys{
 			"listen-peer-urls":            Equal(fmt.Sprintf("http://0.0.0.0:%d", utils.TypeDeref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))),
-			"initial-advertise-peer-urls": Equal(fmt.Sprintf("http@%s@%s@%s", peerSvcName, etcd.Namespace, strconv.Itoa(int(pointer.Int32Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))))),
+			"initial-advertise-peer-urls": Equal(fmt.Sprintf("http@%s@%s@%s", peerSvcName, etcd.Namespace, strconv.Itoa(int(ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer))))),
 		}))
 		g.Expect(actualETCDConfig).ToNot(HaveKey("peer-transport-security"))
 	}

--- a/internal/component/configmap/etcdconfig.go
+++ b/internal/component/configmap/etcdconfig.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gardener/etcd-druid/internal/common"
 	"github.com/gardener/etcd-druid/internal/utils"
 
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // default values
@@ -122,7 +122,7 @@ func getSchemeAndSecurityConfig(tlsConfig *druidv1alpha1.TLSConfig, caPath, serv
 
 func prepareInitialCluster(etcd *druidv1alpha1.Etcd, peerScheme string) string {
 	domainName := fmt.Sprintf("%s.%s.%s", druidv1alpha1.GetPeerServiceName(etcd.ObjectMeta), etcd.Namespace, "svc")
-	serverPort := strconv.Itoa(int(pointer.Int32Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)))
+	serverPort := strconv.Itoa(int(ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)))
 	builder := strings.Builder{}
 	for i := 0; i < int(etcd.Spec.Replicas); i++ {
 		podName := druidv1alpha1.GetOrdinalPodName(etcd.ObjectMeta, i)

--- a/internal/component/configmap/etcdconfig.go
+++ b/internal/component/configmap/etcdconfig.go
@@ -11,7 +11,6 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/common"
-	"github.com/gardener/etcd-druid/internal/utils"
 
 	"k8s.io/utils/ptr"
 )
@@ -74,19 +73,19 @@ func createEtcdConfig(etcd *druidv1alpha1.Etcd) *etcdConfig {
 	cfg := &etcdConfig{
 		Name:                    fmt.Sprintf("etcd-%s", etcd.UID[:6]),
 		DataDir:                 defaultDataDir,
-		Metrics:                 utils.TypeDeref(etcd.Spec.Etcd.Metrics, druidv1alpha1.Basic),
+		Metrics:                 ptr.Deref(etcd.Spec.Etcd.Metrics, druidv1alpha1.Basic),
 		SnapshotCount:           defaultSnapshotCount,
 		EnableV2:                false,
 		QuotaBackendBytes:       getDBQuotaBytes(etcd),
 		InitialClusterToken:     defaultInitialClusterToken,
 		InitialClusterState:     defaultInitialClusterState,
 		InitialCluster:          prepareInitialCluster(etcd, peerScheme),
-		AutoCompactionMode:      utils.TypeDeref(etcd.Spec.Common.AutoCompactionMode, druidv1alpha1.Periodic),
-		AutoCompactionRetention: utils.TypeDeref(etcd.Spec.Common.AutoCompactionRetention, defaultAutoCompactionRetention),
-		ListenPeerUrls:          fmt.Sprintf("%s://0.0.0.0:%d", peerScheme, utils.TypeDeref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)),
-		ListenClientUrls:        fmt.Sprintf("%s://0.0.0.0:%d", clientScheme, utils.TypeDeref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient)),
-		AdvertisePeerUrls:       fmt.Sprintf("%s@%s@%s@%d", peerScheme, peerSvcName, etcd.Namespace, utils.TypeDeref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)),
-		AdvertiseClientUrls:     fmt.Sprintf("%s@%s@%s@%d", clientScheme, peerSvcName, etcd.Namespace, utils.TypeDeref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient)),
+		AutoCompactionMode:      ptr.Deref(etcd.Spec.Common.AutoCompactionMode, druidv1alpha1.Periodic),
+		AutoCompactionRetention: ptr.Deref(etcd.Spec.Common.AutoCompactionRetention, defaultAutoCompactionRetention),
+		ListenPeerUrls:          fmt.Sprintf("%s://0.0.0.0:%d", peerScheme, ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)),
+		ListenClientUrls:        fmt.Sprintf("%s://0.0.0.0:%d", clientScheme, ptr.Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient)),
+		AdvertisePeerUrls:       fmt.Sprintf("%s@%s@%s@%d", peerScheme, peerSvcName, etcd.Namespace, ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)),
+		AdvertiseClientUrls:     fmt.Sprintf("%s@%s@%s@%d", clientScheme, peerSvcName, etcd.Namespace, ptr.Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient)),
 	}
 	if peerSecurityConfig != nil {
 		cfg.PeerSecurity = *peerSecurityConfig
@@ -113,7 +112,7 @@ func getSchemeAndSecurityConfig(tlsConfig *druidv1alpha1.TLSConfig, caPath, serv
 			CertFile:       fmt.Sprintf("%s/tls.crt", serverTLSPath),
 			KeyFile:        fmt.Sprintf("%s/tls.key", serverTLSPath),
 			ClientCertAuth: true,
-			TrustedCAFile:  fmt.Sprintf("%s/%s", caPath, utils.TypeDeref(tlsConfig.TLSCASecretRef.DataKey, defaultTLSCASecretKey)),
+			TrustedCAFile:  fmt.Sprintf("%s/%s", caPath, ptr.Deref(tlsConfig.TLSCASecretRef.DataKey, defaultTLSCASecretKey)),
 			AutoTLS:        false,
 		}
 	}

--- a/internal/component/peerservice/peerservice.go
+++ b/internal/component/peerservice/peerservice.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -137,7 +138,7 @@ func emptyPeerService(objectKey client.ObjectKey) *corev1.Service {
 }
 
 func getPorts(etcd *druidv1alpha1.Etcd) []corev1.ServicePort {
-	peerPort := utils.TypeDeref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)
+	peerPort := ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)
 	return []corev1.ServicePort{
 		{
 			Name:       "peer",

--- a/internal/component/peerservice/peerservice_test.go
+++ b/internal/component/peerservice/peerservice_test.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
@@ -98,7 +98,7 @@ func TestSyncWhenNoServiceExists(t *testing.T) {
 		},
 		{
 			name:           "create service when none exists with custom ports",
-			createWithPort: pointer.Int32(2222),
+			createWithPort: ptr.To[int32](2222),
 		},
 		{
 			name:      "returns error when client create fails",
@@ -147,11 +147,11 @@ func TestSyncWhenServiceExists(t *testing.T) {
 	}{
 		{
 			name:           "update peer service with new server port",
-			updateWithPort: pointer.Int32(2222),
+			updateWithPort: ptr.To[int32](2222),
 		},
 		{
 			name:           "update fails when there is a patch error",
-			updateWithPort: pointer.Int32(2222),
+			updateWithPort: ptr.To[int32](2222),
 			patchErr:       testutils.TestAPIInternalErr,
 			expectedError: &druiderr.DruidError{
 				Code:      ErrSyncPeerService,

--- a/internal/component/peerservice/peerservice_test.go
+++ b/internal/component/peerservice/peerservice_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gardener/etcd-druid/internal/common"
 	"github.com/gardener/etcd-druid/internal/component"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
-	"github.com/gardener/etcd-druid/internal/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	"github.com/go-logr/logr"
@@ -245,7 +244,7 @@ func newPeerService(etcd *druidv1alpha1.Etcd) *corev1.Service {
 }
 
 func matchPeerService(g *WithT, etcd *druidv1alpha1.Etcd, actualSvc corev1.Service) {
-	peerPort := utils.TypeDeref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)
+	peerPort := ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)
 	etcdObjMeta := etcd.ObjectMeta
 	g.Expect(actualSvc).To(MatchFields(IgnoreExtras, Fields{
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{

--- a/internal/component/poddistruptionbudget/poddisruptionbudget.go
+++ b/internal/component/poddistruptionbudget/poddisruptionbudget.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -115,7 +116,7 @@ func buildResource(etcd *druidv1alpha1.Etcd, pdb *policyv1.PodDisruptionBudget) 
 		MatchLabels: druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta),
 	}
 	if metav1.HasAnnotation(etcd.ObjectMeta, annotationAllowUnhealthyPodEviction) {
-		pdb.Spec.UnhealthyPodEvictionPolicy = utils.PointerOf(policyv1.AlwaysAllow)
+		pdb.Spec.UnhealthyPodEvictionPolicy = ptr.To(policyv1.AlwaysAllow)
 	} else {
 		pdb.Spec.UnhealthyPodEvictionPolicy = nil
 	}

--- a/internal/component/serviceaccount/serviceaccount.go
+++ b/internal/component/serviceaccount/serviceaccount.go
@@ -17,7 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -107,7 +107,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 func buildResource(etcd *druidv1alpha1.Etcd, sa *corev1.ServiceAccount, autoMountServiceAccountToken bool) {
 	sa.Labels = getLabels(etcd)
 	sa.OwnerReferences = []metav1.OwnerReference{druidv1alpha1.GetAsOwnerReference(etcd.ObjectMeta)}
-	sa.AutomountServiceAccountToken = pointer.Bool(autoMountServiceAccountToken)
+	sa.AutomountServiceAccountToken = ptr.To(autoMountServiceAccountToken)
 }
 
 func getLabels(etcd *druidv1alpha1.Etcd) map[string]string {

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -22,7 +22,6 @@ import (
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -99,9 +98,9 @@ func newStsBuilder(client client.Client,
 		etcdBackupRestoreImage: etcdBackupRestoreImage,
 		initContainerImage:     initContainerImage,
 		sts:                    sts,
-		clientPort:             pointer.Int32Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient),
-		serverPort:             pointer.Int32Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer),
-		backupPort:             pointer.Int32Deref(etcd.Spec.Backup.Port, common.DefaultPortEtcdBackupRestore),
+		clientPort:             ptr.Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient),
+		serverPort:             ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer),
+		backupPort:             ptr.Deref(etcd.Spec.Backup.Port, common.DefaultPortEtcdBackupRestore),
 	}, nil
 }
 
@@ -140,7 +139,7 @@ func (b *stsBuilder) createStatefulSetSpec(ctx component.OperatorContext) error 
 	}
 
 	b.sts.Spec = appsv1.StatefulSetSpec{
-		Replicas: pointer.Int32(b.replicas),
+		Replicas: ptr.To(b.replicas),
 		Selector: &metav1.LabelSelector{
 			MatchLabels: druidv1alpha1.GetDefaultLabels(b.etcd.ObjectMeta),
 		},
@@ -156,7 +155,7 @@ func (b *stsBuilder) createStatefulSetSpec(ctx component.OperatorContext) error 
 			Spec: corev1.PodSpec{
 				HostAliases:           b.getHostAliases(),
 				ServiceAccountName:    druidv1alpha1.GetServiceAccountName(b.etcd.ObjectMeta),
-				ShareProcessNamespace: pointer.Bool(true),
+				ShareProcessNamespace: ptr.To(true),
 				InitContainers:        b.getPodInitContainers(),
 				Containers: []corev1.Container{
 					b.getEtcdContainer(),
@@ -231,9 +230,9 @@ func (b *stsBuilder) getPodInitContainers() []corev1.Container {
 		Args:            []string{fmt.Sprintf("chown -R %d:%d %s", nonRootUser, nonRootUser, common.VolumeMountPathEtcdData)},
 		VolumeMounts:    []corev1.VolumeMount{b.getEtcdDataVolumeMount()},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsGroup:   pointer.Int64(0),
-			RunAsNonRoot: pointer.Bool(false),
-			RunAsUser:    pointer.Int64(0),
+			RunAsGroup:   ptr.To[int64](0),
+			RunAsNonRoot: ptr.To(false),
+			RunAsUser:    ptr.To[int64](0),
 		},
 	})
 	if b.etcd.IsBackupStoreEnabled() {
@@ -248,9 +247,9 @@ func (b *stsBuilder) getPodInitContainers() []corev1.Container {
 					Args:            []string{fmt.Sprintf("chown -R %d:%d /home/nonroot/%s", nonRootUser, nonRootUser, *b.etcd.Spec.Backup.Store.Container)},
 					VolumeMounts:    []corev1.VolumeMount{*etcdBackupVolumeMount},
 					SecurityContext: &corev1.SecurityContext{
-						RunAsGroup:   pointer.Int64(0),
-						RunAsNonRoot: pointer.Bool(false),
-						RunAsUser:    pointer.Int64(0),
+						RunAsGroup:   ptr.To[int64](0),
+						RunAsNonRoot: ptr.To(false),
+						RunAsUser:    ptr.To[int64](0),
 					},
 				})
 			}
@@ -319,12 +318,12 @@ func (b *stsBuilder) getEtcdBackupVolumeMount() *corev1.VolumeMount {
 			if b.useEtcdWrapper {
 				return &corev1.VolumeMount{
 					Name:      common.VolumeNameLocalBackup,
-					MountPath: fmt.Sprintf("/home/nonroot/%s", pointer.StringDeref(b.etcd.Spec.Backup.Store.Container, "")),
+					MountPath: fmt.Sprintf("/home/nonroot/%s", ptr.Deref(b.etcd.Spec.Backup.Store.Container, "")),
 				}
 			} else {
 				return &corev1.VolumeMount{
 					Name:      common.VolumeNameLocalBackup,
-					MountPath: pointer.StringDeref(b.etcd.Spec.Backup.Store.Container, ""),
+					MountPath: ptr.Deref(b.etcd.Spec.Backup.Store.Container, ""),
 				}
 			}
 		}
@@ -651,10 +650,10 @@ func (b *stsBuilder) getPodSecurityContext() *corev1.PodSecurityContext {
 		return nil
 	}
 	return &corev1.PodSecurityContext{
-		RunAsGroup:   pointer.Int64(nonRootUser),
-		RunAsNonRoot: pointer.Bool(true),
-		RunAsUser:    pointer.Int64(nonRootUser),
-		FSGroup:      pointer.Int64(nonRootUser),
+		RunAsGroup:   ptr.To[int64](nonRootUser),
+		RunAsNonRoot: ptr.To(true),
+		RunAsUser:    ptr.To[int64](nonRootUser),
+		FSGroup:      ptr.To[int64](nonRootUser),
 	}
 }
 
@@ -715,7 +714,7 @@ func (b *stsBuilder) getPodVolumes(ctx component.OperatorContext) ([]corev1.Volu
 							Path: common.EtcdConfigFileName, // sub-path under the volume mount path, to store the contents of configmap key etcd.conf.yaml
 						},
 					},
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		},
@@ -750,7 +749,7 @@ func (b *stsBuilder) getClientTLSVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  clientTLSConfig.TLSCASecretRef.Name,
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		},
@@ -759,7 +758,7 @@ func (b *stsBuilder) getClientTLSVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  clientTLSConfig.ServerTLSSecretRef.Name,
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		},
@@ -768,7 +767,7 @@ func (b *stsBuilder) getClientTLSVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  clientTLSConfig.ClientTLSSecretRef.Name,
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		},
@@ -783,7 +782,7 @@ func (b *stsBuilder) getPeerTLSVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  peerTLSConfig.TLSCASecretRef.Name,
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		},
@@ -792,7 +791,7 @@ func (b *stsBuilder) getPeerTLSVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  peerTLSConfig.ServerTLSSecretRef.Name,
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		},
@@ -807,7 +806,7 @@ func (b *stsBuilder) getBackupRestoreTLSVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  tlsConfig.TLSCASecretRef.Name,
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		},
@@ -816,7 +815,7 @@ func (b *stsBuilder) getBackupRestoreTLSVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  tlsConfig.ServerTLSSecretRef.Name,
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		},
@@ -825,7 +824,7 @@ func (b *stsBuilder) getBackupRestoreTLSVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  tlsConfig.ClientTLSSecretRef.Name,
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		},
@@ -849,7 +848,7 @@ func (b *stsBuilder) getBackupVolume(ctx component.OperatorContext) (*corev1.Vol
 			Name: common.VolumeNameLocalBackup,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: hostPath + "/" + pointer.StringDeref(store.Container, ""),
+					Path: hostPath + "/" + ptr.Deref(store.Container, ""),
 					Type: &hpt,
 				},
 			},
@@ -864,7 +863,7 @@ func (b *stsBuilder) getBackupVolume(ctx component.OperatorContext) (*corev1.Vol
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  store.SecretRef.Name,
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		}, nil

--- a/internal/component/statefulset/statefulset.go
+++ b/internal/component/statefulset/statefulset.go
@@ -107,11 +107,9 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 			fmt.Sprintf("Error checking if StatefulSet pods are updated for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	if !podsHaveDesiredLabels {
-		errMessage := fmt.Sprintf("StatefulSet pods are not yet updated with new labels, for StatefulSet: %v for etcd: %v", getObjectKey(sts.ObjectMeta), druidv1alpha1.GetNamespaceName(etcd.ObjectMeta))
-		return druiderr.WrapError(fmt.Errorf(errMessage),
-			druiderr.ErrRequeueAfter,
+		return druiderr.New(druiderr.ErrRequeueAfter,
 			"PreSync",
-			errMessage,
+			fmt.Sprintf("StatefulSet pods are not yet updated with new labels, for StatefulSet: %v for etcd: %v", getObjectKey(sts.ObjectMeta), druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	} else {
 		ctx.Logger.Info("StatefulSet pods are updated with new labels", "objectKey", getObjectKey(etcd.ObjectMeta))

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -24,7 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
@@ -124,7 +124,7 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 			cl := testutils.CreateTestFakeClientForObjects(nil, tc.createErr, nil, nil, []client.Object{buildBackupSecret()}, getObjectKey(etcd.ObjectMeta))
 			etcdImage, etcdBRImage, initContainerImage, err := utils.GetEtcdImages(etcd, iv, true)
 			g.Expect(err).ToNot(HaveOccurred())
-			stsMatcher := NewStatefulSetMatcher(g, cl, etcd, tc.replicas, true, initContainerImage, etcdImage, etcdBRImage, pointer.String(druidstore.Local))
+			stsMatcher := NewStatefulSetMatcher(g, cl, etcd, tc.replicas, true, initContainerImage, etcdImage, etcdBRImage, ptr.To(druidstore.Local))
 			operator := New(cl, iv, map[featuregate.Feature]bool{
 				features.UseEtcdWrapper: true,
 			})

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -112,13 +112,13 @@ func (s StatefulSetMatcher) matchVolumeClaimTemplates() gomegatypes.GomegaMatche
 	defaultStorageCapacity := apiresource.MustParse("16Gi")
 	return ConsistOf(MatchFields(IgnoreExtras, Fields{
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{
-			"Name": Equal(utils.TypeDeref(s.etcd.Spec.VolumeClaimTemplate, s.etcd.Name)),
+			"Name": Equal(ptr.Deref(s.etcd.Spec.VolumeClaimTemplate, s.etcd.Name)),
 		}),
 		"Spec": MatchFields(IgnoreExtras, Fields{
 			"AccessModes": ConsistOf(corev1.ReadWriteOnce),
 			"Resources": MatchFields(IgnoreExtras, Fields{
 				"Requests": MatchKeys(IgnoreExtras, Keys{
-					corev1.ResourceStorage: Equal(utils.TypeDeref(s.etcd.Spec.StorageCapacity, defaultStorageCapacity)),
+					corev1.ResourceStorage: Equal(ptr.Deref(s.etcd.Spec.StorageCapacity, defaultStorageCapacity)),
 				}),
 			}),
 			"StorageClassName": Equal(s.etcd.Spec.StorageClass),
@@ -152,7 +152,7 @@ func (s StatefulSetMatcher) matchPodSpec() gomegatypes.GomegaMatcher {
 		"Containers":            s.matchContainers(),
 		"SecurityContext":       s.matchEtcdPodSecurityContext(),
 		"Volumes":               s.matchPodVolumes(),
-		"PriorityClassName":     Equal(utils.TypeDeref(s.etcd.Spec.PriorityClassName, "")),
+		"PriorityClassName":     Equal(ptr.Deref(s.etcd.Spec.PriorityClassName, "")),
 	})
 }
 
@@ -201,7 +201,7 @@ func (s StatefulSetMatcher) matchContainers() gomegatypes.GomegaMatcher {
 }
 
 func (s StatefulSetMatcher) matchEtcdContainer() gomegatypes.GomegaMatcher {
-	etcdContainerResources := utils.TypeDeref(s.etcd.Spec.Etcd.Resources, defaultTestContainerResources)
+	etcdContainerResources := ptr.Deref(s.etcd.Spec.Etcd.Resources, defaultTestContainerResources)
 	return MatchFields(IgnoreExtras|IgnoreMissing, Fields{
 		"Name":            Equal("etcd"),
 		"Image":           Equal(s.etcdImage),
@@ -242,7 +242,7 @@ func (s StatefulSetMatcher) matchEtcdContainerVolMounts() gomegatypes.GomegaMatc
 }
 
 func (s StatefulSetMatcher) matchBackupRestoreContainer() gomegatypes.GomegaMatcher {
-	containerResources := testutils.TypeDeref(s.etcd.Spec.Backup.Resources, defaultTestContainerResources)
+	containerResources := ptr.Deref(s.etcd.Spec.Backup.Resources, defaultTestContainerResources)
 	return MatchFields(IgnoreExtras, Fields{
 		"Name":            Equal("backup-restore"),
 		"Image":           Equal(s.etcdBRImage),
@@ -286,7 +286,7 @@ func (s StatefulSetMatcher) matchEtcdContainerReadinessHandler() gomegatypes.Gom
 
 func (s StatefulSetMatcher) matchEtcdContainerReadinessProbeCmd() gomegatypes.GomegaMatcher {
 	if s.etcd.Spec.Etcd.ClientUrlTLS != nil {
-		dataKey := utils.TypeDeref(s.etcd.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.DataKey, "ca.crt")
+		dataKey := ptr.Deref(s.etcd.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.DataKey, "ca.crt")
 		return HaveExactElements(
 			"/bin/sh",
 			"-ec",
@@ -312,7 +312,7 @@ func (s StatefulSetMatcher) matchEtcdContainerCmdArgs() gomegatypes.GomegaMatche
 	if s.etcd.Spec.Etcd.ClientUrlTLS == nil {
 		cmdArgs = append(cmdArgs, "--backup-restore-tls-enabled=false")
 	} else {
-		dataKey := utils.TypeDeref(s.etcd.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.DataKey, "ca.crt")
+		dataKey := ptr.Deref(s.etcd.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.DataKey, "ca.crt")
 		cmdArgs = append(cmdArgs, "--backup-restore-tls-enabled=true")
 		cmdArgs = append(cmdArgs, "--etcd-client-cert-path=/var/etcd/ssl/client/tls.crt")
 		cmdArgs = append(cmdArgs, "--etcd-client-key-path=/var/etcd/ssl/client/tls.key")
@@ -322,7 +322,7 @@ func (s StatefulSetMatcher) matchEtcdContainerCmdArgs() gomegatypes.GomegaMatche
 }
 
 func (s StatefulSetMatcher) matchEtcdDataVolMount() gomegatypes.GomegaMatcher {
-	volumeClaimTemplateName := utils.TypeDeref(s.etcd.Spec.VolumeClaimTemplate, s.etcd.Name)
+	volumeClaimTemplateName := ptr.Deref(s.etcd.Spec.VolumeClaimTemplate, s.etcd.Name)
 	return matchVolMount(volumeClaimTemplateName, common.VolumeMountPathEtcdData)
 }
 

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
@@ -71,9 +71,9 @@ func NewStatefulSetMatcher(g *WithT,
 		etcdImage:          etcdImage,
 		etcdBRImage:        etcdBRImage,
 		provider:           provider,
-		clientPort:         pointer.Int32Deref(etcd.Spec.Etcd.ClientPort, 2379),
-		serverPort:         pointer.Int32Deref(etcd.Spec.Etcd.ServerPort, 2380),
-		backupPort:         pointer.Int32Deref(etcd.Spec.Backup.Port, 8080),
+		clientPort:         ptr.Deref(etcd.Spec.Etcd.ClientPort, 2379),
+		serverPort:         ptr.Deref(etcd.Spec.Etcd.ServerPort, 2380),
+		backupPort:         ptr.Deref(etcd.Spec.Backup.Port, 8080),
 	}
 }
 
@@ -369,9 +369,9 @@ func (s StatefulSetMatcher) getEtcdBackupVolumeMountMatcher() gomegatypes.Gomega
 	case druidstore.Local:
 		if s.etcd.Spec.Backup.Store.Container != nil {
 			if s.useEtcdWrapper {
-				return matchVolMount(common.VolumeNameLocalBackup, fmt.Sprintf("/home/nonroot/%s", pointer.StringDeref(s.etcd.Spec.Backup.Store.Container, "")))
+				return matchVolMount(common.VolumeNameLocalBackup, fmt.Sprintf("/home/nonroot/%s", ptr.Deref(s.etcd.Spec.Backup.Store.Container, "")))
 			} else {
-				return matchVolMount(common.VolumeNameLocalBackup, pointer.StringDeref(s.etcd.Spec.Backup.Store.Container, ""))
+				return matchVolMount(common.VolumeNameLocalBackup, ptr.Deref(s.etcd.Spec.Backup.Store.Container, ""))
 			}
 		}
 	case druidstore.GCS:
@@ -540,7 +540,7 @@ func (s StatefulSetMatcher) getBackupVolumeMatcher() gomegatypes.GomegaMatcher {
 			"Name": Equal(common.VolumeNameLocalBackup),
 			"VolumeSource": MatchFields(IgnoreExtras, Fields{
 				"HostPath": PointTo(MatchFields(IgnoreExtras, Fields{
-					"Path": Equal(fmt.Sprintf("%s/%s", hostPath, pointer.StringDeref(s.etcd.Spec.Backup.Store.Container, ""))),
+					"Path": Equal(fmt.Sprintf("%s/%s", hostPath, ptr.Deref(s.etcd.Spec.Backup.Store.Container, ""))),
 					"Type": PointTo(Equal(corev1.HostPathDirectory)),
 				})),
 			}),

--- a/internal/controller/compaction/reconciler.go
+++ b/internal/controller/compaction/reconciler.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -274,8 +274,8 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         druidv1alpha1.GroupVersion.String(),
-					BlockOwnerDeletion: pointer.Bool(true),
-					Controller:         pointer.Bool(true),
+					BlockOwnerDeletion: ptr.To(true),
+					Controller:         ptr.To(true),
 					Kind:               "Etcd",
 					Name:               etcd.Name,
 					UID:                etcd.UID,
@@ -284,16 +284,16 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 		},
 
 		Spec: batchv1.JobSpec{
-			ActiveDeadlineSeconds: pointer.Int64(int64(activeDeadlineSeconds)),
-			Completions:           pointer.Int32(1),
-			BackoffLimit:          pointer.Int32(0),
+			ActiveDeadlineSeconds: ptr.To[int64](int64(activeDeadlineSeconds)),
+			Completions:           ptr.To[int32](1),
+			BackoffLimit:          ptr.To[int32](0),
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: getEtcdCompactionAnnotations(etcd.Spec.Annotations),
 					Labels:      getLabels(etcd),
 				},
 				Spec: v1.PodSpec{
-					ActiveDeadlineSeconds: pointer.Int64(int64(activeDeadlineSeconds)),
+					ActiveDeadlineSeconds: ptr.To[int64](int64(activeDeadlineSeconds)),
 					ServiceAccountName:    druidv1alpha1.GetServiceAccountName(etcd.ObjectMeta),
 					RestartPolicy:         v1.RestartPolicyNever,
 					Containers: []v1.Container{{
@@ -389,12 +389,12 @@ func getCompactionJobVolumeMounts(etcd *druidv1alpha1.Etcd, featureMap map[featu
 		if featureMap[features.UseEtcdWrapper] {
 			vms = append(vms, v1.VolumeMount{
 				Name:      "host-storage",
-				MountPath: "/home/nonroot/" + pointer.StringDeref(etcd.Spec.Backup.Store.Container, ""),
+				MountPath: "/home/nonroot/" + ptr.Deref(etcd.Spec.Backup.Store.Container, ""),
 			})
 		} else {
 			vms = append(vms, v1.VolumeMount{
 				Name:      "host-storage",
-				MountPath: pointer.StringDeref(etcd.Spec.Backup.Store.Container, ""),
+				MountPath: ptr.Deref(etcd.Spec.Backup.Store.Container, ""),
 			})
 		}
 	case druidstore.GCS:
@@ -439,7 +439,7 @@ func getCompactionJobVolumes(ctx context.Context, cl client.Client, logger logr.
 			Name: "host-storage",
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{
-					Path: hostPath + "/" + pointer.StringDeref(storeValues.Container, ""),
+					Path: hostPath + "/" + ptr.Deref(storeValues.Container, ""),
 					Type: &hpt,
 				},
 			},

--- a/internal/controller/compaction/register_test.go
+++ b/internal/controller/compaction/register_test.go
@@ -17,7 +17,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
@@ -264,17 +264,17 @@ func createObjectsForSnapshotLeasePredicate(g *WithT, name string, isLeaseObj, i
 	// if it's a new object indicating a create event, create a new lease object and return.
 	if isNewObject {
 		if isHolderIdentitySet {
-			holderIdentity = pointer.String(strconv.Itoa(generateRandomInt(g)))
+			holderIdentity = ptr.To(strconv.Itoa(generateRandomInt(g)))
 		}
 		obj = createLease(name, holderIdentity)
 		return
 	}
 
 	// create old and new lease objects.
-	holderIdentity = pointer.String(strconv.Itoa(generateRandomInt(g)))
+	holderIdentity = ptr.To(strconv.Itoa(generateRandomInt(g)))
 	oldObj = createLease(name, holderIdentity)
 	if isHolderIdentityChanged {
-		newHolderIdentity = pointer.String(strconv.Itoa(generateRandomInt(g)))
+		newHolderIdentity = ptr.To(strconv.Itoa(generateRandomInt(g)))
 	} else {
 		newHolderIdentity = holderIdentity
 	}

--- a/internal/controller/etcd/reconcile_status.go
+++ b/internal/controller/etcd/reconcile_status.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gardener/etcd-druid/internal/utils"
 
 	"github.com/go-logr/logr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -77,7 +77,7 @@ func (r *Reconciler) inspectStatefulSetAndMutateETCDStatus(ctx component.Operato
 		etcd.Status.CurrentReplicas = 0
 		etcd.Status.ReadyReplicas = 0
 		etcd.Status.UpdatedReplicas = 0
-		etcd.Status.Ready = pointer.Bool(false)
+		etcd.Status.Ready = ptr.To(false)
 	}
 	return ctrlutils.ContinueReconcile()
 }

--- a/internal/controller/etcd/register_test.go
+++ b/internal/controller/etcd/register_test.go
@@ -9,7 +9,6 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	mockmanager "github.com/gardener/etcd-druid/internal/mock/controller-runtime/manager"
-	"github.com/gardener/etcd-druid/internal/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -37,7 +36,7 @@ func TestBuildPredicateWithOnlyAutoReconcileEnabled(t *testing.T) {
 		{
 			name:                    "only spec has changed and previous reconciliation is in progress",
 			etcdSpecChanged:         true,
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateProcessing),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateProcessing),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -46,7 +45,7 @@ func TestBuildPredicateWithOnlyAutoReconcileEnabled(t *testing.T) {
 		{
 			name:                    "only spec has changed and previous reconciliation has completed",
 			etcdSpecChanged:         true,
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateSucceeded),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateSucceeded),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -55,7 +54,7 @@ func TestBuildPredicateWithOnlyAutoReconcileEnabled(t *testing.T) {
 		{
 			name:                    "only spec has changed and previous reconciliation has errored",
 			etcdSpecChanged:         true,
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateError),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateError),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -73,7 +72,7 @@ func TestBuildPredicateWithOnlyAutoReconcileEnabled(t *testing.T) {
 			name:                    "both spec and status have changed and previous reconciliation is in progress",
 			etcdSpecChanged:         true,
 			etcdStatusChanged:       true,
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateProcessing),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateProcessing),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -159,7 +158,7 @@ func TestBuildPredicateWithNoAutoReconcileButReconcileAnnotPresent(t *testing.T)
 		{
 			name:                    "only spec has changed and previous reconciliation is in progress",
 			etcdSpecChanged:         true,
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateProcessing),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateProcessing),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -168,7 +167,7 @@ func TestBuildPredicateWithNoAutoReconcileButReconcileAnnotPresent(t *testing.T)
 		{
 			name:                    "only spec has changed and previous reconciliation is completed",
 			etcdSpecChanged:         true,
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateSucceeded),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateSucceeded),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -177,7 +176,7 @@ func TestBuildPredicateWithNoAutoReconcileButReconcileAnnotPresent(t *testing.T)
 		{
 			name:                    "only status has changed and previous reconciliation is in progress",
 			etcdStatusChanged:       true,
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateProcessing),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateProcessing),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -186,7 +185,7 @@ func TestBuildPredicateWithNoAutoReconcileButReconcileAnnotPresent(t *testing.T)
 		{
 			name:                    "only status has changed and previous reconciliation is completed",
 			etcdStatusChanged:       true,
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateSucceeded),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateSucceeded),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -203,7 +202,7 @@ func TestBuildPredicateWithNoAutoReconcileButReconcileAnnotPresent(t *testing.T)
 		},
 		{
 			name:                    "neither spec nor status has changed and previous reconciliation is in error",
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateError),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateError),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -211,7 +210,7 @@ func TestBuildPredicateWithNoAutoReconcileButReconcileAnnotPresent(t *testing.T)
 		},
 		{
 			name:                    "neither spec nor status has changed and previous reconciliation is completed",
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateSucceeded),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateSucceeded),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -247,7 +246,7 @@ func TestBuildPredicateWithAutoReconcileAndReconcileAnnotSet(t *testing.T) {
 		{
 			name:                    "only status has changed and previous reconciliation is in progress",
 			etcdStatusChanged:       true,
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateProcessing),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateProcessing),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -256,7 +255,7 @@ func TestBuildPredicateWithAutoReconcileAndReconcileAnnotSet(t *testing.T) {
 		{
 			name:                    "only status has changed and previous reconciliation is completed",
 			etcdStatusChanged:       true,
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateSucceeded),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateSucceeded),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -273,7 +272,7 @@ func TestBuildPredicateWithAutoReconcileAndReconcileAnnotSet(t *testing.T) {
 		},
 		{
 			name:                    "neither spec nor status has changed and previous reconciliation is in error",
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateError),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateError),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -281,7 +280,7 @@ func TestBuildPredicateWithAutoReconcileAndReconcileAnnotSet(t *testing.T) {
 		},
 		{
 			name:                    "neither spec nor status has changed and previous reconciliation is in progress",
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateProcessing),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateProcessing),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,
@@ -289,7 +288,7 @@ func TestBuildPredicateWithAutoReconcileAndReconcileAnnotSet(t *testing.T) {
 		},
 		{
 			name:                    "neither spec nor status has changed and previous reconciliation is completed",
-			lastOperationState:      utils.PointerOf(druidv1alpha1.LastOperationStateSucceeded),
+			lastOperationState:      ptr.To(druidv1alpha1.LastOperationStateSucceeded),
 			shouldAllowCreateEvent:  true,
 			shouldAllowDeleteEvent:  true,
 			shouldAllowGenericEvent: false,

--- a/internal/controller/etcd/register_test.go
+++ b/internal/controller/etcd/register_test.go
@@ -14,7 +14,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	. "github.com/onsi/gomega"
@@ -315,7 +315,7 @@ func TestBuildPredicateWithAutoReconcileAndReconcileAnnotSet(t *testing.T) {
 func createEtcd() *druidv1alpha1.Etcd {
 	etcd := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).WithReplicas(3).Build()
 	etcd.Status = druidv1alpha1.EtcdStatus{
-		ObservedGeneration: pointer.Int64(0),
+		ObservedGeneration: ptr.To[int64](0),
 		Etcd: &druidv1alpha1.CrossVersionObjectReference{
 			Kind:       "StatefulSet",
 			Name:       testutils.TestEtcdName,
@@ -324,7 +324,7 @@ func createEtcd() *druidv1alpha1.Etcd {
 		CurrentReplicas: 3,
 		Replicas:        3,
 		ReadyReplicas:   3,
-		Ready:           pointer.Bool(true),
+		Ready:           ptr.To(true),
 	}
 	return etcd
 }
@@ -338,13 +338,13 @@ func updateEtcd(originalEtcd *druidv1alpha1.Etcd, specChanged, statusChanged boo
 	}
 	if specChanged {
 		// made a single change to the spec
-		newEtcd.Spec.Backup.Image = pointer.String("eu.gcr.io/gardener-project/gardener/etcdbrctl-distroless:v1.0.0")
+		newEtcd.Spec.Backup.Image = ptr.To("eu.gcr.io/gardener-project/gardener/etcdbrctl-distroless:v1.0.0")
 		newEtcd.Generation++
 	}
 	if statusChanged {
 		// made a single change to the status
 		newEtcd.Status.ReadyReplicas = 2
-		newEtcd.Status.Ready = pointer.Bool(false)
+		newEtcd.Status.Ready = ptr.To(false)
 	}
 	if lastOpState != nil {
 		newEtcd.Status.LastOperation = &druidv1alpha1.LastOperation{

--- a/internal/controller/etcdcopybackupstask/reconciler.go
+++ b/internal/controller/etcdcopybackupstask/reconciler.go
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -241,7 +241,7 @@ func setStatusDetails(status *druidv1alpha1.EtcdCopyBackupsTaskStatus, generatio
 		status.Conditions = nil
 	}
 	if err != nil {
-		status.LastError = pointer.String(err.Error())
+		status.LastError = ptr.To(err.Error())
 	} else {
 		status.LastError = nil
 	}
@@ -344,7 +344,7 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 							VolumeMounts:    volumeMounts,
 						},
 					},
-					ShareProcessNamespace: pointer.Bool(true),
+					ShareProcessNamespace: ptr.To(true),
 					Volumes:               volumes,
 				},
 			},
@@ -363,18 +363,18 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 					Args:         []string{fmt.Sprintf("%s%s%s%s", "chown -R 65532:65532 /home/nonroot/", *targetStore.Container, " /home/nonroot/", *sourceStore.Container)},
 					VolumeMounts: volumeMounts,
 					SecurityContext: &corev1.SecurityContext{
-						RunAsGroup:   pointer.Int64(0),
-						RunAsNonRoot: pointer.Bool(false),
-						RunAsUser:    pointer.Int64(0),
+						RunAsGroup:   ptr.To[int64](0),
+						RunAsNonRoot: ptr.To(false),
+						RunAsUser:    ptr.To[int64](0),
 					},
 				},
 			}
 		}
 		job.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsGroup:   pointer.Int64(65532),
-			RunAsNonRoot: pointer.Bool(true),
-			RunAsUser:    pointer.Int64(65532),
-			FSGroup:      pointer.Int64(65532),
+			RunAsGroup:   ptr.To[int64](65532),
+			RunAsNonRoot: ptr.To(true),
+			RunAsUser:    ptr.To[int64](65532),
+			FSGroup:      ptr.To[int64](65532),
 		}
 	}
 
@@ -463,7 +463,7 @@ func (r *Reconciler) createVolumesFromStore(ctx context.Context, store *druidv1a
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  store.SecretRef.Name,
-					DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+					DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 				},
 			},
 		})

--- a/internal/controller/etcdcopybackupstask/reconciler_test.go
+++ b/internal/controller/etcdcopybackupstask/reconciler_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -165,12 +165,12 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 					&imagevector.ImageSource{
 						Name:       common.ImageKeyEtcdBackupRestore,
 						Repository: "test-repo",
-						Tag:        pointer.String("etcd-test-tag"),
+						Tag:        ptr.To("etcd-test-tag"),
 					},
 					&imagevector.ImageSource{
 						Name:       common.ImageKeyAlpine,
 						Repository: "test-repo",
-						Tag:        pointer.String("init-container-test-tag"),
+						Tag:        ptr.To("init-container-test-tag"),
 					},
 				},
 				Config: &Config{
@@ -272,7 +272,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 			BeforeEach(func() {
 				store = druidv1alpha1.StoreSpec{
 					Prefix:    "store_prefix",
-					Container: pointer.String("store_container"),
+					Container: ptr.To("store_container"),
 				}
 				provider = "storage_provider"
 				prefix = "prefix"
@@ -334,12 +334,12 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 				Spec: druidv1alpha1.EtcdCopyBackupsTaskSpec{
 					SourceStore: druidv1alpha1.StoreSpec{
 						Prefix:    "/source",
-						Container: pointer.String("source-container"),
+						Container: ptr.To("source-container"),
 						Provider:  &providerLocal,
 					},
 					TargetStore: druidv1alpha1.StoreSpec{
 						Prefix:    "/target",
-						Container: pointer.String("target-container"),
+						Container: ptr.To("target-container"),
 						Provider:  &providerS3,
 						SecretRef: &corev1.SecretReference{
 							Name: "test-secret",
@@ -355,13 +355,13 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 		})
 
 		It("should include the max backup age in the arguments", func() {
-			task.Spec.MaxBackupAge = pointer.Uint32(10)
+			task.Spec.MaxBackupAge = ptr.To[uint32](10)
 			arguments := createJobArgs(task, druidstore.Local, druidstore.S3)
 			Expect(arguments).To(Equal(append(expected, "--max-backup-age=10")))
 		})
 
 		It("should include the max number of backups in the arguments", func() {
-			task.Spec.MaxBackups = pointer.Uint32(5)
+			task.Spec.MaxBackups = ptr.To[uint32](5)
 			arguments := createJobArgs(task, druidstore.Local, druidstore.S3)
 			Expect(arguments).To(Equal(append(expected, "--max-backups-to-copy=5")))
 		})
@@ -454,7 +454,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 				BeforeEach(func() {
 					storageProvider := druidv1alpha1.StorageProvider(provider)
 					storeSpec = &druidv1alpha1.StoreSpec{
-						Container: pointer.String("source-container"),
+						Container: ptr.To("source-container"),
 						Provider:  &storageProvider,
 					}
 				})
@@ -501,7 +501,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 				}
 
 				store = &druidv1alpha1.StoreSpec{
-					Container: pointer.String("source-container"),
+					Container: ptr.To("source-container"),
 					Prefix:    "/tmp",
 					Provider:  &providerLocal,
 				}
@@ -598,7 +598,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 						// Set up test variables and create necessary secrets
 						storageProvider = druidv1alpha1.StorageProvider(provider)
 						store = &druidv1alpha1.StoreSpec{
-							Container: pointer.String("source-container"),
+							Container: ptr.To("source-container"),
 							Provider:  &storageProvider,
 						}
 						secret = &corev1.Secret{
@@ -629,7 +629,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 						Expect(volumeSource.Secret).NotTo(BeNil())
 						Expect(*volumeSource.Secret).To(Equal(corev1.SecretVolumeSource{
 							SecretName:  store.SecretRef.Name,
-							DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+							DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 						}))
 					})
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -60,6 +60,16 @@ func IsRequeueAfterError(err error) bool {
 	return false
 }
 
+// New creates a new DruidError with the given error code, operation and message.
+func New(code druidv1alpha1.ErrorCode, operation string, message string) error {
+	return &DruidError{
+		Code:       code,
+		Operation:  operation,
+		Message:    message,
+		ObservedAt: time.Now().UTC(),
+	}
+}
+
 // WrapError wraps an error and contextual information like code, operation and message to create a DruidError
 // Consumers can use errors.As or errors.Is to check if the error is of type DruidError and get its constituent fields.
 func WrapError(err error, code druidv1alpha1.ErrorCode, operation string, message string) error {

--- a/internal/health/condition/check_data_volumes_ready_test.go
+++ b/internal/health/condition/check_data_volumes_ready_test.go
@@ -15,7 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -52,7 +52,7 @@ var _ = Describe("DataVolumesReadyCheck", func() {
 					OwnerReferences: []metav1.OwnerReference{druidv1alpha1.GetAsOwnerReference(etcd.ObjectMeta)},
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: pointer.Int32(1),
+					Replicas: ptr.To[int32](1),
 					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 						{
 							ObjectMeta: metav1.ObjectMeta{

--- a/internal/health/etcdmember/builder_test.go
+++ b/internal/health/etcdmember/builder_test.go
@@ -10,7 +10,7 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	. "github.com/gardener/etcd-druid/internal/health/etcdmember"
 	. "github.com/onsi/ginkgo/v2"
@@ -44,21 +44,21 @@ var _ = Describe("Builder", func() {
 				oldMembers = map[string]druidv1alpha1.EtcdMemberStatus{
 					"1": {
 						Name:               "member1",
-						ID:                 pointer.String("1"),
+						ID:                 ptr.To("1"),
 						Status:             druidv1alpha1.EtcdMemberStatusReady,
 						Reason:             "foo reason",
 						LastTransitionTime: metav1.NewTime(now.Add(-12 * time.Hour)),
 					},
 					"2": {
 						Name:               "member2",
-						ID:                 pointer.String("2"),
+						ID:                 ptr.To("2"),
 						Status:             druidv1alpha1.EtcdMemberStatusReady,
 						Reason:             "bar reason",
 						LastTransitionTime: metav1.NewTime(now.Add(-6 * time.Hour)),
 					},
 					"3": {
 						Name:               "member3",
-						ID:                 pointer.String("3"),
+						ID:                 ptr.To("3"),
 						Status:             druidv1alpha1.EtcdMemberStatusReady,
 						Reason:             "foobar reason",
 						LastTransitionTime: metav1.NewTime(now.Add(-18 * time.Hour)),
@@ -75,7 +75,7 @@ var _ = Describe("Builder", func() {
 			It("should correctly set the LastTransitionTime", func() {
 				builder.WithResults([]Result{
 					&result{
-						MemberID:     pointer.String("3"),
+						MemberID:     ptr.To("3"),
 						MemberName:   "member3",
 						MemberStatus: druidv1alpha1.EtcdMemberStatusUnknown,
 						MemberReason: "unknown reason",
@@ -109,14 +109,14 @@ var _ = Describe("Builder", func() {
 			It("should not add any members but sort them", func() {
 				builder.WithResults([]Result{
 					&result{
-						MemberID:     pointer.String("2"),
+						MemberID:     ptr.To("2"),
 						MemberName:   "member2",
 						MemberRole:   &memberRoleMember,
 						MemberStatus: druidv1alpha1.EtcdMemberStatusReady,
 						MemberReason: "foo reason",
 					},
 					&result{
-						MemberID:     pointer.String("1"),
+						MemberID:     ptr.To("1"),
 						MemberName:   "member1",
 						MemberRole:   &memberRoleLeader,
 						MemberStatus: druidv1alpha1.EtcdMemberStatusUnknown,

--- a/internal/health/etcdmember/check_ready_test.go
+++ b/internal/health/etcdmember/check_ready_test.go
@@ -17,7 +17,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/gardener/etcd-druid/internal/health/etcdmember"
@@ -56,7 +56,7 @@ var _ = Describe("ReadyCheck", func() {
 		Context("single node etcd: when just expired", func() {
 			It("should set the affected condition to UNKNOWN because lease is lost", func() {
 				now := time.Now()
-				lease := createMemberLease(member1Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(now.Add(-1*unknownThreshold).Add(-1*time.Second)))
+				lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(now.Add(-1*unknownThreshold).Add(-1*time.Second)))
 				pod := createMemberPod(member1Name, etcdNamespace, true)
 				existingObjects := mapToClientObjects([]*coordinationv1.Lease{lease}, []*corev1.Pod{pod})
 				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
@@ -73,7 +73,7 @@ var _ = Describe("ReadyCheck", func() {
 			It("should set the affected condition to FAILED because containers are not ready", func() {
 				now := time.Now()
 				pod := createMemberPod(member1Name, etcdNamespace, false)
-				lease := createMemberLease(member1Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(now.Add(-1*unknownThreshold).Add(-1*time.Second)))
+				lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(now.Add(-1*unknownThreshold).Add(-1*time.Second)))
 				existingObjects := mapToClientObjects([]*coordinationv1.Lease{lease}, []*corev1.Pod{pod})
 				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
 				check = ReadyCheck(cl, logr.Discard(), notReadyThreshold, unknownThreshold)
@@ -88,7 +88,7 @@ var _ = Describe("ReadyCheck", func() {
 
 			It("should set the affected condition to FAILED because Pod is not found", func() {
 				now := time.Now()
-				lease := createMemberLease(member1Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(now.Add(-1*unknownThreshold).Add(-1*time.Second)))
+				lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(now.Add(-1*unknownThreshold).Add(-1*time.Second)))
 				existingObjects := mapToClientObjects([]*coordinationv1.Lease{lease}, nil)
 				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
 				check = ReadyCheck(cl, logr.Discard(), notReadyThreshold, unknownThreshold)
@@ -103,7 +103,7 @@ var _ = Describe("ReadyCheck", func() {
 
 			It("should set the affected condition to FAILED because Pod retrieval errors out", func() {
 				now := time.Now()
-				lease := createMemberLease(member1Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(now.Add(-1*unknownThreshold).Add(-1*time.Second)))
+				lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(now.Add(-1*unknownThreshold).Add(-1*time.Second)))
 				existingObjects := mapToClientObjects([]*coordinationv1.Lease{lease}, nil)
 				cl := testutils.CreateTestFakeClientForObjects(testutils.TestAPIInternalErr, nil, nil, nil, existingObjects)
 				check = ReadyCheck(cl, logr.Discard(), notReadyThreshold, unknownThreshold)
@@ -123,9 +123,9 @@ var _ = Describe("ReadyCheck", func() {
 				now := time.Now()
 				shortExpirationTime := now.Add(-1 * unknownThreshold).Add(-1 * time.Second)
 				longExpirationTime := now.Add(-1 * unknownThreshold).Add(-1 * time.Second).Add(-1 * notReadyThreshold)
-				member1Lease := createMemberLease(member1Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(shortExpirationTime))
-				member2Lease := createMemberLease(member2Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member2ID, druidv1alpha1.EtcdRoleMember)), utils.PointerOf(longExpirationTime))
-				member3Lease := createMemberLease(member3Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member3ID, druidv1alpha1.EtcdRoleMember)), utils.PointerOf(shortExpirationTime))
+				member1Lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(shortExpirationTime))
+				member2Lease := createMemberLease(member2Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member2ID, druidv1alpha1.EtcdRoleMember)), utils.PointerOf(longExpirationTime))
+				member3Lease := createMemberLease(member3Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member3ID, druidv1alpha1.EtcdRoleMember)), utils.PointerOf(shortExpirationTime))
 				member1Pod := createMemberPod(member1Name, etcdNamespace, true)
 				member2Pod := createMemberPod(member2Name, etcdNamespace, false)
 				existingObjects := mapToClientObjects([]*coordinationv1.Lease{member1Lease, member2Lease, member3Lease}, []*corev1.Pod{member1Pod, member2Pod})
@@ -159,9 +159,9 @@ var _ = Describe("ReadyCheck", func() {
 			It("should set member ready", func() {
 				now := time.Now()
 				renewTime := now.Add(-1 * 20 * time.Second)
-				member1Lease := createMemberLease(member1Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(renewTime))
-				member2Lease := createMemberLease(member2Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member2ID, druidv1alpha1.EtcdRoleMember)), utils.PointerOf(renewTime))
-				member3Lease := createMemberLease(member3Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member3ID, druidv1alpha1.EtcdRoleMember)), utils.PointerOf(renewTime))
+				member1Lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(renewTime))
+				member2Lease := createMemberLease(member2Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member2ID, druidv1alpha1.EtcdRoleMember)), utils.PointerOf(renewTime))
+				member3Lease := createMemberLease(member3Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member3ID, druidv1alpha1.EtcdRoleMember)), utils.PointerOf(renewTime))
 
 				existingObjects := mapToClientObjects([]*coordinationv1.Lease{member1Lease, member2Lease, member3Lease}, nil)
 				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
@@ -195,9 +195,9 @@ var _ = Describe("ReadyCheck", func() {
 				renewTime := now.Add(-1 * 20 * time.Second)
 				shortExpirationTime := now.Add(-1 * unknownThreshold).Add(-1 * time.Second)
 
-				member1Lease := createMemberLease(member1Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(renewTime))
-				member2Lease := createMemberLease(member2Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member2ID, druidv1alpha1.EtcdRoleMember)), utils.PointerOf(shortExpirationTime))
-				member3Lease := createMemberLease(member3Name, etcdNamespace, pointer.String(fmt.Sprintf("%s:%s", member3ID, druidv1alpha1.EtcdRoleMember)), nil)
+				member1Lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)), utils.PointerOf(renewTime))
+				member2Lease := createMemberLease(member2Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member2ID, druidv1alpha1.EtcdRoleMember)), utils.PointerOf(shortExpirationTime))
+				member3Lease := createMemberLease(member3Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member3ID, druidv1alpha1.EtcdRoleMember)), nil)
 				existingObjects := mapToClientObjects([]*coordinationv1.Lease{member1Lease, member2Lease, member3Lease}, nil)
 				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
 				check = ReadyCheck(cl, logr.Discard(), notReadyThreshold, unknownThreshold)
@@ -240,7 +240,7 @@ func createMemberLease(name, namespace string, holderIdentity *string, renewTime
 		},
 		Spec: coordinationv1.LeaseSpec{
 			HolderIdentity:       holderIdentity,
-			LeaseDurationSeconds: pointer.Int32(leaseDurationSeconds),
+			LeaseDurationSeconds: ptr.To[int32](leaseDurationSeconds),
 		},
 	}
 	if renewTime != nil {

--- a/internal/health/status/check_test.go
+++ b/internal/health/status/check_test.go
@@ -11,7 +11,6 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/health/condition"
 	"github.com/gardener/etcd-druid/internal/health/etcdmember"
-	"github.com/gardener/etcd-druid/internal/utils"
 
 	"github.com/gardener/gardener/pkg/utils/test"
 	"github.com/go-logr/logr"
@@ -117,9 +116,9 @@ var _ = Describe("Check", func() {
 			defer test.WithVar(&EtcdMemberChecks, []EtcdMemberCheckFn{
 				func(_ client.Client, _ logr.Logger, _, _ time.Duration) etcdmember.Checker {
 					return createEtcdMemberCheck(
-						etcdMemberResult{ptr.To("1"), "member1", utils.PointerOf[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleLeader), druidv1alpha1.EtcdMemberStatusUnknown, "Unknown"},
-						etcdMemberResult{ptr.To("2"), "member2", utils.PointerOf[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleMember), druidv1alpha1.EtcdMemberStatusNotReady, "bar reason"},
-						etcdMemberResult{ptr.To("3"), "member3", utils.PointerOf[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleMember), druidv1alpha1.EtcdMemberStatusReady, "foobar reason"},
+						etcdMemberResult{ptr.To("1"), "member1", ptr.To[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleLeader), druidv1alpha1.EtcdMemberStatusUnknown, "Unknown"},
+						etcdMemberResult{ptr.To("2"), "member2", ptr.To[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleMember), druidv1alpha1.EtcdMemberStatusNotReady, "bar reason"},
+						etcdMemberResult{ptr.To("3"), "member3", ptr.To[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleMember), druidv1alpha1.EtcdMemberStatusReady, "foobar reason"},
 					)
 				},
 			})()

--- a/internal/health/status/check_test.go
+++ b/internal/health/status/check_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/test"
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -69,21 +69,21 @@ var _ = Describe("Check", func() {
 				},
 				Members: []druidv1alpha1.EtcdMemberStatus{
 					{
-						ID:                 pointer.String("1"),
+						ID:                 ptr.To("1"),
 						Name:               "member1",
 						Status:             druidv1alpha1.EtcdMemberStatusReady,
 						LastTransitionTime: metav1.NewTime(timeBefore),
 						Reason:             "foo reason",
 					},
 					{
-						ID:                 pointer.String("2"),
+						ID:                 ptr.To("2"),
 						Name:               "member2",
 						Status:             druidv1alpha1.EtcdMemberStatusNotReady,
 						LastTransitionTime: metav1.NewTime(timeBefore),
 						Reason:             "bar reason",
 					},
 					{
-						ID:                 pointer.String("3"),
+						ID:                 ptr.To("3"),
 						Name:               "member3",
 						Status:             druidv1alpha1.EtcdMemberStatusReady,
 						LastTransitionTime: metav1.NewTime(timeBefore),
@@ -117,9 +117,9 @@ var _ = Describe("Check", func() {
 			defer test.WithVar(&EtcdMemberChecks, []EtcdMemberCheckFn{
 				func(_ client.Client, _ logr.Logger, _, _ time.Duration) etcdmember.Checker {
 					return createEtcdMemberCheck(
-						etcdMemberResult{pointer.String("1"), "member1", utils.PointerOf[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleLeader), druidv1alpha1.EtcdMemberStatusUnknown, "Unknown"},
-						etcdMemberResult{pointer.String("2"), "member2", utils.PointerOf[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleMember), druidv1alpha1.EtcdMemberStatusNotReady, "bar reason"},
-						etcdMemberResult{pointer.String("3"), "member3", utils.PointerOf[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleMember), druidv1alpha1.EtcdMemberStatusReady, "foobar reason"},
+						etcdMemberResult{ptr.To("1"), "member1", utils.PointerOf[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleLeader), druidv1alpha1.EtcdMemberStatusUnknown, "Unknown"},
+						etcdMemberResult{ptr.To("2"), "member2", utils.PointerOf[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleMember), druidv1alpha1.EtcdMemberStatusNotReady, "bar reason"},
+						etcdMemberResult{ptr.To("3"), "member3", utils.PointerOf[druidv1alpha1.EtcdRole](druidv1alpha1.EtcdRoleMember), druidv1alpha1.EtcdMemberStatusReady, "foobar reason"},
 					)
 				},
 			})()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -17,7 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
@@ -66,7 +66,7 @@ func TestGetHostMountPathFromSecretRef(t *testing.T) {
 			secretRefDefined:      true,
 			secretExists:          true,
 			hostPathSetInSecret:   true,
-			hostPathInSecret:      pointer.String(hostPath),
+			hostPathInSecret:      ptr.To(hostPath),
 			expectedHostMountPath: hostPath,
 		},
 		{

--- a/internal/utils/envvar.go
+++ b/internal/utils/envvar.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gardener/etcd-druid/internal/common"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // GetEnvVarFromValue returns environment variable object with the provided name and value
@@ -42,7 +42,7 @@ func GetEnvVarFromSecret(name, secretName, secretKey string, optional bool) core
 					Name: secretName,
 				},
 				Key:      secretKey,
-				Optional: pointer.Bool(optional),
+				Optional: ptr.To(optional),
 			},
 		},
 	}
@@ -59,7 +59,7 @@ func GetBackupRestoreContainerEnvVars(store *druidv1alpha1.StoreSpec) ([]corev1.
 		return envVars, nil
 	}
 
-	storageContainer := pointer.StringDeref(store.Container, "")
+	storageContainer := ptr.Deref(store.Container, "")
 	envVars = append(envVars, GetEnvVarFromValue(common.EnvStorageContainer, storageContainer))
 
 	return envVars, nil

--- a/internal/utils/image.go
+++ b/internal/utils/image.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gardener/etcd-druid/internal/common"
 
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // GetEtcdImages returns images for etcd and backup-restore by inspecting the etcd spec and the image vector
@@ -58,7 +58,7 @@ func chooseImage(key string, specImage *string, iv imagevector.ImageVector) (*st
 	if err != nil {
 		return nil, err
 	}
-	return pointer.String(ivImage[key].String()), nil
+	return ptr.To(ivImage[key].String()), nil
 }
 
 // GetEtcdBackupRestoreImage returns the image for backup-restore from the given image vector.

--- a/internal/utils/miscellaneous.go
+++ b/internal/utils/miscellaneous.go
@@ -51,14 +51,6 @@ func Key(namespaceOrName string, nameOpt ...string) client.ObjectKey {
 	return client.ObjectKey{Namespace: namespace, Name: name}
 }
 
-// TypeDeref dereferences a pointer to a type if it is not nil, else it returns the default value.
-func TypeDeref[T any](val *T, defaultVal T) T {
-	if val != nil {
-		return *val
-	}
-	return defaultVal
-}
-
 // IsEmptyString returns true if the string is empty or contains only whitespace characters.
 func IsEmptyString(s string) bool {
 	return len(strings.TrimSpace(s)) == 0
@@ -70,9 +62,4 @@ func IfConditionOr[T any](condition bool, trueVal, falseVal T) T {
 		return trueVal
 	}
 	return falseVal
-}
-
-// PointerOf returns a pointer to the given value.
-func PointerOf[T any](val T) *T {
-	return &val
 }

--- a/internal/webhook/util/decode.go
+++ b/internal/webhook/util/decode.go
@@ -108,7 +108,7 @@ func (d *RequestDecoder) doDecodeRequestObjects(req admission.Request) (oldObj, 
 			return
 		}
 	default:
-		err = druiderr.WrapError(fmt.Errorf("unsupported operation %s", req.Operation), ErrDecodeRequestObject, "doDecodeRequestObjects", "unsupported operation")
+		err = druiderr.New(ErrDecodeRequestObject, "doDecodeRequestObjects", "unsupported operation")
 	}
 	return
 }

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -24,12 +24,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8s_labels "k8s.io/apimachinery/pkg/labels"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -519,14 +518,14 @@ func startEtcdZeroDownTimeValidatorJob(ctx context.Context, cl client.Client, et
 // getEtcdLeaderPodName returns the leader pod name by using lease
 func getEtcdLeaderPodName(ctx context.Context, cl client.Client, etcd *v1alpha1.Etcd) (*types.NamespacedName, error) {
 	leaseList := &v1.LeaseList{}
-	r1, err := k8s_labels.NewRequirement(v1alpha1.LabelPartOfKey, selection.Equals, []string{etcd.Name})
+	r1, err := k8slabels.NewRequirement(v1alpha1.LabelPartOfKey, selection.Equals, []string{etcd.Name})
 	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
-	r2, err := k8s_labels.NewRequirement(v1alpha1.LabelComponentKey, selection.Equals, []string{common.ComponentNameMemberLease})
+	r2, err := k8slabels.NewRequirement(v1alpha1.LabelComponentKey, selection.Equals, []string{common.ComponentNameMemberLease})
 	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
 
 	opts := &client.ListOptions{
 		Namespace:     etcd.Namespace,
-		LabelSelector: k8s_labels.NewSelector().Add(*r1, *r2),
+		LabelSelector: k8slabels.NewSelector().Add(*r1, *r2),
 	}
 	ExpectWithOffset(1, cl.List(ctx, leaseList, opts)).ShouldNot(HaveOccurred())
 
@@ -574,7 +573,7 @@ func checkDefragmentationFinished(ctx context.Context, cl client.Client, etcd *v
 		// Get etcd leader pod logs to ensure etcd cluster defragmentation is finished or not.
 		logs, err := getPodLogs(ctx, leaderPodKey, &corev1.PodLogOptions{
 			Container:    "backup-restore",
-			SinceSeconds: pointer.Int64(60),
+			SinceSeconds: ptr.To[int64](60),
 		})
 
 		if err != nil {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -122,7 +122,7 @@ var (
 	backupDeltaSnapshotMemoryLimit = resource.MustParse("100Mi")
 	gzipCompression                = v1alpha1.GzipCompression
 	backupCompression              = v1alpha1.CompressionSpec{
-		Enabled: pointer.Bool(true),
+		Enabled: ptr.To(true),
 		Policy:  &gzipCompression,
 	}
 	defaultBackupStore = v1alpha1.StoreSpec{
@@ -814,7 +814,7 @@ func newTestHelperJob(jobName string, podSpec *corev1.PodSpec) *batchv1.Job {
 			Template: corev1.PodTemplateSpec{
 				Spec: *podSpec,
 			},
-			BackoffLimit: pointer.Int32(0),
+			BackoffLimit: ptr.To[int32](0),
 		},
 	}
 }
@@ -858,7 +858,7 @@ func createTLSVolume(name, secretName string) corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  secretName,
-				DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+				DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 			},
 		},
 	}
@@ -946,7 +946,7 @@ func getDebugPod(etcd *v1alpha1.Etcd) *corev1.Pod {
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  etcd.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.Name,
-							DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+							DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 						},
 					},
 				},
@@ -955,7 +955,7 @@ func getDebugPod(etcd *v1alpha1.Etcd) *corev1.Pod {
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  etcd.Spec.Etcd.ClientUrlTLS.ServerTLSSecretRef.Name,
-							DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+							DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 						},
 					},
 				},
@@ -964,7 +964,7 @@ func getDebugPod(etcd *v1alpha1.Etcd) *corev1.Pod {
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
 							SecretName:  etcd.Spec.Etcd.ClientUrlTLS.ClientTLSSecretRef.Name,
-							DefaultMode: pointer.Int32(common.ModeOwnerReadWriteGroupRead),
+							DefaultMode: ptr.To(common.ModeOwnerReadWriteGroupRead),
 						},
 					},
 				},

--- a/test/integration/controllers/compaction/reconciler_test.go
+++ b/test/integration/controllers/compaction/reconciler_test.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -56,13 +56,13 @@ var _ = Describe("Compaction Controller", func() {
 
 			// manually update full lease spec since there is no running instance of etcd-backup-restore
 			By("update full snapshot lease")
-			fullSnapLease.Spec.HolderIdentity = pointer.String("0")
+			fullSnapLease.Spec.HolderIdentity = ptr.To("0")
 			fullSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), fullSnapLease)).To(Succeed())
 
 			// manually update delta lease spec since there is no running instance of etcd-backup-restore
 			By("update delta snapshot lease")
-			deltaSnapLease.Spec.HolderIdentity = pointer.String("101")
+			deltaSnapLease.Spec.HolderIdentity = ptr.To("101")
 			deltaSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), deltaSnapLease)).To(Succeed())
 
@@ -114,12 +114,12 @@ var _ = Describe("Compaction Controller", func() {
 			// Expect(k8sClient.Create(ctx, j)).To(Succeed())
 
 			// Deliberately update the full lease
-			fullSnapLease.Spec.HolderIdentity = pointer.String("0")
+			fullSnapLease.Spec.HolderIdentity = ptr.To("0")
 			fullSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), fullSnapLease)).To(Succeed())
 
 			// Deliberately update the delta lease
-			deltaSnapLease.Spec.HolderIdentity = pointer.String("101")
+			deltaSnapLease.Spec.HolderIdentity = ptr.To("101")
 			deltaSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), deltaSnapLease)).To(Succeed())
 
@@ -162,12 +162,12 @@ var _ = Describe("Compaction Controller", func() {
 			fullSnapLease, deltaSnapLease = createEtcdSnapshotLeasesAndWait(k8sClient, instance)
 
 			// Deliberately update the full lease
-			fullSnapLease.Spec.HolderIdentity = pointer.String("0")
+			fullSnapLease.Spec.HolderIdentity = ptr.To("0")
 			fullSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), fullSnapLease)).To(Succeed())
 
 			// Deliberately update the delta lease
-			deltaSnapLease.Spec.HolderIdentity = pointer.String("101")
+			deltaSnapLease.Spec.HolderIdentity = ptr.To("101")
 			deltaSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), deltaSnapLease)).To(Succeed())
 
@@ -206,12 +206,12 @@ var _ = Describe("Compaction Controller", func() {
 			fullSnapLease, deltaSnapLease = createEtcdSnapshotLeasesAndWait(k8sClient, instance)
 
 			// Deliberately update the full lease
-			fullSnapLease.Spec.HolderIdentity = pointer.String("0")
+			fullSnapLease.Spec.HolderIdentity = ptr.To("0")
 			fullSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), fullSnapLease)).To(Succeed())
 
 			// Deliberately update the delta lease
-			deltaSnapLease.Spec.HolderIdentity = pointer.String("101")
+			deltaSnapLease.Spec.HolderIdentity = ptr.To("101")
 			deltaSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), deltaSnapLease)).To(Succeed())
 
@@ -247,12 +247,12 @@ var _ = Describe("Compaction Controller", func() {
 			fullSnapLease, deltaSnapLease = createEtcdSnapshotLeasesAndWait(k8sClient, instance)
 
 			// Deliberately update the full lease
-			fullSnapLease.Spec.HolderIdentity = pointer.String("0")
+			fullSnapLease.Spec.HolderIdentity = ptr.To("0")
 			fullSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), fullSnapLease)).To(Succeed())
 
 			// Deliberately update the delta lease
-			deltaSnapLease.Spec.HolderIdentity = pointer.String("101")
+			deltaSnapLease.Spec.HolderIdentity = ptr.To("101")
 			deltaSnapLease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
 			Expect(k8sClient.Update(context.TODO(), deltaSnapLease)).To(Succeed())
 
@@ -428,7 +428,7 @@ func validateStoreGCPForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1.J
 												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
 											}),
 											"Key":      Equal("storageAPIEndpoint"),
-											"Optional": Equal(pointer.Bool(true)),
+											"Optional": Equal(ptr.To(true)),
 										})),
 									})),
 								}),
@@ -552,7 +552,7 @@ func validateStoreAzureForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1
 												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
 											}),
 											"Key":      Equal("emulatorEnabled"),
-											"Optional": Equal(pointer.Bool(true)),
+											"Optional": Equal(ptr.To(true)),
 										})),
 									})),
 								}),
@@ -564,7 +564,7 @@ func validateStoreAzureForCompactionJob(instance *druidv1alpha1.Etcd, j *batchv1
 												"Name": Equal(instance.Spec.Backup.Store.SecretRef.Name),
 											}),
 											"Key":      Equal("storageAPIEndpoint"),
-											"Optional": Equal(pointer.Bool(true)),
+											"Optional": Equal(ptr.To(true)),
 										})),
 									})),
 								}),

--- a/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
@@ -21,7 +21,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -358,7 +358,7 @@ func getVolumesElements(volumePrefix string, store *druidv1alpha1.StoreSpec) Ele
 			"VolumeSource": MatchFields(IgnoreExtras, Fields{
 				"Secret": PointTo(MatchFields(IgnoreExtras, Fields{
 					"SecretName":  Equal(store.SecretRef.Name),
-					"DefaultMode": Equal(pointer.Int32(common.ModeOwnerReadWriteGroupRead)),
+					"DefaultMode": Equal(ptr.To(common.ModeOwnerReadWriteGroupRead)),
 				})),
 			}),
 		}),
@@ -405,7 +405,7 @@ func matchTaskStatus(jobStatus *batchv1.JobStatus) gomegatypes.GomegaMatcher {
 	return MatchFields(IgnoreExtras, Fields{
 		"Status": MatchFields(IgnoreExtras, Fields{
 			"Conditions":         MatchAllElements(conditionIdentifier, conditionElements),
-			"ObservedGeneration": Equal(pointer.Int64(1)),
+			"ObservedGeneration": Equal(ptr.To[int64](1)),
 		}),
 	})
 }

--- a/test/it/controller/etcd/assertions.go
+++ b/test/it/controller/etcd/assertions.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
@@ -405,7 +406,7 @@ func assertETCDStatusFieldsDerivedFromStatefulSet(ctx context.Context, t *testin
 		if etcdInstance.Status.Replicas != *sts.Spec.Replicas {
 			return fmt.Errorf("expected replicas to be %d, found %d", sts.Spec.Replicas, etcdInstance.Status.Replicas)
 		}
-		if utils.TypeDeref(etcdInstance.Status.Ready, false) != expectedReadyStatus {
+		if ptr.Deref(etcdInstance.Status.Ready, false) != expectedReadyStatus {
 			return fmt.Errorf("expected ready to be %t, found %s", expectedReadyStatus, logPointerTypeToString[bool](etcdInstance.Status.Ready))
 		}
 		return nil

--- a/test/it/controller/etcd/helper.go
+++ b/test/it/controller/etcd/helper.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -130,7 +130,7 @@ func createStsPods(ctx context.Context, t *testing.T, cl client.Client, etcdObje
 					{
 						APIVersion:         sts.APIVersion,
 						Kind:               sts.Kind,
-						BlockOwnerDeletion: pointer.Bool(true),
+						BlockOwnerDeletion: ptr.To(true),
 						Name:               sts.Name,
 						UID:                sts.UID,
 					},
@@ -164,7 +164,7 @@ func createAndAssertEtcdReconciliation(ctx context.Context, t *testing.T, reconc
 	createAndAssertEtcdAndAllManagedResources(ctx, t, reconcilerTestEnv, etcdInstance)
 
 	// assert etcd status reconciliation
-	assertETCDObservedGeneration(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), pointer.Int64(1), 5*time.Second, 1*time.Second)
+	assertETCDObservedGeneration(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), ptr.To[int64](1), 5*time.Second, 1*time.Second)
 	expectedLastOperation := &druidv1alpha1.LastOperation{
 		Type:  druidv1alpha1.LastOperationTypeReconcile,
 		State: druidv1alpha1.LastOperationStateSucceeded,
@@ -187,7 +187,7 @@ func updateMemberLeaseSpec(ctx context.Context, t *testing.T, cl client.Client, 
 		lease := &coordinationv1.Lease{}
 		g.Expect(cl.Get(ctx, client.ObjectKey{Name: config.name, Namespace: namespace}, lease)).To(Succeed())
 		updatedLease := lease.DeepCopy()
-		updatedLease.Spec.HolderIdentity = pointer.String(fmt.Sprintf("%s:%s", config.memberID, config.role))
+		updatedLease.Spec.HolderIdentity = ptr.To(fmt.Sprintf("%s:%s", config.memberID, config.role))
 		updatedLease.Spec.RenewTime = config.renewTime
 		g.Expect(cl.Update(ctx, updatedLease)).To(Succeed())
 		t.Logf("successfully updated member lease %s with holderIdentity: %s", config.name, *updatedLease.Spec.HolderIdentity)

--- a/test/it/controller/etcd/reconciler_test.go
+++ b/test/it/controller/etcd/reconciler_test.go
@@ -22,7 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
@@ -117,7 +117,7 @@ func testAllManagedResourcesAreCreated(t *testing.T, testNs string, reconcilerTe
 	// It is sufficient to test that the resources are created as part of the sync. The configuration of each
 	// resource is now extensively covered in the unit tests for the respective component operator.
 	assertAllComponentsExists(ctx, t, reconcilerTestEnv, etcdInstance, timeout, pollingInterval)
-	assertETCDObservedGeneration(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), pointer.Int64(1), 5*time.Second, 1*time.Second)
+	assertETCDObservedGeneration(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), ptr.To[int64](1), 5*time.Second, 1*time.Second)
 	expectedLastOperation := &druidv1alpha1.LastOperation{
 		Type:  druidv1alpha1.LastOperationTypeReconcile,
 		State: druidv1alpha1.LastOperationStateSucceeded,
@@ -217,7 +217,7 @@ func testEtcdSpecUpdateWhenNoReconcileOperationAnnotationIsSet(t *testing.T, tes
 	// ***************** test etcd spec reconciliation  *****************
 	assertAllComponentsExists(ctx, t, reconcilerTestEnv, etcdInstance, 2*time.Second, 2*time.Second)
 	_ = updateAndGetStsRevision(ctx, t, reconcilerTestEnv.itTestEnv.GetClient(), etcdInstance)
-	assertETCDObservedGeneration(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), pointer.Int64(1), 5*time.Second, 1*time.Second)
+	assertETCDObservedGeneration(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), ptr.To[int64](1), 5*time.Second, 1*time.Second)
 	// ensure that sts generation does not change, ie, it should remain 1, as sts is not updated after etcd spec change without reconcile operation annotation
 	assertStatefulSetGeneration(ctx, t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), 1, 30*time.Second, 2*time.Second)
 }
@@ -249,7 +249,7 @@ func testEtcdSpecUpdateWhenReconcileOperationAnnotationIsSet(t *testing.T, testN
 	// ***************** test etcd spec reconciliation  *****************
 	assertAllComponentsExists(ctx, t, reconcilerTestEnv, etcdInstance, 30*time.Minute, 2*time.Second)
 	_ = updateAndGetStsRevision(ctx, t, reconcilerTestEnv.itTestEnv.GetClient(), etcdInstance)
-	assertETCDObservedGeneration(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), pointer.Int64(2), 2*time.Minute, 1*time.Second)
+	assertETCDObservedGeneration(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), ptr.To[int64](2), 2*time.Minute, 1*time.Second)
 	expectedLastOperation := &druidv1alpha1.LastOperation{
 		Type:  druidv1alpha1.LastOperationTypeReconcile,
 		State: druidv1alpha1.LastOperationStateSucceeded,
@@ -438,9 +438,9 @@ func testConditionsAndMembersWhenAllMemberLeasesAreActive(t *testing.T, etcd *dr
 	cl := reconcilerTestEnv.itTestEnv.GetClient()
 	assertETCDStatusConditions(t, cl, client.ObjectKeyFromObject(etcd), expectedConditions, 2*time.Minute, 2*time.Second)
 	expectedMemberStatuses := []druidv1alpha1.EtcdMemberStatus{
-		{Name: mlcs[0].name, ID: pointer.String(mlcs[0].memberID), Role: &mlcs[0].role, Status: druidv1alpha1.EtcdMemberStatusReady},
-		{Name: mlcs[1].name, ID: pointer.String(mlcs[1].memberID), Role: &mlcs[1].role, Status: druidv1alpha1.EtcdMemberStatusReady},
-		{Name: mlcs[2].name, ID: pointer.String(mlcs[2].memberID), Role: &mlcs[2].role, Status: druidv1alpha1.EtcdMemberStatusReady},
+		{Name: mlcs[0].name, ID: ptr.To(mlcs[0].memberID), Role: &mlcs[0].role, Status: druidv1alpha1.EtcdMemberStatusReady},
+		{Name: mlcs[1].name, ID: ptr.To(mlcs[1].memberID), Role: &mlcs[1].role, Status: druidv1alpha1.EtcdMemberStatusReady},
+		{Name: mlcs[2].name, ID: ptr.To(mlcs[2].memberID), Role: &mlcs[2].role, Status: druidv1alpha1.EtcdMemberStatusReady},
 	}
 	assertETCDMemberStatuses(t, cl, client.ObjectKeyFromObject(etcd), expectedMemberStatuses, 2*time.Minute, 2*time.Second)
 }

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -87,7 +87,7 @@ func (eb *EtcdBuilder) WithClientTLS() *EtcdBuilder {
 			SecretReference: corev1.SecretReference{
 				Name: "client-url-ca-etcd",
 			},
-			DataKey: pointer.String("ca.crt"),
+			DataKey: ptr.To("ca.crt"),
 		},
 		ClientTLSSecretRef: corev1.SecretReference{
 			Name: "client-url-etcd-client-tls",
@@ -110,7 +110,7 @@ func (eb *EtcdBuilder) WithPeerTLS() *EtcdBuilder {
 			SecretReference: corev1.SecretReference{
 				Name: "peer-url-ca-etcd",
 			},
-			DataKey: pointer.String("ca.crt"),
+			DataKey: ptr.To("ca.crt"),
 		},
 		ServerTLSSecretRef: corev1.SecretReference{
 			Name: "peer-url-etcd-server-tls",
@@ -134,7 +134,7 @@ func (eb *EtcdBuilder) WithReadyStatus() *EtcdBuilder {
 		Replicas:        eb.etcd.Spec.Replicas,
 		CurrentReplicas: eb.etcd.Spec.Replicas,
 		UpdatedReplicas: eb.etcd.Spec.Replicas,
-		Ready:           pointer.Bool(true),
+		Ready:           ptr.To(true),
 		Members:         members,
 		Conditions: []druidv1alpha1.Condition{
 			{Type: druidv1alpha1.ConditionTypeAllMembersReady, Status: druidv1alpha1.ConditionTrue},
@@ -397,8 +397,8 @@ func getDefaultEtcd(name, namespace string) *druidv1alpha1.Etcd {
 						"memory": ParseQuantity("1000Mi"),
 					},
 				},
-				ClientPort: pointer.Int32(common.DefaultPortEtcdClient),
-				ServerPort: pointer.Int32(common.DefaultPortEtcdPeer),
+				ClientPort: ptr.To(common.DefaultPortEtcdClient),
+				ServerPort: ptr.To(common.DefaultPortEtcdPeer),
 			},
 			Common: druidv1alpha1.SharedConfig{
 				AutoCompactionMode:      &autoCompactionMode,
@@ -411,7 +411,7 @@ func getDefaultEtcd(name, namespace string) *druidv1alpha1.Etcd {
 func getBackupSpec() druidv1alpha1.BackupSpec {
 	return druidv1alpha1.BackupSpec{
 		Image:                    &imageBR,
-		Port:                     pointer.Int32(common.DefaultPortEtcdBackupRestore),
+		Port:                     ptr.To(common.DefaultPortEtcdBackupRestore),
 		FullSnapshotSchedule:     &snapshotSchedule,
 		GarbageCollectionPolicy:  &garbageCollectionPolicy,
 		GarbageCollectionPeriod:  &garbageCollectionPeriod,

--- a/test/utils/etcdcopybackupstask.go
+++ b/test/utils/etcdcopybackupstask.go
@@ -14,7 +14,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // CreateEtcdCopyBackupsTask creates an instance of EtcdCopyBackupsTask for the given provider and optional fields boolean.
@@ -24,8 +24,8 @@ func CreateEtcdCopyBackupsTask(name, namespace string, provider druidv1alpha1.St
 		waitForFinalSnapshot     *druidv1alpha1.WaitForFinalSnapshotSpec
 	)
 	if withOptionalFields {
-		maxBackupAge = pointer.Uint32(7)
-		maxBackups = pointer.Uint32(42)
+		maxBackupAge = ptr.To[uint32](7)
+		maxBackups = ptr.To[uint32](42)
 		waitForFinalSnapshot = &druidv1alpha1.WaitForFinalSnapshotSpec{
 			Enabled: true,
 			Timeout: &metav1.Duration{Duration: 10 * time.Minute},
@@ -42,7 +42,7 @@ func CreateEtcdCopyBackupsTask(name, namespace string, provider druidv1alpha1.St
 		},
 		Spec: druidv1alpha1.EtcdCopyBackupsTaskSpec{
 			SourceStore: druidv1alpha1.StoreSpec{
-				Container: pointer.String("source-container"),
+				Container: ptr.To("source-container"),
 				Prefix:    "/tmp",
 				Provider:  &provider,
 				SecretRef: &corev1.SecretReference{
@@ -51,7 +51,7 @@ func CreateEtcdCopyBackupsTask(name, namespace string, provider druidv1alpha1.St
 				},
 			},
 			TargetStore: druidv1alpha1.StoreSpec{
-				Container: pointer.String("target-container"),
+				Container: ptr.To("target-container"),
 				Prefix:    "/tmp",
 				Provider:  &provider,
 				SecretRef: &corev1.SecretReference{
@@ -80,8 +80,8 @@ func CreateEtcdCopyBackupsJob(taskName, namespace string) *batchv1.Job {
 					Kind:               "EtcdCopyBackupsTask",
 					Name:               taskName,
 					UID:                "",
-					Controller:         pointer.Bool(true),
-					BlockOwnerDeletion: pointer.Bool(true),
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
 				},
 			},
 		},

--- a/test/utils/imagevector.go
+++ b/test/utils/imagevector.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gardener/etcd-druid/internal/common"
 
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // CreateImageVector creates an image vector initializing it will different image sources.
@@ -18,14 +18,14 @@ func CreateImageVector(withEtcdImage, withBackupRestoreImage, withEtcdWrapperIma
 		imageSources = append(imageSources, &imagevector.ImageSource{
 			Name:       common.ImageKeyEtcd,
 			Repository: TestImageRepo,
-			Tag:        pointer.String(ETCDImageSourceTag),
+			Tag:        ptr.To(ETCDImageSourceTag),
 		})
 	}
 	if withBackupRestoreImage {
 		imageSources = append(imageSources, &imagevector.ImageSource{
 			Name:       common.ImageKeyEtcdBackupRestore,
 			Repository: TestImageRepo,
-			Tag:        pointer.String(ETCDBRImageTag),
+			Tag:        ptr.To(ETCDBRImageTag),
 		})
 
 	}
@@ -33,20 +33,20 @@ func CreateImageVector(withEtcdImage, withBackupRestoreImage, withEtcdWrapperIma
 		imageSources = append(imageSources, &imagevector.ImageSource{
 			Name:       common.ImageKeyEtcdWrapper,
 			Repository: TestImageRepo,
-			Tag:        pointer.String(ETCDWrapperImageTag),
+			Tag:        ptr.To(ETCDWrapperImageTag),
 		})
 	}
 	if withBackupRestoreDistrolessImage {
 		imageSources = append(imageSources, &imagevector.ImageSource{
 			Name:       common.ImageKeyEtcdBackupRestoreDistroless,
 			Repository: TestImageRepo,
-			Tag:        pointer.String(ETCDBRDistrolessImageTag),
+			Tag:        ptr.To(ETCDBRDistrolessImageTag),
 		})
 	}
 	imageSources = append(imageSources, &imagevector.ImageSource{
 		Name:       common.ImageKeyAlpine,
 		Repository: TestImageRepo,
-		Tag:        pointer.String(InitContainerTag),
+		Tag:        ptr.To(InitContainerTag),
 	})
 	return imageSources
 }

--- a/test/utils/lease.go
+++ b/test/utils/lease.go
@@ -15,7 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,8 +36,8 @@ func CreateLease(name, namespace, etcdName string, etcdUID types.UID, componentN
 				Kind:               "Etcd",
 				Name:               etcdName,
 				UID:                etcdUID,
-				Controller:         pointer.Bool(true),
-				BlockOwnerDeletion: pointer.Bool(true),
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
 			}},
 		},
 	}

--- a/test/utils/misc.go
+++ b/test/utils/misc.go
@@ -49,14 +49,6 @@ func MergeMaps[K comparable, V any](sourceMaps ...map[K]V) map[K]V {
 	return merged
 }
 
-// TypeDeref dereferences a pointer to a type if it is not nil, else it returns the default value.
-func TypeDeref[T any](val *T, defaultVal T) T {
-	if val != nil {
-		return *val
-	}
-	return defaultVal
-}
-
 // GenerateRandomAlphanumericString generates a random alphanumeric string of the given length.
 func GenerateRandomAlphanumericString(g *WithT, length int) string {
 	b := make([]byte, length)

--- a/test/utils/statefulset.go
+++ b/test/utils/statefulset.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // CreateStatefulSet creates a statefulset with its owner reference set to etcd.
@@ -36,14 +36,14 @@ func CreateStatefulSet(name, namespace string, etcdUID types.UID, replicas int32
 				Kind:               "Etcd",
 				Name:               name,
 				UID:                etcdUID,
-				Controller:         pointer.Bool(true),
-				BlockOwnerDeletion: pointer.Bool(true),
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
 			}},
 			Finalizers:    nil,
 			ManagedFields: nil,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: pointer.Int32(replicas),
+			Replicas: ptr.To(replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					druidv1alpha1.LabelManagedByKey: druidv1alpha1.LabelManagedByValue,
@@ -71,7 +71,7 @@ func CreateStatefulSet(name, namespace string, etcdUID types.UID, replicas int32
 						Resources: corev1.VolumeResourceRequirements{
 							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("25Gi")},
 						},
-						StorageClassName: pointer.String("gardener.cloud-fast"),
+						StorageClassName: ptr.To("gardener.cloud-fast"),
 					},
 				},
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

The pkg "k8s.io/utils/pointer" is deprecated starting from k8s.io/utils version `v0.0.0-20240502163921-fe8a2dddb1d0` which is our current version in master. It is recommended to use the alternate pkg "k8s.io/utils/ptr" from here on. 

This PR removes the deprecated package and uses the recommended package for pointer related operations.

Check the release timeline for `k8s.io/utils` [here](https://pkg.go.dev/k8s.io/utils@v0.0.0-20240502163921-fe8a2dddb1d0?tab=versions)

**Which issue(s) this PR fixes**:
Fixes #863

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
remove deprecated pkg `k8s.io/utils/pointer` and use pkg `k8s.io/utils/ptr`
```
