### PR TITLE
Add additional latest tag to images during release

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -14,6 +14,7 @@ etcd-druid:
         dockerimages:
           etcd-druid:
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcd-druid
+            tag_as_latest: True
             dockerfile: 'Dockerfile'
             inputs:
               repos:
@@ -64,6 +65,7 @@ etcd-druid:
           dockerimages:
             etcd-druid:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
+              tag_as_latest: True
         release:
           nextversion: 'bump_minor'
           git_tags:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -14,7 +14,6 @@ etcd-druid:
         dockerimages:
           etcd-druid:
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcd-druid
-            tag_as_latest: True
             dockerfile: 'Dockerfile'
             inputs:
               repos:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:

Add `latest` tag to every image built as part of the release job in the CI pipeline.

This is to consume the helm charts as it is, currently it expects a `latest` tag for the `etcd-druid` image which it cannot find from the `europe-docker` registry as we currently only have `version` specific tags. Adding the `latest` tag would make it better for open-source consumers to quickly test the functionality, as we have seen cases of people reporting the missing tag.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
add additional `latest` tag to released images.
```
