### PR TITLE
Fix peer TLS enablement during scale-up of etcd cluster

### DIFF
--- a/internal/component/rolebinding/rolebinding.go
+++ b/internal/component/rolebinding/rolebinding.go
@@ -80,14 +80,14 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 			fmt.Sprintf("Error during create or update of role-binding %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
-	ctx.Logger.Info("synced", "component", "role", "objectKey", objectKey, "result", result)
+	ctx.Logger.Info("synced", "component", "role-binding", "objectKey", objectKey, "result", result)
 	return nil
 }
 
 // TriggerDelete triggers the deletion of the role binding for the given Etcd.
 func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta metav1.ObjectMeta) error {
 	objectKey := getObjectKey(etcdObjMeta)
-	ctx.Logger.Info("Triggering deletion of role", "objectKey", objectKey)
+	ctx.Logger.Info("Triggering deletion of role-binding", "objectKey", objectKey)
 	if err := r.client.Delete(ctx, emptyRoleBinding(objectKey)); err != nil {
 		if errors.IsNotFound(err) {
 			ctx.Logger.Info("No RoleBinding found, Deletion is a No-Op", "objectKey", objectKey)

--- a/internal/utils/lease.go
+++ b/internal/utils/lease.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const peerURLTLSEnabledKey = "member.etcd.gardener.cloud/tls-enabled"
+const PeerURLTLSEnabledKey = "member.etcd.gardener.cloud/tls-enabled"
 
 // IsPeerURLTLSEnabledForMembers checks if TLS has been enabled for all existing members of an etcd cluster identified by etcdName and in the provided namespace.
 func IsPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger logr.Logger, namespace, etcdName string, numReplicas int32) (bool, error) {
@@ -47,7 +47,7 @@ func IsPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger
 
 func parseAndGetTLSEnabledValue(lease coordinationv1.Lease, logger logr.Logger) (bool, error) {
 	if lease.Annotations != nil {
-		if tlsEnabledStr, ok := lease.Annotations[peerURLTLSEnabledKey]; ok {
+		if tlsEnabledStr, ok := lease.Annotations[PeerURLTLSEnabledKey]; ok {
 			tlsEnabled, err := strconv.ParseBool(tlsEnabledStr)
 			if err != nil {
 				logger.Error(err, "tls-enabled value is not a valid boolean", "namespace", lease.Namespace, "leaseName", lease.Name)

--- a/internal/utils/lease.go
+++ b/internal/utils/lease.go
@@ -18,7 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const PeerURLTLSEnabledKey = "member.etcd.gardener.cloud/tls-enabled"
+// LeaseAnnotationKeyPeerURLTLSEnabled is the annotation key present on the member lease.
+// If its value is `true` then it indicates that the member is TLS enabled.
+// If the annotation is not present or its value is `false` then it indicates that the member is not TLS enabled.
+const LeaseAnnotationKeyPeerURLTLSEnabled = "member.etcd.gardener.cloud/tls-enabled"
 
 // IsPeerURLTLSEnabledForMembers checks if TLS has been enabled for all existing members of an etcd cluster identified by etcdName and in the provided namespace.
 func IsPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger logr.Logger, namespace, etcdName string, numReplicas int32) (bool, error) {
@@ -47,7 +50,7 @@ func IsPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger
 
 func parseAndGetTLSEnabledValue(lease coordinationv1.Lease, logger logr.Logger) (bool, error) {
 	if lease.Annotations != nil {
-		if tlsEnabledStr, ok := lease.Annotations[PeerURLTLSEnabledKey]; ok {
+		if tlsEnabledStr, ok := lease.Annotations[LeaseAnnotationKeyPeerURLTLSEnabled]; ok {
 			tlsEnabled, err := strconv.ParseBool(tlsEnabledStr)
 			if err != nil {
 				logger.Error(err, "tls-enabled value is not a valid boolean", "namespace", lease.Namespace, "leaseName", lease.Name)

--- a/internal/utils/lease_test.go
+++ b/internal/utils/lease_test.go
@@ -96,7 +96,7 @@ func createLeases(namespace, etcdName string, numLease, withTLSEnabled int) []*c
 		var annotations map[string]string
 		if tlsEnabledCount < withTLSEnabled {
 			annotations = map[string]string{
-				PeerURLTLSEnabledKey: "true",
+				LeaseAnnotationKeyPeerURLTLSEnabled: "true",
 			}
 			tlsEnabledCount++
 		} else {
@@ -120,7 +120,7 @@ func randomizeAnnotations() map[string]string {
 	rBool := r.Intn(2) == 1
 	if rBool {
 		return map[string]string{
-			PeerURLTLSEnabledKey: "false",
+			LeaseAnnotationKeyPeerURLTLSEnabled: "false",
 		}
 	}
 	return nil

--- a/internal/utils/lease_test.go
+++ b/internal/utils/lease_test.go
@@ -96,7 +96,7 @@ func createLeases(namespace, etcdName string, numLease, withTLSEnabled int) []*c
 		var annotations map[string]string
 		if tlsEnabledCount < withTLSEnabled {
 			annotations = map[string]string{
-				peerURLTLSEnabledKey: "true",
+				PeerURLTLSEnabledKey: "true",
 			}
 			tlsEnabledCount++
 		} else {
@@ -120,7 +120,7 @@ func randomizeAnnotations() map[string]string {
 	rBool := r.Intn(2) == 1
 	if rBool {
 		return map[string]string{
-			peerURLTLSEnabledKey: "false",
+			PeerURLTLSEnabledKey: "false",
 		}
 	}
 	return nil

--- a/test/it/controller/etcd/reconciler_test.go
+++ b/test/it/controller/etcd/reconciler_test.go
@@ -240,9 +240,9 @@ func testEtcdSpecUpdateWhenReconcileOperationAnnotationIsSet(t *testing.T, testN
 	memberLeaseNames := druidv1alpha1.GetMemberLeaseNames(etcdInstance.ObjectMeta, etcdInstance.Spec.Replicas)
 	t.Log("updating member leases with peer-tls-enabled annotation set to true")
 	mlcs := []etcdMemberLeaseConfig{
-		{name: memberLeaseNames[0], annotations: map[string]string{utils.PeerURLTLSEnabledKey: "true"}},
-		{name: memberLeaseNames[1], annotations: map[string]string{utils.PeerURLTLSEnabledKey: "true"}},
-		{name: memberLeaseNames[2], annotations: map[string]string{utils.PeerURLTLSEnabledKey: "true"}},
+		{name: memberLeaseNames[0], annotations: map[string]string{utils.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+		{name: memberLeaseNames[1], annotations: map[string]string{utils.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+		{name: memberLeaseNames[2], annotations: map[string]string{utils.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
 	}
 	updateMemberLeases(context.Background(), t, reconcilerTestEnv.itTestEnv.GetClient(), testNs, mlcs)
 	// get latest version of etcdInstance


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
The PR fixes a bug in peer TLS enablement during scale-up of etcd cluster, which caused new pods to come up even before first pod had enabled peer TLS for itself. The root cause was the erroneous usage of `druiderrors.Wrap(err,,,)` in `handlePeerTLSChanges()`, where `err` was set to `nil` by the previous `patchOrUpdate(sts)` call, rather than using `druiderrors.New(,,)` in order to retry reconciliation after the default 10 second interval. The PR also simplifies the `handlePeerTLSChanges()` flow.

Thanks @ashwani2k for identifying this bug in the behavior.

The PR also rectifies couple of log messages.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @unmarshall @ashwani2k @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
