### PR TITLE
Fix `make deploy-debug`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ deploy-dev: $(SKAFFOLD) $(HELM)
 
 .PHONY: deploy-debug
 deploy-debug: $(SKAFFOLD) $(HELM)
-	@VERSION=$(VERSION) GIT_SHA=$(GIT_SHA) $(SKAFFOLD) debug --cleanup=false -m etcd-druid
+	@VERSION=$(VERSION) GIT_SHA=$(GIT_SHA) $(SKAFFOLD) debug --cleanup=false -m etcd-druid -p debug
 
 .PHONY: undeploy
 undeploy: $(SKAFFOLD) $(HELM)

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -18,7 +18,6 @@ build:
         flags:
           - -v
         ldflags:
-          - -w
           - -X github.com/gardener/etcd-druid/internal/version.Version={{.VERSION}}
           - -X github.com/gardener/etcd-druid/internal/version.GitSHA={{.GIT_SHA}}
 deploy:
@@ -31,6 +30,17 @@ deploy:
         setValues: # empty `setValues` value is not allowed
           foo: bar
 profiles:
+  # Profile to disable druid leader election, to allow debugging without abrupt exits due to failure to renew leader election lease within time.
+  - name: debug
+    patches:
+      - op: add
+        path: /deploy/helm/releases/0/setValues/replicas
+        value: 1
+      - op: add
+        path: /deploy/helm/releases/0/setValues/controllerManager
+        value:
+          leaderElection:
+            enabled: false
   - name: e2e-test
     activation:
       - env: "DRUID_E2E_TEST=true"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Fix a bug introduced by #842, which added the `-w` flag to the go build flags. This has now been removed. Additionally, enabling leader election during debugging caused timeouts due to druid not being able to renew its lease while the developer walks through the code via breakpoints. This has now been fixed by removing leader election when deploying druid in debug mode, and setting replicas to `1`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
