### PR TITLE
Upgrade etcd-backup-restore-distroless: `v0.28.3` -> `v0.28.4`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -14,7 +14,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.28.3"
+  tag: "v0.28.4"
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper


### PR DESCRIPTION
**Release Notes**:

```bugfix operator github.com/gardener/etcd-backup-restore #761 @ishan16696
Fixed a bug in detecting single member restoration scenario for the zeroth pod and when no storage provider for backups is configured.
```

```improvement operator github.com/gardener/etcd-backup-restore #765 @ishan16696
Retry to take full snapshot if the previous full snapshot operation fails.
```

