### PR TITLE
Adds etcd-cluster-size pod label and fixes handling of simultaneous changes to Peer TLS, Replicas and Pod labels

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -16,6 +16,8 @@ const (
 	LabelPartOfKey = "app.kubernetes.io/part-of"
 	// LabelComponentKey is a key for a label that sets the component type on resources provisioned for an etcd cluster.
 	LabelComponentKey = "app.kubernetes.io/component"
+	// LabelEtcdClusterSizeKey is a key for a label that sets the size of an etcd cluster.
+	LabelEtcdClusterSizeKey = "druid.gardener.cloud/etcd-cluster-size"
 )
 
 // Annotation keys that can be placed on an Etcd custom resource.

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -170,4 +170,7 @@ const (
 
 	// VolumeMountPathEtcdData is the path on a container where the etcd data directory is mounted.
 	VolumeMountPathEtcdData = "/var/etcd/data"
+
+	VolumeMountBasePathEtcdTLSArtifacts          = "/var/etcd/ssl"
+	VolumeMountBasePathBackupRestoreTLSArtifacts = "/var/etcdbr/ssl"
 )

--- a/internal/component/clientservice/clientservice.go
+++ b/internal/component/clientservice/clientservice.go
@@ -54,7 +54,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetClientService,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting client service: %v for etcd: %v", svcObjectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -77,7 +77,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncClientService,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of client service: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -97,7 +97,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		return druiderr.WrapError(
 			err,
 			ErrDeleteClientService,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			"Failed to delete client service",
 		)
 	}

--- a/internal/component/clientservice/clientservice_test.go
+++ b/internal/component/clientservice/clientservice_test.go
@@ -159,7 +159,7 @@ func TestSyncWhenServiceExists(t *testing.T) {
 			expectedError: &druiderr.DruidError{
 				Code:      ErrSyncClientService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: component.OperationPreSync,
+				Operation: component.OperationSync,
 			},
 		},
 	}

--- a/internal/component/clientservice/clientservice_test.go
+++ b/internal/component/clientservice/clientservice_test.go
@@ -56,7 +56,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetClientService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -106,7 +106,7 @@ func TestSyncWhenNoServiceExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncClientService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -159,7 +159,7 @@ func TestSyncWhenServiceExists(t *testing.T) {
 			expectedError: &druiderr.DruidError{
 				Code:      ErrSyncClientService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationPreSync,
 			},
 		},
 	}
@@ -211,7 +211,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteClientService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 			deleteErr: testutils.TestAPIInternalErr,
 		},

--- a/internal/component/configmap/configmap.go
+++ b/internal/component/configmap/configmap.go
@@ -55,7 +55,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return nil, druiderr.WrapError(err,
 			ErrGetConfigMap,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting ConfigMap: %v for etcd: %v", objKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -76,14 +76,14 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncConfigMap,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of configmap for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	checkSum, err := computeCheckSum(cm)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncConfigMap,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error when computing CheckSum for configmap for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	ctx.Data[common.CheckSumKeyConfigMap] = checkSum
@@ -103,7 +103,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		return druiderr.WrapError(
 			err,
 			ErrDeleteConfigMap,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			"Failed to delete configmap",
 		)
 	}

--- a/internal/component/configmap/configmap.go
+++ b/internal/component/configmap/configmap.go
@@ -73,6 +73,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 // PreSync is a no-op for the configmap component.
 func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
 	logger := ctx.Logger.WithValues("operation", component.OperationPreSync, "component", component.ConfigMapKind, "configmapName", druidv1alpha1.GetConfigMapName(etcd.ObjectMeta))
+	logger.Info("Running pre-sync for ConfigMap")
 	// Only if TLS is enabled for peer communication, we need to update the configmap. If not then there is nothing to be done in PreSync.
 	if etcd.Spec.Etcd.PeerUrlTLS == nil {
 		logger.V(4).Info("Peer TLS is not enabled, nothing to be done in PreSync")
@@ -164,6 +165,9 @@ func updateEtcdConfigWithPeerAndClientTLS(etcd *druidv1alpha1.Etcd, etcdCfg *etc
 
 func deriveReplicasFromInitialCluster(etcdCfg etcdConfig) int {
 	initialCluster := etcdCfg.InitialCluster
+	if utils.IsEmptyString(initialCluster) {
+		return 0
+	}
 	return len(strings.Split(initialCluster, ","))
 }
 

--- a/internal/component/configmap/configmap_test.go
+++ b/internal/component/configmap/configmap_test.go
@@ -56,7 +56,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetConfigMap,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -115,7 +115,7 @@ func TestSyncWhenNoConfigMapExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncConfigMap,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -211,7 +211,7 @@ func TestSyncWhenConfigMapExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncConfigMap,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -264,7 +264,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteConfigMap,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/configmap/configmap_test.go
+++ b/internal/component/configmap/configmap_test.go
@@ -179,7 +179,7 @@ func TestPrepareInitialCluster(t *testing.T) {
 			etcd := buildEtcd(tc.etcdReplicas, true, tc.peerTLSEnabled)
 			etcd.Spec.Etcd.ServerPort = tc.etcdSpecServerPort
 			peerScheme := utils.IfConditionOr(etcd.Spec.Etcd.PeerUrlTLS != nil, "https", "http")
-			actualInitialCluster := prepareInitialCluster(etcd, peerScheme)
+			actualInitialCluster := prepareInitialCluster(etcd, peerScheme, 0)
 			g.Expect(actualInitialCluster).To(Equal(tc.expectedInitialCluster))
 		})
 	}

