### PR TITLE
Fix `.ci/component_descriptor` script

### DIFF
--- a/.ci/hack/component_descriptor
+++ b/.ci/hack/component_descriptor
@@ -47,33 +47,26 @@ fi
 
 echo "Enriching component descriptor from ${BASE_DEFINITION_PATH}"
 
-image_vector_path=""
-if [[ -f "$repo_root_dir/charts/images.yaml" ]]; then
-  image_vector_path="$repo_root_dir/charts/images.yaml"
-elif [[ -f "$repo_root_dir/imagevector/images.yaml" ]]; then
-  image_vector_path="$repo_root_dir/imagevector/images.yaml"
+image_vector_path="$repo_root_dir/internal/images/images.yaml"
+
+# default environment variables
+if [[ -z "${COMPONENT_PREFIXES}" ]]; then
+  # Match only images with OCM component references, ie, images created from gardener org repositories.
+  # In other words, don't match external images like europe-docker.pkg.dev/gardener-project/public/3rd/alpine.
+  COMPONENT_PREFIXES="europe-docker.pkg.dev/gardener-project/public/gardener"
 fi
 
-if [[ ! -z "$image_vector_path" ]]; then
-  # default environment variables
-  if [[ -z "${COMPONENT_PREFIXES}" ]]; then
-    # Match only images with OCM component references, ie, images created from gardener org repositories.
-    # In other words, don't match external images like europe-docker.pkg.dev/gardener-project/public/3rd/alpine.
-    COMPONENT_PREFIXES="europe-docker.pkg.dev/gardener-project/public/gardener"
-  fi
-
-  if [[ -z "${COMPONENT_CLI_ARGS}" ]]; then
-    COMPONENT_CLI_ARGS="
-    --comp-desc ${BASE_DEFINITION_PATH} \
-    --image-vector "$image_vector_path" \
-    --component-prefixes "${COMPONENT_PREFIXES}" \
-    "
-  fi
-
-  # translates all images defined the images.yaml into component descriptor resources.
-  # For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
-  component-cli image-vector add ${COMPONENT_CLI_ARGS}
+if [[ -z "${COMPONENT_CLI_ARGS}" ]]; then
+  COMPONENT_CLI_ARGS="
+  --comp-desc ${BASE_DEFINITION_PATH} \
+  --image-vector "$image_vector_path" \
+  --component-prefixes "${COMPONENT_PREFIXES}" \
+  "
 fi
+
+# translates all images defined the images.yaml into component descriptor resources.
+# For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
+component-cli image-vector add ${COMPONENT_CLI_ARGS}
 
 if [[ -d "$repo_root_dir/charts/" ]]; then
   for image_tpl_path in "$repo_root_dir/charts/"*"/templates/_images.tpl"; do

--- a/.ci/hack/component_descriptor
+++ b/.ci/hack/component_descriptor
@@ -3,7 +3,6 @@
 set -e
 
 repo_root_dir="$1"
-repo_name="${2:-github.com/gardener/gardener}"
 descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
 
 echo "Enriching component descriptor from ${BASE_DEFINITION_PATH}"

--- a/.ci/hack/component_descriptor
+++ b/.ci/hack/component_descriptor
@@ -1,94 +1,27 @@
 #!/usr/bin/env bash
 
-# Derived from https://github.com/gardener/gardener/blob/v1.86.0/hack/.ci/component_descriptor
-
-# Configuration Options:
-#
-# COMPONENT_PREFIXES: Set the image prefix that should be used to
-#                     determine if an image is defined by another component.
-#                     Defaults to "europe-docker.pkg.dev/gardener-project/public/gardener"
-#
-# COMPONENT_CLI_ARGS: Set all component-cli arguments.
-#                     This should be used with care as all defaults are overwritten.
-#
-
 set -e
 
 repo_root_dir="$1"
 repo_name="${2:-github.com/gardener/gardener}"
 descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
 
