### PR TITLE
upgrade to greatest patch-version of etc-custom-image

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -8,7 +8,7 @@ images:
 - name: etcd
   sourceRepository: github.com/gardener/etcd-custom-image
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd
-  tag: "v3.4.26-3"
+  tag: "v3.4.26-6"
 - name: etcd-backup-restore-distroless
   resourceId:
     name: 'etcdbrctl'


### PR DESCRIPTION
**How to categorize this PR?**
/area delivery
/kind cleanup

**What this PR does / why we need it**: switch to custom-image w/ component-descriptor pointing to google-artifact-registry

```other operator
switch to etcd-custom-image v3.4.26-7 (hosted in google-artifact-registry, rather than - deprecated GCR)
```