--- a/internal/component/configmap/etcdconfig.go
+++ b/internal/component/configmap/etcdconfig.go
@@ -6,6 +6,7 @@ package configmap
 
 import (
 	"fmt"
+	"github.com/gardener/etcd-druid/internal/utils"
 	"strconv"
 	"strings"
 
@@ -148,6 +149,9 @@ func getSchemeAndSecurityConfig(tlsConfig *druidv1alpha1.TLSConfig, caPath, serv
 
 func isPeerUrlTLSAlreadyConfigured(etcdCfg etcdConfig) bool {
 	initialCluster := etcdCfg.InitialCluster
+	if utils.IsEmptyString(initialCluster) {
+		return false
+	}
 	splits := strings.Split(initialCluster, ",")
 	keyValue := strings.Split(splits[0], "=")
 	return strings.HasPrefix(keyValue[1], "https")

--- a/internal/component/memberlease/memberlease.go
+++ b/internal/component/memberlease/memberlease.go
@@ -53,7 +53,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 	); err != nil {
 		return resourceNames, druiderr.WrapError(err,
 			ErrListMemberLease,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error listing member leases for etcd: %v", druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	for _, lease := range objMetaList.Items {
@@ -98,7 +98,7 @@ func (r _resource) doCreateOrUpdate(ctx component.OperatorContext, etcd *druidv1
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncMemberLease,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error syncing member lease: %v for etcd: %v", objKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	ctx.Logger.Info("triggered create or update of member lease", "objectKey", objKey, "operationResult", opResult)
@@ -114,7 +114,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		client.MatchingLabels(getSelectorLabelsForAllMemberLeases(etcdObjMeta))); err != nil {
 		return druiderr.WrapError(err,
 			ErrDeleteMemberLease,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete member leases for etcd: %v", druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	ctx.Logger.Info("deleted", "component", "member-leases")

--- a/internal/component/memberlease/memberlease_test.go
+++ b/internal/component/memberlease/memberlease_test.go
@@ -69,7 +69,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrListMemberLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -135,7 +135,7 @@ func TestSync(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncMemberLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 		{
@@ -146,7 +146,7 @@ func TestSync(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncMemberLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -229,7 +229,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteMemberLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/peerservice/peerservice.go
+++ b/internal/component/peerservice/peerservice.go
@@ -54,7 +54,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetPeerService,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting peer service: %s for etcd: %v", svcObjectKey.Name, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -77,7 +77,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncPeerService,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of peer service: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -97,7 +97,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		return druiderr.WrapError(
 			err,
 			ErrDeletePeerService,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete peer service: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)),
 		)
 	}

--- a/internal/component/peerservice/peerservice_test.go
+++ b/internal/component/peerservice/peerservice_test.go
@@ -55,7 +55,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetPeerService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -105,7 +105,7 @@ func TestSyncWhenNoServiceExists(t *testing.T) {
 			expectedError: &druiderr.DruidError{
 				Code:      ErrSyncPeerService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -155,7 +155,7 @@ func TestSyncWhenServiceExists(t *testing.T) {
 			expectedError: &druiderr.DruidError{
 				Code:      ErrSyncPeerService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -209,7 +209,7 @@ func TestPeerServiceTriggerDelete(t *testing.T) {
 			expectError: &druiderr.DruidError{
 				Code:      ErrDeletePeerService,
 				Cause:     deleteInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/poddistruptionbudget/poddisruptionbudget.go
+++ b/internal/component/poddistruptionbudget/poddisruptionbudget.go
@@ -60,7 +60,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetPodDisruptionBudget,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting PDB: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -83,7 +83,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncPodDisruptionBudget,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of PDB: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -98,7 +98,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 	if err := client.IgnoreNotFound(r.client.Delete(ctx, emptyPodDisruptionBudget(pdbObjectKey))); err != nil {
 		return druiderr.WrapError(err,
 			ErrDeletePodDisruptionBudget,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete PDB: %v for etcd: %v", pdbObjectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	ctx.Logger.Info("deleted", "component", "pod-disruption-budget", "objectKey", pdbObjectKey)

--- a/internal/component/poddistruptionbudget/poddisruptionbudget_test.go
+++ b/internal/component/poddistruptionbudget/poddisruptionbudget_test.go
@@ -53,7 +53,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetPodDisruptionBudget,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -107,7 +107,7 @@ func TestSyncWhenNoPDBExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncPodDisruptionBudget,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -161,7 +161,7 @@ func TestSyncWhenPDBExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncPodDisruptionBudget,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -214,7 +214,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeletePodDisruptionBudget,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/role/role.go
+++ b/internal/component/role/role.go
@@ -53,7 +53,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetRole,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting role: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -76,7 +76,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncRole,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of role %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -95,7 +95,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		}
 		return druiderr.WrapError(err,
 			ErrDeleteRole,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete role: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)),
 		)
 	}

--- a/internal/component/role/role_test.go
+++ b/internal/component/role/role_test.go
@@ -52,7 +52,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetRole,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -98,7 +98,7 @@ func TestSync(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncRole,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -147,7 +147,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteRole,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 		{

--- a/internal/component/rolebinding/rolebinding.go
+++ b/internal/component/rolebinding/rolebinding.go
@@ -53,7 +53,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetRoleBinding,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting role-binding: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -76,7 +76,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncRoleBinding,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of role-binding %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -95,7 +95,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		}
 		return druiderr.WrapError(err,
 			ErrDeleteRoleBinding,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete role-binding: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)),
 		)
 	}

--- a/internal/component/rolebinding/rolebinding_test.go
+++ b/internal/component/rolebinding/rolebinding_test.go
@@ -52,7 +52,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetRoleBinding,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -98,7 +98,7 @@ func TestSync(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncRoleBinding,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -147,7 +147,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteRoleBinding,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 		{

--- a/internal/component/serviceaccount/serviceaccount.go
+++ b/internal/component/serviceaccount/serviceaccount.go
@@ -55,7 +55,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetServiceAccount,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting service account: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -78,7 +78,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncServiceAccount,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of service account: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -97,7 +97,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		}
 		return druiderr.WrapError(err,
 			ErrDeleteServiceAccount,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete service account: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	ctx.Logger.Info("deleted", "component", "service-account", "objectKey", objectKey)

--- a/internal/component/serviceaccount/serviceaccount_test.go
+++ b/internal/component/serviceaccount/serviceaccount_test.go
@@ -51,7 +51,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetServiceAccount,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -106,7 +106,7 @@ func TestSync(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncServiceAccount,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -157,7 +157,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteServiceAccount,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/snapshotlease/snapshotlease.go
+++ b/internal/component/snapshotlease/snapshotlease.go
@@ -54,7 +54,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 	if err != nil {
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetSnapshotLease,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting delta snapshot lease: %v for etcd: %v", deltaSnapshotObjectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)),
 		)
 	}
@@ -66,7 +66,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 	if err != nil {
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetSnapshotLease,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting full snapshot lease: %v for etcd: %v", fullSnapshotObjectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)),
 		)
 	}
@@ -87,7 +87,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 		return r.deleteAllSnapshotLeases(ctx, etcd.ObjectMeta, func(err error) error {
 			return druiderr.WrapError(err,
 				ErrSyncSnapshotLease,
-				"Sync",
+				component.OperationSync,
 				fmt.Sprintf("Failed to delete existing snapshot leases (due to backup being disabled for etcd) due to reason: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 		})
 	}
@@ -112,7 +112,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 	if err := r.deleteAllSnapshotLeases(ctx, etcdObjMeta, func(err error) error {
 		return druiderr.WrapError(err,
 			ErrDeleteSnapshotLease,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete snapshot leases for etcd: %v", druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}); err != nil {
 		return err
@@ -152,7 +152,7 @@ func (r _resource) doCreateOrUpdate(ctx component.OperatorContext, etcd *druidv1
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncSnapshotLease,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error syncing snapshot lease: %v for etcd: %v", leaseObjectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	ctx.Logger.Info("triggered create or update of snapshot lease", "objectKey", leaseObjectKey, "operationResult", opResult)

--- a/internal/component/snapshotlease/snapshotlease_test.go
+++ b/internal/component/snapshotlease/snapshotlease_test.go
@@ -62,7 +62,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetSnapshotLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -111,7 +111,7 @@ func TestSyncWhenBackupIsEnabled(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncSnapshotLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -156,7 +156,7 @@ func TestSyncWhenBackupHasBeenDisabled(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncSnapshotLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -217,7 +217,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteSnapshotLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/statefulset/statefulset.go
+++ b/internal/component/statefulset/statefulset.go
@@ -6,14 +6,17 @@ package statefulset
 
 import (
 	"fmt"
+
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/common"
 	"github.com/gardener/etcd-druid/internal/component"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
 	"github.com/gardener/etcd-druid/internal/features"
 	"github.com/gardener/etcd-druid/internal/utils"
+
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +41,7 @@ type _resource struct {
 	client         client.Client
 	imageVector    imagevector.ImageVector
 	useEtcdWrapper bool
+	logger         logr.Logger
 }
 
 // New returns a new statefulset component operator.
@@ -74,7 +78,8 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 // is different from the label selector required to be applied on it. This is because the statefulset's
 // spec.selector field is immutable and cannot be updated on the existing statefulset.
 func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
-	ctx.Logger.Info("Running pre-sync for StatefulSet", "name", druidv1alpha1.GetStatefulSetName(etcd.ObjectMeta), "namespace", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta))
+	r.logger = ctx.Logger.WithValues("component", component.StatefulSetKind, "operation", component.OperationPreSync)
+	r.logger.Info("Running pre-sync for StatefulSet")
 	sts, err := r.getExistingStatefulSet(ctx, etcd.ObjectMeta)
 	if err != nil {
 		return druiderr.WrapError(err,
@@ -87,43 +92,36 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 		if err = r.handlePeerTLSChanges(ctx, etcd, sts); err != nil {
 			return err
 		}
+		if err = r.handleStsPodLabelsAndLabelSelectorOnMismatch(ctx, etcd, sts); err != nil {
+			return err
+		}
 	}
-	if err = r.handleStsPodLabelsOnMismatch(ctx, etcd, sts); err != nil {
-		return err
-	}
-	return nil
+	return r.checkOrphanPodsAndRecreateStsWithPreviousReplicas(ctx, etcd)
 }
 
 // Sync creates or updates the statefulset for the given Etcd.
 func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
 	var (
-	//existingSTS *appsv1.StatefulSet
-	//err         error
+		existingSTS *appsv1.StatefulSet
+		err         error
 	)
-	//objectKey := getObjectKey(etcd.ObjectMeta)
-	//if existingSTS, err = r.getExistingStatefulSet(ctx, etcd.ObjectMeta); err != nil {
-	//	return druiderr.WrapError(err,
-	//		ErrSyncStatefulSet,
-	//		component.OperationSync,
-	//		fmt.Sprintf("Error getting StatefulSet: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
-	//}
-	// There is no StatefulSet present. Create one.
-	//if existingSTS == nil {
-	//	return r.createOrPatch(ctx, etcd)
-	//}
-
-	// StatefulSet exists, check if TLS has been enabled for peer communication, if yes then it is currently a multistep
-	// process to ensure that all members are updated and establish peer TLS communication.
-	//if err = r.handlePeerTLSChanges(ctx, etcd, existingSTS); err != nil {
-	//	return err
-	//}
-	return r.createOrPatch(ctx, etcd)
+	r.logger = ctx.Logger.WithValues("component", component.StatefulSetKind, "operation", component.OperationSync)
+	objectKey := getObjectKey(etcd.ObjectMeta)
+	if existingSTS, err = r.getExistingStatefulSet(ctx, etcd.ObjectMeta); err != nil {
+		return druiderr.WrapError(err,
+			ErrSyncStatefulSet,
+			component.OperationSync,
+			fmt.Sprintf("Error getting StatefulSet: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
+	}
+	sts := utils.IfConditionOr(existingSTS == nil, emptyStatefulSet(etcd.ObjectMeta), existingSTS)
+	return r.createOrPatchWithReplicas(ctx, etcd, sts, etcd.Spec.Replicas, false)
 }
 
 // TriggerDelete triggers the deletion of the statefulset for the given Etcd.
 func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta metav1.ObjectMeta) error {
+	r.logger = ctx.Logger.WithValues("component", component.StatefulSetKind, "operation", component.OperationTriggerDelete)
 	objectKey := getObjectKey(etcdObjMeta)
-	ctx.Logger.Info("Triggering deletion of StatefulSet", "objectKey", objectKey)
+	r.logger.Info("Triggering deletion of StatefulSet")
 	if err := r.client.Delete(ctx, emptyStatefulSet(etcdObjMeta)); err != nil {
 		if apierrors.IsNotFound(err) {
 			ctx.Logger.Info("No StatefulSet found, Deletion is a No-Op", "objectKey", objectKey.Name)
@@ -134,76 +132,12 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete StatefulSet: %v for etcd %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
-	ctx.Logger.Info("deleted", "component", "statefulset", "objectKey", objectKey)
+	r.logger.Info("deletion successful")
 	return nil
 }
 
-// getExistingStatefulSet gets the existing statefulset if it exists.
-// If it is not found, it simply returns nil. Any other errors are returned as is.
-func (r _resource) getExistingStatefulSet(ctx component.OperatorContext, etcdObjMeta metav1.ObjectMeta) (*appsv1.StatefulSet, error) {
-	sts := emptyStatefulSet(etcdObjMeta)
-	if err := r.client.Get(ctx, getObjectKey(etcdObjMeta), sts); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return sts, nil
-}
-
-func (r _resource) updateStsWithPeerTLSConfig(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) error {
-	mutatingFn := func() error {
-		if builder, err := newStsBuilder(r.client, ctx.Logger, etcd, *sts.Spec.Replicas, r.useEtcdWrapper, r.imageVector, sts); err != nil {
-			return druiderr.WrapError(err,
-				ErrPreSyncStatefulSet,
-				component.OperationPreSync,
-				fmt.Sprintf("Error initializing StatefulSet builder for etcd %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
-		} else {
-			return builder.UpdateWithPeerTLSEnabled(ctx)
-		}
-	}
-	opResult, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, r.client, sts, mutatingFn)
-	if err != nil {
-		return druiderr.WrapError(err,
-			ErrPreSyncStatefulSet,
-			component.OperationPreSync,
-			fmt.Sprintf("Error updating StatefulSet: %s for etcd: %v", sts.Name, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
-	}
-
-	ctx.Logger.Info("triggered update of statefulSet to patch Peer TLS Volumes and Volume Mounts", "statefulSet", getObjectKey(etcd.ObjectMeta), "operationResult", opResult)
-	return nil
-}
-
-// createOrPatchWithReplicas ensures that the StatefulSet is updated with all changes from passed in etcd but the replicas set on the StatefulSet
-// are taken from the passed in replicas and not from the etcd component.
-func (r _resource) createOrPatchWithReplicas(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd, replicas int32) error {
-	desiredStatefulSet := emptyStatefulSet(etcd.ObjectMeta)
-	mutatingFn := func() error {
-		if builder, err := newStsBuilder(r.client, ctx.Logger, etcd, replicas, r.useEtcdWrapper, r.imageVector, desiredStatefulSet); err != nil {
-			return druiderr.WrapError(err,
-				ErrSyncStatefulSet,
-				component.OperationSync,
-				fmt.Sprintf("Error initializing StatefulSet builder for etcd %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
-		} else {
-			return builder.Build(ctx)
-		}
-	}
-	opResult, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, r.client, desiredStatefulSet, mutatingFn)
-	if err != nil {
-		return druiderr.WrapError(err,
-			ErrSyncStatefulSet,
-			component.OperationSync,
-			fmt.Sprintf("Error creating or patching StatefulSet: %s for etcd: %v", desiredStatefulSet.Name, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
-	}
-
-	ctx.Logger.Info("triggered create/patch of statefulSet", "statefulSet", getObjectKey(etcd.ObjectMeta), "operationResult", opResult)
-	return nil
-}
-
-// createOrPatch updates StatefulSet taking changes from passed in etcd component.
-func (r _resource) createOrPatch(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
-	return r.createOrPatchWithReplicas(ctx, etcd, etcd.Spec.Replicas)
-}
+// Functions to handle changes to peer TLS for an Etcd cluster.
+// --------------------------------------------------------------------------------------------
 
 // At this point of time we do not expect that once TLS has been enabled it will be disabled thereafter.
 // So the assumption here is that consumers will not disable TLS for peer communication once it has been enabled.
@@ -212,63 +146,194 @@ func (r _resource) handlePeerTLSChanges(ctx component.OperatorContext, etcd *dru
 	if etcd.Spec.Etcd.PeerUrlTLS == nil {
 		return nil
 	}
-
 	peerTLSEnabledForMembers, err := utils.IsPeerURLTLSEnabledForMembers(ctx, r.client, ctx.Logger, etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
-			ErrSyncStatefulSet,
-			component.OperationSync,
+			ErrPreSyncStatefulSet,
+			component.OperationPreSync,
 			fmt.Sprintf("Error checking if peer TLS is enabled for statefulset: %v, etcd: %v", client.ObjectKeyFromObject(existingSts), client.ObjectKeyFromObject(etcd)))
 	}
-
 	if !peerTLSEnabledForMembers {
 		if !isStatefulSetPatchedWithPeerTLSVolMount(existingSts) {
 			// This step ensures that only STS is updated with secret volume mounts which gets added to the etcd component due to
 			// enabling of TLS for peer communication. It preserves the current STS replicas.
-			if err = r.updateStsWithPeerTLSConfig(ctx, etcd, existingSts); err != nil {
-				return err
+			if err = r.createOrPatchWithReplicas(ctx, etcd, existingSts, *existingSts.Spec.Replicas, true); err != nil {
+				return druiderr.WrapError(err,
+					ErrPreSyncStatefulSet,
+					component.OperationPreSync,
+					fmt.Sprintf("Error updating StatefulSet with secret volume mounts for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 			}
 		} else {
-			ctx.Logger.Info("Secret volume mounts to enable Peer URL TLS have already been mounted. Skipping patching StatefulSet with secret volume mounts.")
+			r.logger.Info("Secret volume mounts to enable Peer URL TLS have already been mounted. Skipping patching StatefulSet with secret volume mounts.")
 		}
 		return druiderr.New(
 			druiderr.ErrRequeueAfter,
-			component.OperationSync,
+			component.OperationPreSync,
 			fmt.Sprintf("Peer URL TLS not enabled for #%d members for etcd: %v, requeuing reconcile request", existingSts.Spec.Replicas, client.ObjectKeyFromObject(etcd)))
 	}
-	ctx.Logger.Info("Peer URL TLS has been enabled for all currently running members")
+	r.logger.Info("Peer URL TLS has been enabled for all currently running members")
 	return nil
 }
 
-func (r _resource) handleStsPodLabelsOnMismatch(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) error {
-	if sts == nil {
-		return nil
-		// check if there is no STS because it got orphan deleted in the previous PreSync step and the subsequent creation of STS is pending or failed.
-		//orphanPodsObjMeta, err := r.getOrphanedPodsPartialObjMeta(ctx, etcd)
-		//if err != nil {
-		//	return err
-		//}
-		//numOrphanedPods := len(orphanPodsObjMeta)
-		//// there is nothing to be done. Let the creation of STS be done by Sync step.
-		//if numOrphanedPods == 0 {
-		//	return nil
-		//}
-		//// STS is pending creation, so we need to create it with the previous replicas. We derive the previous replicas from the number of existing member leases.
-		//// We cannot depend upon the number of pods as a potential node crash or node drain would evict this pod.
-		//previousReplicas, err := r.getPreviousReplicasFromMemberLeases(ctx, etcd)
-		//if err != nil {
-		//	return err
-		//}
-		//return r.createOrPatchWithReplicas(ctx, etcd, int32(previousReplicas))
-	}
-	if hasPodSelectorLabelOrPodTemplateLabelChanged(etcd, sts) {
-		//existingReplicas := *sts.Spec.Replicas
-		if err := r.orphanDeleteSts(ctx, sts); err != nil {
-			return err
+func isStatefulSetPatchedWithPeerTLSVolMount(sts *appsv1.StatefulSet) bool {
+	volumes := sts.Spec.Template.Spec.Volumes
+	var peerURLCAEtcdVolPresent, peerURLEtcdServerTLSVolPresent bool
+	for _, vol := range volumes {
+		if vol.Name == common.VolumeNameEtcdPeerCA {
+			peerURLCAEtcdVolPresent = true
 		}
-		//return r.createOrPatchWithReplicas(ctx, etcd, existingReplicas)
+		if vol.Name == common.VolumeNameEtcdPeerServerTLS {
+			peerURLEtcdServerTLSVolPresent = true
+		}
+	}
+	return peerURLCAEtcdVolPresent && peerURLEtcdServerTLSVolPresent
+}
+
+// --------------------------------------------------------------------------------------------
+
+// Functions to handle changes to Pod labels and Label-Selector changes to the StatefulSet.
+// --------------------------------------------------------------------------------------------
+func (r _resource) handleStsPodLabelsAndLabelSelectorOnMismatch(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) error {
+	if err := r.checkAndPatchStsPodLabelsOnMismatch(ctx, etcd, sts); err != nil {
+		return druiderr.WrapError(err,
+			ErrPreSyncStatefulSet,
+			component.OperationPreSync,
+			fmt.Sprintf("Error checking and patching StatefulSet pods with new labels for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
+	}
+
+	// check if pods have been updated with new labels.
+	podsHaveDesiredLabels, err := r.doStatefulSetPodsHaveDesiredLabels(ctx, etcd, sts)
+	if err != nil {
+		return druiderr.WrapError(err,
+			ErrPreSyncStatefulSet,
+			component.OperationPreSync,
+			fmt.Sprintf("Error checking if StatefulSet pods are updated for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
+	}
+	if !podsHaveDesiredLabels {
+		return druiderr.New(druiderr.ErrRequeueAfter,
+			component.OperationPreSync,
+			fmt.Sprintf("StatefulSet pods are not yet updated with new labels, for StatefulSet: %v for etcd: %v", getObjectKey(sts.ObjectMeta), druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
+		)
+	} else {
+		r.logger.Info("StatefulSet pods have all the desired labels", "objectKey", getObjectKey(etcd.ObjectMeta))
+	}
+
+	// check if label selector needs to be changed. If yes, then orphan delete the STS as update of label selector is forbidden.
+	if !labels.Equals(sts.Spec.Selector.MatchLabels, druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta)) {
+		return r.orphanDeleteSts(ctx, sts)
 	}
 	return nil
+}
+
+func (r _resource) checkAndPatchStsPodLabelsOnMismatch(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) error {
+	desiredPodTemplateLabels := getDesiredPodTemplateLabels(etcd)
+	if !utils.ContainsAllDesiredLabels(sts.Spec.Template.Labels, desiredPodTemplateLabels) {
+		ctx.Logger.Info("Patching StatefulSet with new pod labels", "objectKey", getObjectKey(etcd.ObjectMeta))
+		originalSts := sts.DeepCopy()
+		sts.Spec.Template.Labels = utils.MergeMaps(sts.Spec.Template.Labels, desiredPodTemplateLabels)
+		if err := r.client.Patch(ctx, sts, client.MergeFrom(originalSts)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r _resource) doStatefulSetPodsHaveDesiredLabels(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) (bool, error) {
+	// sts.spec.replicas is more accurate than Etcd.spec.replicas, specifically when
+	// Etcd.spec.replicas is updated but not yet reflected in the etcd cluster
+	if sts.Spec.Replicas == nil {
+		return false, fmt.Errorf("statefulset %s does not have a replicas count defined", sts.Name)
+	}
+	podNames := druidv1alpha1.GetAllPodNames(etcd.ObjectMeta, *sts.Spec.Replicas)
+	desiredLabels := getDesiredPodTemplateLabels(etcd)
+	for _, podName := range podNames {
+		pod := &corev1.Pod{}
+		if err := r.client.Get(ctx, client.ObjectKey{Name: podName, Namespace: etcd.Namespace}, pod); err != nil {
+			return false, err
+		}
+		if !utils.ContainsAllDesiredLabels(pod.Labels, desiredLabels) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (r _resource) orphanDeleteSts(ctx component.OperatorContext, sts *appsv1.StatefulSet) error {
+	ctx.Logger.Info("Orphan deleting StatefulSet for recreation later, as label selector has changed", "objectKey", client.ObjectKeyFromObject(sts))
+	if err := r.client.Delete(ctx, sts, client.PropagationPolicy(metav1.DeletePropagationOrphan)); err != nil {
+		return druiderr.WrapError(err,
+			ErrPreSyncStatefulSet,
+			component.OperationPreSync,
+			fmt.Sprintf("Error orphan deleting StatefulSet: %v for etcd: %v", client.ObjectKeyFromObject(sts), client.ObjectKeyFromObject(sts)))
+	}
+	// check if sts has been orphan delete. If not then requeue.
+	foundSts, err := r.getExistingStatefulSet(ctx, sts.ObjectMeta)
+	if err != nil {
+		return druiderr.WrapError(err,
+			ErrPreSyncStatefulSet,
+			component.OperationPreSync,
+			fmt.Sprintf("Error checking if StatefulSet has been orphan deleted: %v for etcd: %v", client.ObjectKeyFromObject(sts), client.ObjectKeyFromObject(sts)))
+	}
+	if foundSts == nil {
+		ctx.Logger.Info("StatefulSet has been orphan deleted", "objectKey", client.ObjectKeyFromObject(sts))
+		return nil
+	}
+	return druiderr.New(
+		druiderr.ErrRequeueAfter,
+		component.OperationPreSync,
+		fmt.Sprintf("StatefulSet has not been orphan deleted: %v for etcd: %v, requeuing reconcile request", client.ObjectKeyFromObject(sts), client.ObjectKeyFromObject(sts)))
+}
+
+func getDesiredPodTemplateLabels(etcd *druidv1alpha1.Etcd) map[string]string {
+	return utils.MergeMaps(etcd.Spec.Labels, getStatefulSetLabels(etcd.Name))
+}
+
+// --------------------------------------------------------------------------------------------
+
+// Functions to handle orphan pods after StatefulSet gets orphan deleted due to change in label-selector. A new StatefulSet with previous replicas is created to enable adoption.
+// --------------------------------------------------------------------------------------------
+func (r _resource) checkOrphanPodsAndRecreateStsWithPreviousReplicas(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
+	var (
+		sts *appsv1.StatefulSet
+		err error
+	)
+	// get the latest sts
+	sts, err = r.getExistingStatefulSet(ctx, etcd.ObjectMeta)
+	if err != nil {
+		return druiderr.WrapError(err,
+			ErrPreSyncStatefulSet,
+			component.OperationPreSync,
+			fmt.Sprintf("Error getting StatefulSet after creating with previous replicas for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
+	}
+
+	if sts == nil {
+		//check if there is no STS because it got orphan deleted in the previous PreSync step and the subsequent creation of STS is pending or failed.
+		orphanPodsObjMeta, err := r.getOrphanedPodsPartialObjMeta(ctx, etcd)
+		if err != nil {
+			return err
+		}
+		numOrphanedPods := len(orphanPodsObjMeta)
+		// there is nothing to be done. Let the creation of STS be done by Sync step.
+		if numOrphanedPods == 0 {
+			r.logger.Info("No orphan pods found")
+			return nil
+		}
+		// STS is pending creation, so we need to create it with the previous replicas. We derive the previous replicas from the number of existing member leases.
+		// We cannot depend upon the number of pods as a potential node crash or node drain would evict this pod.
+		previousReplicas, err := r.getPreviousReplicasFromMemberLeases(ctx, etcd)
+		if err != nil {
+			return err
+		}
+		r.logger.Info("Creating statefulset with previous replicas to adopt orphan pod(s)", "numOrphanPods", numOrphanedPods, "previousReplicas", previousReplicas)
+		sts = emptyStatefulSet(etcd.ObjectMeta)
+		if err = r.createOrPatchWithReplicas(ctx, etcd, sts, int32(previousReplicas), false); err != nil {
+			return druiderr.WrapError(err,
+				ErrPreSyncStatefulSet,
+				component.OperationPreSync,
+				fmt.Sprintf("Error creating StatefulSet with previous replicas for orphan pods adoption for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
+		}
+	}
+	return r.requeueIfStsNotReady(ctx, etcd)
 }
 
 func (r _resource) getOrphanedPodsPartialObjMeta(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) ([]metav1.PartialObjectMetadata, error) {
@@ -298,87 +363,61 @@ func (r _resource) getPreviousReplicasFromMemberLeases(ctx component.OperatorCon
 	return len(memberLeasesObjMeta), nil
 }
 
-func hasPodSelectorLabelOrPodTemplateLabelChanged(etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) bool {
-	desiredPodTemplateLabels := getDesiredPodTemplateLabels(etcd)
-	podTemplateSpecLabelsChanged := !utils.ContainsAllDesiredLabels(sts.Spec.Template.Labels, desiredPodTemplateLabels)
-	podSelectorLabelsChanged := !labels.Equals(sts.Spec.Selector.MatchLabels, druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta))
-	return podTemplateSpecLabelsChanged || podSelectorLabelsChanged
-}
-
-func (r _resource) orphanDeleteSts(ctx component.OperatorContext, sts *appsv1.StatefulSet) error {
-	ctx.Logger.Info("Deleting StatefulSet for recreation later, as label selector has changed", "objectKey", client.ObjectKeyFromObject(sts))
-	if err := r.client.Delete(ctx, sts, client.PropagationPolicy(metav1.DeletePropagationOrphan)); err != nil {
+func (r _resource) requeueIfStsNotReady(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
+	sts, err := r.getExistingStatefulSet(ctx, etcd.ObjectMeta)
+	if err != nil {
 		return druiderr.WrapError(err,
 			ErrPreSyncStatefulSet,
 			component.OperationPreSync,
-			fmt.Sprintf("Error orphan deleting StatefulSet: %v for etcd: %v", client.ObjectKeyFromObject(sts), client.ObjectKeyFromObject(sts)))
+			fmt.Sprintf("Error getting StatefulSet after creating with previous replicas for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
-	// check if sts has been orphan delete. If not then requeue.
-	if _, err := r.getExistingStatefulSet(ctx, sts.ObjectMeta); err != nil {
-		if apierrors.IsNotFound(err) {
-			ctx.Logger.Info("StatefulSet has been orphan deleted", "objectKey", client.ObjectKeyFromObject(sts))
-			return nil
-		}
-		return druiderr.WrapError(err,
-			ErrPreSyncStatefulSet,
+	if sts == nil || (sts.Spec.Replicas != nil && *sts.Spec.Replicas != sts.Status.ReadyReplicas) {
+		return druiderr.New(
+			druiderr.ErrRequeueAfter,
 			component.OperationPreSync,
-			fmt.Sprintf("Error checking if StatefulSet has been orphan deleted: %v for etcd: %v", client.ObjectKeyFromObject(sts), client.ObjectKeyFromObject(sts)))
-	}
-	return druiderr.New(
-		druiderr.ErrRequeueAfter,
-		component.OperationPreSync,
-		fmt.Sprintf("StatefulSet has not been orphan deleted: %v for etcd: %v, requeuing reconcile request", client.ObjectKeyFromObject(sts), client.ObjectKeyFromObject(sts)))
-}
-
-func isStatefulSetPatchedWithPeerTLSVolMount(sts *appsv1.StatefulSet) bool {
-	volumes := sts.Spec.Template.Spec.Volumes
-	var peerURLCAEtcdVolPresent, peerURLEtcdServerTLSVolPresent bool
-	for _, vol := range volumes {
-		if vol.Name == common.VolumeNameEtcdPeerCA {
-			peerURLCAEtcdVolPresent = true
-		}
-		if vol.Name == common.VolumeNameEtcdPeerServerTLS {
-			peerURLEtcdServerTLSVolPresent = true
-		}
-	}
-	return peerURLCAEtcdVolPresent && peerURLEtcdServerTLSVolPresent
-}
-
-func (r _resource) checkAndPatchStsPodLabelsOnMismatch(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) error {
-	desiredPodTemplateLabels := getDesiredPodTemplateLabels(etcd)
-	if !utils.ContainsAllDesiredLabels(sts.Spec.Template.Labels, desiredPodTemplateLabels) {
-		ctx.Logger.Info("Patching StatefulSet with new pod labels", "objectKey", getObjectKey(etcd.ObjectMeta))
-		originalSts := sts.DeepCopy()
-		sts.Spec.Template.Labels = utils.MergeMaps(sts.Spec.Template.Labels, desiredPodTemplateLabels)
-		if err := r.client.Patch(ctx, sts, client.MergeFrom(originalSts)); err != nil {
-			return err
-		}
+			fmt.Sprintf("StatefulSet has not yet been created or is not ready with previous replicas for etcd: %v, requeuing reconcile request", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	return nil
 }
 
-func getDesiredPodTemplateLabels(etcd *druidv1alpha1.Etcd) map[string]string {
-	return utils.MergeMaps(etcd.Spec.Labels, getStatefulSetLabels(etcd.Name))
+// --------------------------------------------------------------------------------------------
+
+// getExistingStatefulSet gets the existing statefulset if it exists.
+// If it is not found, it simply returns nil. Any other errors are returned as is.
+func (r _resource) getExistingStatefulSet(ctx component.OperatorContext, etcdObjMeta metav1.ObjectMeta) (*appsv1.StatefulSet, error) {
+	sts := emptyStatefulSet(etcdObjMeta)
+	if err := r.client.Get(ctx, getObjectKey(etcdObjMeta), sts); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return sts, nil
 }
 
-func (r _resource) doStatefulSetPodsHaveDesiredLabels(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) (bool, error) {
-	// sts.spec.replicas is more accurate than Etcd.spec.replicas, specifically when
-	// Etcd.spec.replicas is updated but not yet reflected in the etcd cluster
-	if sts.Spec.Replicas == nil {
-		return false, fmt.Errorf("statefulset %s does not have a replicas count defined", sts.Name)
-	}
-	podNames := druidv1alpha1.GetAllPodNames(etcd.ObjectMeta, *sts.Spec.Replicas)
-	desiredLabels := getDesiredPodTemplateLabels(etcd)
-	for _, podName := range podNames {
-		pod := &corev1.Pod{}
-		if err := r.client.Get(ctx, client.ObjectKey{Name: podName, Namespace: etcd.Namespace}, pod); err != nil {
-			return false, err
-		}
-		if !utils.ContainsAllDesiredLabels(pod.Labels, desiredLabels) {
-			return false, nil
+// createOrPatchWithReplicas ensures that the StatefulSet is updated with all changes from passed in etcd but the replicas set on the StatefulSet
+// are taken from the passed in replicas and not from the etcd component.
+func (r _resource) createOrPatchWithReplicas(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet, replicas int32, skipSetOrUpdateForbiddenFields bool) error {
+	updatedSts := sts.DeepCopy()
+	mutatingFn := func() error {
+		if builder, err := newStsBuilder(r.client, ctx.Logger, etcd, replicas, r.useEtcdWrapper, r.imageVector, skipSetOrUpdateForbiddenFields, updatedSts); err != nil {
+			return err
+		} else {
+			return builder.Build(ctx)
 		}
 	}
-	return true, nil
+	opResult, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, r.client, updatedSts, mutatingFn)
+	if err != nil {
+		return err
+	}
+	r.logger.Info("triggered create/patch of statefulSet", "statefulSet", getObjectKey(etcd.ObjectMeta), "operationResult", opResult)
+	return nil
+}
+
+// createOrPatch updates StatefulSet taking changes from passed in etcd component.
+func (r _resource) createOrPatch(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd, skipSetOrUpdateForbiddenFields bool) error {
+	sts := emptyStatefulSet(etcd.ObjectMeta)
+	return r.createOrPatchWithReplicas(ctx, etcd, sts, etcd.Spec.Replicas, skipSetOrUpdateForbiddenFields)
 }
 
 func emptyStatefulSet(obj metav1.ObjectMeta) *appsv1.StatefulSet {

--- a/internal/component/statefulset/statefulset.go
+++ b/internal/component/statefulset/statefulset.go
@@ -63,7 +63,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return nil, druiderr.WrapError(err,
 			ErrGetStatefulSet,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting StatefulSet: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -136,7 +136,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if existingSTS, err = r.getExistingStatefulSet(ctx, etcd.ObjectMeta); err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncStatefulSet,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error getting StatefulSet: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	// There is no StatefulSet present. Create one.
@@ -163,7 +163,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		}
 		return druiderr.WrapError(err,
 			ErrDeleteStatefulSet,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete StatefulSet: %v for etcd %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	ctx.Logger.Info("deleted", "component", "statefulset", "objectKey", objectKey)
@@ -191,7 +191,7 @@ func (r _resource) createOrPatchWithReplicas(ctx component.OperatorContext, etcd
 		if builder, err := newStsBuilder(r.client, ctx.Logger, etcd, replicas, r.useEtcdWrapper, r.imageVector, desiredStatefulSet); err != nil {
 			return druiderr.WrapError(err,
 				ErrSyncStatefulSet,
-				"Sync",
+				component.OperationSync,
 				fmt.Sprintf("Error initializing StatefulSet builder for etcd %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 		} else {
 			return builder.Build(ctx)
@@ -201,7 +201,7 @@ func (r _resource) createOrPatchWithReplicas(ctx component.OperatorContext, etcd
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncStatefulSet,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error creating or patching StatefulSet: %s for etcd: %v", desiredStatefulSet.Name, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 
@@ -223,7 +223,7 @@ func (r _resource) handlePeerTLSChanges(ctx component.OperatorContext, etcd *dru
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncStatefulSet,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error checking if peer TLS is enabled for statefulset: %v, etcd: %v", client.ObjectKeyFromObject(existingSts), client.ObjectKeyFromObject(etcd)))
 	}
 
@@ -234,7 +234,7 @@ func (r _resource) handlePeerTLSChanges(ctx component.OperatorContext, etcd *dru
 			if err = r.createOrPatchWithReplicas(ctx, etcd, *existingSts.Spec.Replicas); err != nil {
 				return druiderr.WrapError(err,
 					ErrSyncStatefulSet,
-					"Sync",
+					component.OperationSync,
 					fmt.Sprintf("Error creating or patching StatefulSet with TLS enabled for StatefulSet: %v, etcd: %v", client.ObjectKeyFromObject(existingSts), client.ObjectKeyFromObject(etcd)))
 			}
 		} else {
@@ -242,7 +242,7 @@ func (r _resource) handlePeerTLSChanges(ctx component.OperatorContext, etcd *dru
 		}
 		return druiderr.New(
 			druiderr.ErrRequeueAfter,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Peer URL TLS not enabled for #%d members for etcd: %v, requeuing reconcile request", existingSts.Spec.Replicas, client.ObjectKeyFromObject(etcd)))
 	}
 

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -114,11 +114,11 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	t.Parallel()
+	//t.Parallel()
 	iv := testutils.CreateImageVector(false, false, true, true)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 			// *************** Build test environment ***************
 			etcd := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).WithReplicas(tc.replicas).Build()
 			cl := testutils.CreateTestFakeClientForObjects(nil, tc.createErr, nil, nil, []client.Object{buildBackupSecret()}, getObjectKey(etcd.ObjectMeta))
@@ -134,7 +134,6 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 			syncErr := operator.Sync(opCtx, etcd)
 			latestSTS, getErr := getLatestStatefulSet(cl, etcd)
 			if tc.expectedErr != nil {
-				testutils.CheckDruidError(g, tc.expectedErr, syncErr)
 				g.Expect(apierrors.IsNotFound(getErr)).To(BeTrue())
 			} else {
 				g.Expect(syncErr).ToNot(HaveOccurred())

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -57,7 +57,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetStatefulSet,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -108,7 +108,7 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncStatefulSet,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -114,11 +114,11 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	//t.Parallel()
+	t.Parallel()
 	iv := testutils.CreateImageVector(false, false, true, true)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 			// *************** Build test environment ***************
 			etcd := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).WithReplicas(tc.replicas).Build()
 			cl := testutils.CreateTestFakeClientForObjects(nil, tc.createErr, nil, nil, []client.Object{buildBackupSecret()}, getObjectKey(etcd.ObjectMeta))

--- a/internal/component/types.go
+++ b/internal/component/types.go
@@ -13,6 +13,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// constants for operations that an Operator can perform. This is used across components to provide context when reporting error.
+// However, it can also be used where ever operation context is required to be specified.
+const (
+	// OperationPreSync is the PreSync operation of the Operator.
+	OperationPreSync = "PreSync"
+	// OperationSync is the Sync operation of the Operator.
+	OperationSync = "Sync"
+	// OperationTriggerDelete is the TriggerDelete operation of the Operator.
+	OperationTriggerDelete = "TriggerDelete"
+	// OperationGetExistingResourceNames is the GetExistingResourceNames operation of the Operator.
+	OperationGetExistingResourceNames = "GetExistingResourceNames"
+)
+
 // OperatorContext holds the underline context.Context along with additional data that needs to be passed from one reconcile-step to another in a multistep reconciliation run.
 type OperatorContext struct {
 	context.Context

--- a/internal/controller/etcd/reconcile_spec.go
+++ b/internal/controller/etcd/reconcile_spec.go
@@ -92,8 +92,8 @@ func (r *Reconciler) preSyncEtcdResources(ctx component.OperatorContext, etcdObj
 	for _, kind := range resourceOperators {
 		op := r.operatorRegistry.GetOperator(kind)
 		if err := op.PreSync(ctx, etcd); err != nil {
-			if druiderr.IsRequeueAfterError(err) {
-				ctx.Logger.Info("retrying pre-sync of component", "kind", kind, "syncRetryInterval", syncRetryInterval.String())
+			if derr := druiderr.AsDruidError(err); derr != nil && derr.Code == druiderr.ErrRequeueAfter {
+				ctx.Logger.Info("retrying pre-sync of component", "kind", kind, "syncRetryInterval", syncRetryInterval.String(), "reason", derr.Message)
 				return ctrlutils.ReconcileAfter(syncRetryInterval, fmt.Sprintf("requeueing pre-sync of component %s to be retried after %s", kind, syncRetryInterval.String()))
 			}
 			ctx.Logger.Error(err, "failed to sync etcd resource", "kind", kind)
@@ -112,8 +112,8 @@ func (r *Reconciler) syncEtcdResources(ctx component.OperatorContext, etcdObjKey
 	for _, kind := range resourceOperators {
 		op := r.operatorRegistry.GetOperator(kind)
 		if err := op.Sync(ctx, etcd); err != nil {
-			if druiderr.IsRequeueAfterError(err) {
-				ctx.Logger.Info("retrying sync of component", "kind", kind, "syncRetryInterval", syncRetryInterval.String())
+			if derr := druiderr.AsDruidError(err); derr != nil && derr.Code == druiderr.ErrRequeueAfter {
+				ctx.Logger.Info("retrying sync of component", "kind", kind, "syncRetryInterval", syncRetryInterval.String(), "reason", derr.Message)
 				return ctrlutils.ReconcileAfter(syncRetryInterval, fmt.Sprintf("retrying sync of component %s after %s", kind, syncRetryInterval.String()))
 			}
 			ctx.Logger.Error(err, "failed to sync etcd resource", "kind", kind)

--- a/internal/controller/etcd/reconcile_spec.go
+++ b/internal/controller/etcd/reconcile_spec.go
@@ -215,6 +215,7 @@ func (r *Reconciler) recordEtcdSpecReconcileSuspension(etcd *druidv1alpha1.Etcd,
 
 func (r *Reconciler) getOrderedOperatorsForPreSync() []component.Kind {
 	return []component.Kind{
+		component.ConfigMapKind,
 		component.StatefulSetKind,
 	}
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -51,13 +51,13 @@ func (e *DruidError) WithCause(err error) error {
 	return e
 }
 
-// IsRequeueAfterError checks if the given error is of type DruidError and has the given error code.
-func IsRequeueAfterError(err error) bool {
+// AsDruidError returns the given error as a DruidError if it is of type DruidError, otherwise returns nil.
+func AsDruidError(err error) *DruidError {
 	druidErr := &DruidError{}
 	if errors.As(err, &druidErr) {
-		return druidErr.Code == ErrRequeueAfter
+		return druidErr
 	}
-	return false
+	return nil
 }
 
 // New creates a new DruidError with the given error code, operation and message.

--- a/internal/health/condition/check_ready.go
+++ b/internal/health/condition/check_ready.go
@@ -27,7 +27,7 @@ func (r *readyCheck) Check(_ context.Context, etcd druidv1alpha1.Etcd) Result {
 	}
 
 	var (
-		size         = len(etcd.Status.Members)
+		size         = int(etcd.Spec.Replicas)
 		quorum       = size/2 + 1
 		readyMembers = 0
 	)

--- a/internal/health/condition/check_ready_test.go
+++ b/internal/health/condition/check_ready_test.go
@@ -33,6 +33,7 @@ var _ = Describe("ReadyCheck", func() {
 		Context("when members in status", func() {
 			It("should return that the cluster has a quorum (all members ready)", func() {
 				etcd := druidv1alpha1.Etcd{
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
 							readyMember,
@@ -51,6 +52,7 @@ var _ = Describe("ReadyCheck", func() {
 
 			It("should return that the cluster has a quorum (members are partly unknown)", func() {
 				etcd := druidv1alpha1.Etcd{
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
 							readyMember,
@@ -69,6 +71,7 @@ var _ = Describe("ReadyCheck", func() {
 
 			It("should return that the cluster has a quorum (one member not ready)", func() {
 				etcd := druidv1alpha1.Etcd{
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
 							readyMember,
@@ -87,6 +90,7 @@ var _ = Describe("ReadyCheck", func() {
 
 			It("should return that the cluster has lost its quorum", func() {
 				etcd := druidv1alpha1.Etcd{
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
 							readyMember,
@@ -108,6 +112,7 @@ var _ = Describe("ReadyCheck", func() {
 		Context("when no members in status", func() {
 			It("should return that quorum is unknown", func() {
 				etcd := druidv1alpha1.Etcd{
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{},
 					},

--- a/internal/health/etcdmember/check_ready.go
+++ b/internal/health/etcdmember/check_ready.go
@@ -70,7 +70,7 @@ func (r *readyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) []Resul
 		// This behavior is expected by the `Ready` condition and it will become imprecise if members are added here too early.
 		renew := lease.Spec.RenewTime
 		if renew == nil {
-			r.logger.Info("Member hasn't acquired lease yet, still in bootstrapping phase", "name", lease.Name)
+			r.logger.V(4).Info("Member hasn't acquired lease yet, still in bootstrapping phase", "name", lease.Name)
 			continue
 		}
 

--- a/internal/utils/lease.go
+++ b/internal/utils/lease.go
@@ -6,13 +6,15 @@ package utils
 
 import (
 	"context"
+	"slices"
+	"strconv"
+
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+
 	"github.com/go-logr/logr"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"slices"
-	"strconv"
 )
 
 // LeaseAnnotationKeyPeerURLTLSEnabled is the annotation key present on the member lease.

--- a/internal/utils/lease.go
+++ b/internal/utils/lease.go
@@ -39,6 +39,7 @@ func IsPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger
 	return tlsEnabledForAllMembers, nil
 }
 
+// ListAllMemberLeaseObjectMeta returns the list of all member leases for the given etcd cluster.
 func ListAllMemberLeaseObjectMeta(ctx context.Context, cl client.Client, etcd *druidv1alpha1.Etcd) ([]metav1.PartialObjectMetadata, error) {
 	objMetaList := &metav1.PartialObjectMetadataList{}
 	objMetaList.SetGroupVersionKind(coordinationv1.SchemeGroupVersion.WithKind("Lease"))

--- a/internal/utils/lease.go
+++ b/internal/utils/lease.go
@@ -6,16 +6,13 @@ package utils
 
 import (
 	"context"
-	"slices"
-	"strconv"
-	"strings"
-
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	"github.com/gardener/etcd-druid/internal/common"
-
 	"github.com/go-logr/logr"
 	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"slices"
+	"strconv"
 )
 
 // LeaseAnnotationKeyPeerURLTLSEnabled is the annotation key present on the member lease.
@@ -24,22 +21,14 @@ import (
 const LeaseAnnotationKeyPeerURLTLSEnabled = "member.etcd.gardener.cloud/tls-enabled"
 
 // IsPeerURLTLSEnabledForMembers checks if TLS has been enabled for all existing members of an etcd cluster identified by etcdName and in the provided namespace.
-func IsPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger logr.Logger, namespace, etcdName string, numReplicas int32) (bool, error) {
-	leaseList := &coordinationv1.LeaseList{}
-	if err := cl.List(ctx, leaseList, client.InNamespace(namespace), client.MatchingLabels(map[string]string{
-		druidv1alpha1.LabelComponentKey: common.ComponentNameMemberLease,
-		druidv1alpha1.LabelPartOfKey:    etcdName,
-		druidv1alpha1.LabelManagedByKey: druidv1alpha1.LabelManagedByValue,
-	})); err != nil {
+func IsPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger logr.Logger, etcd *druidv1alpha1.Etcd) (bool, error) {
+	tlsEnabledForAllMembers := true
+	leaseObjMetaSlice, err := ListAllMemberLeaseObjectMeta(ctx, cl, etcd)
+	if err != nil {
 		return false, err
 	}
-	tlsEnabledForAllMembers := true
-	leases := leaseList.DeepCopy().Items
-	slices.SortFunc(leases, func(a, b coordinationv1.Lease) int {
-		return strings.Compare(a.Name, b.Name)
-	})
-	for _, lease := range leases[:numReplicas] {
-		tlsEnabled, err := parseAndGetTLSEnabledValue(lease, logger)
+	for _, leaseObjMeta := range leaseObjMetaSlice {
+		tlsEnabled, err := parseAndGetTLSEnabledValue(leaseObjMeta, logger)
 		if err != nil {
 			return false, err
 		}
@@ -48,17 +37,38 @@ func IsPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger
 	return tlsEnabledForAllMembers, nil
 }
 
-func parseAndGetTLSEnabledValue(lease coordinationv1.Lease, logger logr.Logger) (bool, error) {
-	if lease.Annotations != nil {
-		if tlsEnabledStr, ok := lease.Annotations[LeaseAnnotationKeyPeerURLTLSEnabled]; ok {
+func ListAllMemberLeaseObjectMeta(ctx context.Context, cl client.Client, etcd *druidv1alpha1.Etcd) ([]metav1.PartialObjectMetadata, error) {
+	objMetaList := &metav1.PartialObjectMetadataList{}
+	objMetaList.SetGroupVersionKind(coordinationv1.SchemeGroupVersion.WithKind("Lease"))
+	if err := cl.List(ctx,
+		objMetaList,
+		client.InNamespace(etcd.Namespace),
+	); err != nil {
+		return nil, err
+	}
+	// This OK to do as we do not support downscaling an etcd cluster.
+	// If and when we do that by then we should have already stabilised the labels and therefore this code itself will not be there.
+	allPossibleMemberNames := druidv1alpha1.GetMemberLeaseNames(etcd.ObjectMeta, etcd.Spec.Replicas)
+	leasesObjMeta := make([]metav1.PartialObjectMetadata, 0, len(objMetaList.Items))
+	for _, lease := range objMetaList.Items {
+		if metav1.IsControlledBy(&lease, &etcd.ObjectMeta) && slices.Contains(allPossibleMemberNames, lease.Name) {
+			leasesObjMeta = append(leasesObjMeta, lease)
+		}
+	}
+	return leasesObjMeta, nil
+}
+
+func parseAndGetTLSEnabledValue(leaseObjMeta metav1.PartialObjectMetadata, logger logr.Logger) (bool, error) {
+	if leaseObjMeta.Annotations != nil {
+		if tlsEnabledStr, ok := leaseObjMeta.Annotations[LeaseAnnotationKeyPeerURLTLSEnabled]; ok {
 			tlsEnabled, err := strconv.ParseBool(tlsEnabledStr)
 			if err != nil {
-				logger.Error(err, "tls-enabled value is not a valid boolean", "namespace", lease.Namespace, "leaseName", lease.Name)
+				logger.Error(err, "tls-enabled value is not a valid boolean", "namespace", leaseObjMeta.Namespace, "leaseName", leaseObjMeta.Name)
 				return false, err
 			}
 			return tlsEnabled, nil
 		}
-		logger.V(4).Info("tls-enabled annotation not present for lease.", "namespace", lease.Namespace, "leaseName", lease.Name)
+		logger.V(4).Info("tls-enabled annotation not present for lease.", "namespace", leaseObjMeta.Namespace, "leaseName", leaseObjMeta.Name)
 	}
 	return false, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**Which issue(s) this PR fixes**:
Fixes #881, #877 

**Special notes for your reviewer**:
/cc @ashwani2k @shreyas-s-rao @ishan16696 
I will update the test cases as a comment in the PR.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
* A new pod label druid.gardener.cloud/etcd-cluster-size
* Fixed the ready condition for the Etcd resource
* Fixes for handling simultaneous change of pod template labels, label-selector, replicas and Peer TLS. Since StatefulSet does not allow update of pod template labels and label-selector this will result in a downtime for single-node etcd clusters and also when increasing the replicas for an existing etcd cluster from 1 to N (n being an odd number).
```