-resources_file="$repo_root_dir/.ci/resources.yaml"
-if [[ -f ${resources_file} ]]; then
-  echo "Adding additional resources from ${resources_file}"
-
-  # component-cli expects a directory where the component descriptor file is named component-descriptor.yaml.
-  # however the pre-rendered component descriptors of the pipeline have different filenames.
-  # therefore create a tempdir and copy the pre-rendered component descriptor to it with the correct filename.
-  tmp_dir="$(mktemp -d)"
-  tmp_cd="${tmp_dir}/component-descriptor.yaml"
-  cp "${BASE_DEFINITION_PATH}" "${tmp_cd}"
-  echo "${tmp_cd}"
-
-  # read the component version.
-  if [[ -z ${EFFECTIVE_VERSION} ]]; then
-    echo "The env variable EFFECTIVE_VERSION must be set"
-    exit 1
-  fi
-
-  # adds all resources defined in the resources file to the component descriptor.
-  component-cli component-archive resources add ${tmp_dir} ${resources_file} -v=3 -- COMPONENT_VERSION=${EFFECTIVE_VERSION}
-
-  # move modified component descriptor back to the original file.
-  mv "${tmp_cd}" "${BASE_DEFINITION_PATH}"
-else
-  echo "Resources file ${resources_file} not found. Skip adding additional resources."
-fi
-
 echo "Enriching component descriptor from ${BASE_DEFINITION_PATH}"
 
 image_vector_path="$repo_root_dir/internal/images/images.yaml"
 
-# default environment variables
-if [[ -z "${COMPONENT_PREFIXES}" ]]; then
-  # Match only images with OCM component references, ie, images created from gardener org repositories.
-  # In other words, don't match external images like europe-docker.pkg.dev/gardener-project/public/3rd/alpine.
-  COMPONENT_PREFIXES="europe-docker.pkg.dev/gardener-project/public/gardener"
-fi
+# Match only images with OCM component references, ie, images created from gardener org repositories.
+# In other words, don't match external images like europe-docker.pkg.dev/gardener-project/public/3rd/alpine.
+component_prefixes="europe-docker.pkg.dev/gardener-project/public/gardener"
 
-if [[ -z "${COMPONENT_CLI_ARGS}" ]]; then
-  COMPONENT_CLI_ARGS="
-  --comp-desc ${BASE_DEFINITION_PATH} \
-  --image-vector "$image_vector_path" \
-  --component-prefixes "${COMPONENT_PREFIXES}" \
-  "
-fi
+component_cli_args="
+--comp-desc ${BASE_DEFINITION_PATH} \
+--image-vector "$image_vector_path" \
+--component-prefixes "$component_prefixes" \
+"
 
-# translates all images defined the images.yaml into component descriptor resources.
+# translates all images defined in internal/images/images.yaml into component descriptor resources.
 # For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
-component-cli image-vector add ${COMPONENT_CLI_ARGS}
-
-if [[ -d "$repo_root_dir/charts/" ]]; then
-  for image_tpl_path in "$repo_root_dir/charts/"*"/templates/_images.tpl"; do
-    if [[ ! -f "$image_tpl_path" ]]; then
-      continue
-    fi
-
-    outputFile=$(sed 's/{{-//' $image_tpl_path | sed 's/}}//' | sed 's/define//' | sed 's/-//' | sed 's/end//' | sed 's/"//' | sed 's/"//' |sed 's/image.//' |  sed -e 's/^[ \t]*//' | awk -v RS= '{for (i=1; i<=NF; i++) printf "%s%s", $i, (i==NF?"\n":" ")}')
-    echo "enriching component descriptor from ${image_tpl_path}"
-
-    while read p; do
-      line="$(echo -e "$p")"
-      IFS=' ' read -r -a array <<< "$line"
-      IFS=': ' read -r -a imageAndTag <<< ${array[1]}
-
-      NAME=${array[0]}
-      REPOSITORY=${imageAndTag[0]}
-      TAG=${imageAndTag[1]}
-
-      ${ADD_DEPENDENCIES_CMD} --container-image-dependencies "{\"name\": \"${NAME}\", \"image_reference\": \"${REPOSITORY}:${TAG}\", \"version\": \"$TAG\"}"
-    done < <(echo "$outputFile")
-  done
-fi
+component-cli image-vector add $component_cli_args
 
 cp "${BASE_DEFINITION_PATH}" "${descriptor_out_file}"


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
Fix images.yaml path in `.ci/component_descriptor` script.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @8R0WNI3 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
