### PR TITLE
[hotfix-v0.23] Fixes Label-Selector, Pod Template label updates and TLS changes for client and peer communication (#883)

### DIFF
--- a/api/v1alpha1/etcd.go
+++ b/api/v1alpha1/etcd.go
@@ -443,6 +443,8 @@ const (
 	LastOperationStateSucceeded LastOperationState = "Succeeded"
 	// LastOperationStateError indicates that an operation is completed with errors and will be retried.
 	LastOperationStateError LastOperationState = "Error"
+	// LastOperationStateRequeue indicates that an operation is not completed and either due to an error or unfulfilled conditions will be retried.
+	LastOperationStateRequeue LastOperationState = "Requeue"
 )
 
 // LastOperation holds the information on the last operation done on the Etcd resource.
@@ -486,7 +488,8 @@ func (e *Etcd) IsReconciliationInProgress() bool {
 	return e.Status.LastOperation != nil &&
 		e.Status.LastOperation.Type == LastOperationTypeReconcile &&
 		(e.Status.LastOperation.State == LastOperationStateProcessing ||
-			e.Status.LastOperation.State == LastOperationStateError)
+			e.Status.LastOperation.State == LastOperationStateError ||
+			e.Status.LastOperation.State == LastOperationStateRequeue)
 }
 
 // IsDeletionInProgress returns true if the Etcd resource is currently being reconciled, else returns false.
@@ -494,5 +497,6 @@ func (e *Etcd) IsDeletionInProgress() bool {
 	return e.Status.LastOperation != nil &&
 		e.Status.LastOperation.Type == LastOperationTypeDelete &&
 		(e.Status.LastOperation.State == LastOperationStateProcessing ||
-			e.Status.LastOperation.State == LastOperationStateError)
+			e.Status.LastOperation.State == LastOperationStateError ||
+			e.Status.LastOperation.State == LastOperationStateRequeue)
 }

--- a/internal/component/clientservice/clientservice.go
+++ b/internal/component/clientservice/clientservice.go
@@ -54,7 +54,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetClientService,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting client service: %v for etcd: %v", svcObjectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -77,7 +77,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncClientService,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of client service: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -97,7 +97,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		return druiderr.WrapError(
 			err,
 			ErrDeleteClientService,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			"Failed to delete client service",
 		)
 	}

--- a/internal/component/clientservice/clientservice_test.go
+++ b/internal/component/clientservice/clientservice_test.go
@@ -56,7 +56,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetClientService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -106,7 +106,7 @@ func TestSyncWhenNoServiceExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncClientService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -159,7 +159,7 @@ func TestSyncWhenServiceExists(t *testing.T) {
 			expectedError: &druiderr.DruidError{
 				Code:      ErrSyncClientService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -211,7 +211,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteClientService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 			deleteErr: testutils.TestAPIInternalErr,
 		},

--- a/internal/component/configmap/configmap.go
+++ b/internal/component/configmap/configmap.go
@@ -55,7 +55,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return nil, druiderr.WrapError(err,
 			ErrGetConfigMap,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting ConfigMap: %v for etcd: %v", objKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -65,7 +65,9 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 }
 
 // PreSync is a no-op for the configmap component.
-func (r _resource) PreSync(_ component.OperatorContext, _ *druidv1alpha1.Etcd) error { return nil }
+func (r _resource) PreSync(_ component.OperatorContext, _ *druidv1alpha1.Etcd) error {
+	return nil
+}
 
 // Sync creates or updates the configmap for the given Etcd.
 func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
@@ -76,14 +78,14 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncConfigMap,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of configmap for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	checkSum, err := computeCheckSum(cm)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncConfigMap,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error when computing CheckSum for configmap for etcd: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	ctx.Data[common.CheckSumKeyConfigMap] = checkSum
@@ -103,7 +105,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		return druiderr.WrapError(
 			err,
 			ErrDeleteConfigMap,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			"Failed to delete configmap",
 		)
 	}

--- a/internal/component/configmap/configmap_test.go
+++ b/internal/component/configmap/configmap_test.go
@@ -56,7 +56,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetConfigMap,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -115,7 +115,7 @@ func TestSyncWhenNoConfigMapExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncConfigMap,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -211,7 +211,7 @@ func TestSyncWhenConfigMapExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncConfigMap,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -264,7 +264,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteConfigMap,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/memberlease/memberlease.go
+++ b/internal/component/memberlease/memberlease.go
@@ -53,7 +53,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 	); err != nil {
 		return resourceNames, druiderr.WrapError(err,
 			ErrListMemberLease,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error listing member leases for etcd: %v", druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	for _, lease := range objMetaList.Items {
@@ -98,7 +98,7 @@ func (r _resource) doCreateOrUpdate(ctx component.OperatorContext, etcd *druidv1
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncMemberLease,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error syncing member lease: %v for etcd: %v", objKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	ctx.Logger.Info("triggered create or update of member lease", "objectKey", objKey, "operationResult", opResult)
@@ -114,7 +114,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		client.MatchingLabels(getSelectorLabelsForAllMemberLeases(etcdObjMeta))); err != nil {
 		return druiderr.WrapError(err,
 			ErrDeleteMemberLease,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete member leases for etcd: %v", druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	ctx.Logger.Info("deleted", "component", "member-leases")

--- a/internal/component/memberlease/memberlease_test.go
+++ b/internal/component/memberlease/memberlease_test.go
@@ -69,7 +69,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrListMemberLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -135,7 +135,7 @@ func TestSync(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncMemberLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 		{
@@ -146,7 +146,7 @@ func TestSync(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncMemberLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -229,7 +229,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteMemberLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/peerservice/peerservice.go
+++ b/internal/component/peerservice/peerservice.go
@@ -54,7 +54,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetPeerService,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting peer service: %s for etcd: %v", svcObjectKey.Name, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -77,7 +77,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncPeerService,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of peer service: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -97,7 +97,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		return druiderr.WrapError(
 			err,
 			ErrDeletePeerService,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete peer service: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)),
 		)
 	}

--- a/internal/component/peerservice/peerservice_test.go
+++ b/internal/component/peerservice/peerservice_test.go
@@ -55,7 +55,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetPeerService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -105,7 +105,7 @@ func TestSyncWhenNoServiceExists(t *testing.T) {
 			expectedError: &druiderr.DruidError{
 				Code:      ErrSyncPeerService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -155,7 +155,7 @@ func TestSyncWhenServiceExists(t *testing.T) {
 			expectedError: &druiderr.DruidError{
 				Code:      ErrSyncPeerService,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -209,7 +209,7 @@ func TestPeerServiceTriggerDelete(t *testing.T) {
 			expectError: &druiderr.DruidError{
 				Code:      ErrDeletePeerService,
 				Cause:     deleteInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/poddistruptionbudget/poddisruptionbudget.go
+++ b/internal/component/poddistruptionbudget/poddisruptionbudget.go
@@ -60,7 +60,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetPodDisruptionBudget,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting PDB: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -83,7 +83,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncPodDisruptionBudget,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of PDB: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -98,7 +98,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 	if err := client.IgnoreNotFound(r.client.Delete(ctx, emptyPodDisruptionBudget(pdbObjectKey))); err != nil {
 		return druiderr.WrapError(err,
 			ErrDeletePodDisruptionBudget,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete PDB: %v for etcd: %v", pdbObjectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	ctx.Logger.Info("deleted", "component", "pod-disruption-budget", "objectKey", pdbObjectKey)

--- a/internal/component/poddistruptionbudget/poddisruptionbudget_test.go
+++ b/internal/component/poddistruptionbudget/poddisruptionbudget_test.go
@@ -53,7 +53,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetPodDisruptionBudget,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -107,7 +107,7 @@ func TestSyncWhenNoPDBExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncPodDisruptionBudget,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -161,7 +161,7 @@ func TestSyncWhenPDBExists(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncPodDisruptionBudget,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -214,7 +214,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeletePodDisruptionBudget,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/role/role.go
+++ b/internal/component/role/role.go
@@ -53,7 +53,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetRole,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting role: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -76,7 +76,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncRole,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of role %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -95,7 +95,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		}
 		return druiderr.WrapError(err,
 			ErrDeleteRole,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete role: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)),
 		)
 	}

--- a/internal/component/role/role_test.go
+++ b/internal/component/role/role_test.go
@@ -52,7 +52,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetRole,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -98,7 +98,7 @@ func TestSync(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncRole,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -147,7 +147,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteRole,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 		{

--- a/internal/component/rolebinding/rolebinding.go
+++ b/internal/component/rolebinding/rolebinding.go
@@ -53,7 +53,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetRoleBinding,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting role-binding: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -76,7 +76,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncRoleBinding,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of role-binding %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -95,7 +95,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		}
 		return druiderr.WrapError(err,
 			ErrDeleteRoleBinding,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete role-binding: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)),
 		)
 	}

--- a/internal/component/rolebinding/rolebinding_test.go
+++ b/internal/component/rolebinding/rolebinding_test.go
@@ -52,7 +52,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetRoleBinding,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -98,7 +98,7 @@ func TestSync(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncRoleBinding,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -147,7 +147,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteRoleBinding,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 		{

--- a/internal/component/serviceaccount/serviceaccount.go
+++ b/internal/component/serviceaccount/serviceaccount.go
@@ -55,7 +55,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 		}
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetServiceAccount,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting service account: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	if metav1.IsControlledBy(objMeta, &etcdObjMeta) {
@@ -78,7 +78,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncServiceAccount,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error during create or update of service account: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)),
 		)
 	}
@@ -97,7 +97,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 		}
 		return druiderr.WrapError(err,
 			ErrDeleteServiceAccount,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete service account: %v for etcd: %v", objectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}
 	ctx.Logger.Info("deleted", "component", "service-account", "objectKey", objectKey)

--- a/internal/component/serviceaccount/serviceaccount_test.go
+++ b/internal/component/serviceaccount/serviceaccount_test.go
@@ -51,7 +51,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetServiceAccount,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -106,7 +106,7 @@ func TestSync(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncServiceAccount,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -157,7 +157,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteServiceAccount,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/snapshotlease/snapshotlease.go
+++ b/internal/component/snapshotlease/snapshotlease.go
@@ -54,7 +54,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 	if err != nil {
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetSnapshotLease,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting delta snapshot lease: %v for etcd: %v", deltaSnapshotObjectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)),
 		)
 	}
@@ -66,7 +66,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 	if err != nil {
 		return resourceNames, druiderr.WrapError(err,
 			ErrGetSnapshotLease,
-			"GetExistingResourceNames",
+			component.OperationGetExistingResourceNames,
 			fmt.Sprintf("Error getting full snapshot lease: %v for etcd: %v", fullSnapshotObjectKey, druidv1alpha1.GetNamespaceName(etcdObjMeta)),
 		)
 	}
@@ -87,7 +87,7 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 		return r.deleteAllSnapshotLeases(ctx, etcd.ObjectMeta, func(err error) error {
 			return druiderr.WrapError(err,
 				ErrSyncSnapshotLease,
-				"Sync",
+				component.OperationSync,
 				fmt.Sprintf("Failed to delete existing snapshot leases (due to backup being disabled for etcd) due to reason: %v", druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 		})
 	}
@@ -112,7 +112,7 @@ func (r _resource) TriggerDelete(ctx component.OperatorContext, etcdObjMeta meta
 	if err := r.deleteAllSnapshotLeases(ctx, etcdObjMeta, func(err error) error {
 		return druiderr.WrapError(err,
 			ErrDeleteSnapshotLease,
-			"TriggerDelete",
+			component.OperationTriggerDelete,
 			fmt.Sprintf("Failed to delete snapshot leases for etcd: %v", druidv1alpha1.GetNamespaceName(etcdObjMeta)))
 	}); err != nil {
 		return err
@@ -152,7 +152,7 @@ func (r _resource) doCreateOrUpdate(ctx component.OperatorContext, etcd *druidv1
 	if err != nil {
 		return druiderr.WrapError(err,
 			ErrSyncSnapshotLease,
-			"Sync",
+			component.OperationSync,
 			fmt.Sprintf("Error syncing snapshot lease: %v for etcd: %v", leaseObjectKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	ctx.Logger.Info("triggered create or update of snapshot lease", "objectKey", leaseObjectKey, "operationResult", opResult)

--- a/internal/component/snapshotlease/snapshotlease_test.go
+++ b/internal/component/snapshotlease/snapshotlease_test.go
@@ -62,7 +62,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrGetSnapshotLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "GetExistingResourceNames",
+				Operation: component.OperationGetExistingResourceNames,
 			},
 		},
 	}
@@ -111,7 +111,7 @@ func TestSyncWhenBackupIsEnabled(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncSnapshotLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -156,7 +156,7 @@ func TestSyncWhenBackupHasBeenDisabled(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncSnapshotLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "Sync",
+				Operation: component.OperationSync,
 			},
 		},
 	}
@@ -217,7 +217,7 @@ func TestTriggerDelete(t *testing.T) {
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrDeleteSnapshotLease,
 				Cause:     testutils.TestAPIInternalErr,
-				Operation: "TriggerDelete",
+				Operation: component.OperationTriggerDelete,
 			},
 		},
 	}

--- a/internal/component/types.go
+++ b/internal/component/types.go
@@ -13,6 +13,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// constants for common operations that an Operator can perform. This is used across components to provide context when reporting error.
+// However, it can also be used where ever operation context is required to be specified.
+// Each component can in turn define their own fine-grained operation labels as well.
+const (
+	// OperationSync is the Sync operation of the Operator.
+	OperationSync = "Sync"
+	// OperationTriggerDelete is the TriggerDelete operation of the Operator.
+	OperationTriggerDelete = "TriggerDelete"
+	// OperationGetExistingResourceNames is the GetExistingResourceNames operation of the Operator.
+	OperationGetExistingResourceNames = "GetExistingResourceNames"
+)
+
 // OperatorContext holds the underline context.Context along with additional data that needs to be passed from one reconcile-step to another in a multistep reconciliation run.
 type OperatorContext struct {
 	context.Context

--- a/internal/controller/etcd/reconcile_delete.go
+++ b/internal/controller/etcd/reconcile_delete.go
@@ -108,7 +108,7 @@ func (r *Reconciler) recordIncompleteDeletionOperation(ctx component.OperatorCon
 	if result := ctrlutils.GetLatestEtcdPartialObjectMeta(ctx, r.client, etcdObjKey, etcdObjMeta); ctrlutils.ShortCircuitReconcileFlow(result) {
 		return result
 	}
-	if err := r.lastOpErrRecorder.RecordErrors(ctx, etcdObjKey, druidv1alpha1.LastOperationTypeDelete, exitReconcileStepResult.GetDescription(), exitReconcileStepResult.GetErrors()...); err != nil {
+	if err := r.lastOpErrRecorder.RecordErrors(ctx, etcdObjKey, druidv1alpha1.LastOperationTypeDelete, exitReconcileStepResult); err != nil {
 		logger.Error(err, "failed to record last operation and last errors for etcd deletion")
 		return ctrlutils.ReconcileWithError(err)
 	}

--- a/internal/controller/etcdcopybackupstask/reconciler.go
+++ b/internal/controller/etcdcopybackupstask/reconciler.go
@@ -304,7 +304,9 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 	env := append(createEnvVarsFromStore(&sourceStore, sourceProvider, "SOURCE_", sourcePrefix), createEnvVarsFromStore(&targetStore, targetProvider, "", "")...)
 
 	// Formulate the job's volume mounts.
-	volumeMounts := append(createVolumeMountsFromStore(&sourceStore, sourceProvider, sourcePrefix, r.Config.FeatureGates[features.UseEtcdWrapper]), createVolumeMountsFromStore(&targetStore, targetProvider, targetPrefix, r.Config.FeatureGates[features.UseEtcdWrapper])...)
+	volumeMounts := append(
+		createVolumeMountsFromStore(&sourceStore, sourceProvider, sourcePrefix, r.Config.FeatureGates[features.UseEtcdWrapper]),
+		createVolumeMountsFromStore(&targetStore, targetProvider, "", r.Config.FeatureGates[features.UseEtcdWrapper])...)
 
 	// Formulate the job's volumes from the source store.
 	sourceVolumes, err := r.createVolumesFromStore(ctx, &sourceStore, task.Namespace, sourceProvider, sourcePrefix)
@@ -313,7 +315,7 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 	}
 
 	// Formulate the job's volumes from the target store.
-	targetVolumes, err := r.createVolumesFromStore(ctx, &targetStore, task.Namespace, targetProvider, targetPrefix)
+	targetVolumes, err := r.createVolumesFromStore(ctx, &targetStore, task.Namespace, targetProvider, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -51,15 +51,6 @@ func (e *DruidError) WithCause(err error) error {
 	return e
 }
 
-// IsRequeueAfterError checks if the given error is of type DruidError and has the given error code.
-func IsRequeueAfterError(err error) bool {
-	druidErr := &DruidError{}
-	if errors.As(err, &druidErr) {
-		return druidErr.Code == ErrRequeueAfter
-	}
-	return false
-}
-
 // New creates a new DruidError with the given error code, operation and message.
 func New(code druidv1alpha1.ErrorCode, operation string, message string) error {
 	return &DruidError{
@@ -105,4 +96,13 @@ func MapToLastErrors(errs []error) []druidv1alpha1.LastError {
 		}
 	}
 	return lastErrs
+}
+
+// AsDruidError returns the given error as a DruidError if it is of type DruidError, otherwise returns nil.
+func AsDruidError(err error) *DruidError {
+	druidErr := &DruidError{}
+	if errors.As(err, &druidErr) {
+		return druidErr
+	}
+	return nil
 }

--- a/internal/health/condition/check_ready_test.go
+++ b/internal/health/condition/check_ready_test.go
@@ -33,6 +33,7 @@ var _ = Describe("ReadyCheck", func() {
 		Context("when members in status", func() {
 			It("should return that the cluster has a quorum (all members ready)", func() {
 				etcd := druidv1alpha1.Etcd{
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
 							readyMember,
@@ -51,6 +52,7 @@ var _ = Describe("ReadyCheck", func() {
 
 			It("should return that the cluster has a quorum (members are partly unknown)", func() {
 				etcd := druidv1alpha1.Etcd{
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
 							readyMember,
@@ -69,6 +71,7 @@ var _ = Describe("ReadyCheck", func() {
 
 			It("should return that the cluster has a quorum (one member not ready)", func() {
 				etcd := druidv1alpha1.Etcd{
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
 							readyMember,
@@ -87,6 +90,7 @@ var _ = Describe("ReadyCheck", func() {
 
 			It("should return that the cluster has lost its quorum", func() {
 				etcd := druidv1alpha1.Etcd{
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
 							readyMember,
@@ -108,6 +112,7 @@ var _ = Describe("ReadyCheck", func() {
 		Context("when no members in status", func() {
 			It("should return that quorum is unknown", func() {
 				etcd := druidv1alpha1.Etcd{
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{},
 					},

--- a/internal/health/etcdmember/check_ready.go
+++ b/internal/health/etcdmember/check_ready.go
@@ -70,7 +70,7 @@ func (r *readyCheck) Check(ctx context.Context, etcd druidv1alpha1.Etcd) []Resul
 		// This behavior is expected by the `Ready` condition and it will become imprecise if members are added here too early.
 		renew := lease.Spec.RenewTime
 		if renew == nil {
-			r.logger.Info("Member hasn't acquired lease yet, still in bootstrapping phase", "name", lease.Name)
+			r.logger.V(4).Info("Member hasn't acquired lease yet, still in bootstrapping phase", "name", lease.Name)
 			continue
 		}
 

--- a/internal/images/images.yaml
+++ b/internal/images/images.yaml
@@ -14,11 +14,11 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.30.1"
+  tag: "v0.30.2"
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
-  tag: "v0.1.1"
+  tag: "v0.2.0"
 - name: alpine
   repository: europe-docker.pkg.dev/gardener-project/public/3rd/alpine
   tag: "3.18.4"

--- a/internal/utils/labels.go
+++ b/internal/utils/labels.go
@@ -4,6 +4,11 @@
 
 package utils
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
 // ContainsAllDesiredLabels checks if the actual map contains all the desired labels.
 func ContainsAllDesiredLabels(actual, desired map[string]string) bool {
 	for key, desiredValue := range desired {
@@ -19,4 +24,16 @@ func ContainsAllDesiredLabels(actual, desired map[string]string) bool {
 func ContainsLabel(actual map[string]string, key, value string) bool {
 	actualValue, ok := actual[key]
 	return ok && actualValue == value
+}
+
+// DoesLabelSelectorMatchLabels checks if the given label selector matches the given labels.
+func DoesLabelSelectorMatchLabels(labelSelector *metav1.LabelSelector, resourceLabels map[string]string) (bool, error) {
+	if labelSelector == nil {
+		return true, nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return false, err
+	}
+	return selector.Matches(labels.Set(resourceLabels)), nil
 }

--- a/internal/utils/lease.go
+++ b/internal/utils/lease.go
@@ -8,13 +8,12 @@ import (
 	"context"
 	"slices"
 	"strconv"
-	"strings"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	"github.com/gardener/etcd-druid/internal/common"
 
 	"github.com/go-logr/logr"
 	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,23 +22,25 @@ import (
 // If the annotation is not present or its value is `false` then it indicates that the member is not TLS enabled.
 const LeaseAnnotationKeyPeerURLTLSEnabled = "member.etcd.gardener.cloud/tls-enabled"
 
-// IsPeerURLTLSEnabledForMembers checks if TLS has been enabled for all existing members of an etcd cluster identified by etcdName and in the provided namespace.
-func IsPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger logr.Logger, namespace, etcdName string, numReplicas int32) (bool, error) {
-	leaseList := &coordinationv1.LeaseList{}
-	if err := cl.List(ctx, leaseList, client.InNamespace(namespace), client.MatchingLabels(map[string]string{
-		druidv1alpha1.LabelComponentKey: common.ComponentNameMemberLease,
-		druidv1alpha1.LabelPartOfKey:    etcdName,
-		druidv1alpha1.LabelManagedByKey: druidv1alpha1.LabelManagedByValue,
-	})); err != nil {
+// IsPeerURLInSyncForAllMembers checks if the peer URL is in sync for all existing members of an etcd cluster identified by etcdName and in the provided namespace.
+func IsPeerURLInSyncForAllMembers(ctx context.Context, cl client.Client, logger logr.Logger, etcd *druidv1alpha1.Etcd, replicas int32) (bool, error) {
+	peerURLTLSEnabled := etcd.Spec.Etcd.PeerUrlTLS != nil
+	if peerURLTLSEnabled {
+		return isPeerURLTLSEnabledForMembers(ctx, cl, logger, etcd, replicas)
+	}
+	return isPeerURLTLSDisabledForMembers(ctx, cl, logger, etcd, replicas)
+}
+
+// isPeerURLTLSEnabledForMembers checks if TLS has been enabled for all existing members of an etcd cluster identified by etcdName and in the provided namespace.
+func isPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger logr.Logger, etcd *druidv1alpha1.Etcd, replicas int32) (bool, error) {
+	tlsEnabledForAllMembers := true
+	leaseObjMetaSlice, err := ListAllMemberLeaseObjectMeta(ctx, cl, etcd)
+	if err != nil {
 		return false, err
 	}
-	tlsEnabledForAllMembers := true
-	leases := leaseList.DeepCopy().Items
-	slices.SortFunc(leases, func(a, b coordinationv1.Lease) int {
-		return strings.Compare(a.Name, b.Name)
-	})
-	for _, lease := range leases[:numReplicas] {
-		tlsEnabled, err := parseAndGetTLSEnabledValue(lease, logger)
+	targetMembers := leaseObjMetaSlice[:replicas]
+	for _, leaseObjMeta := range targetMembers {
+		tlsEnabled, err := parseAndGetTLSEnabledValue(leaseObjMeta, logger)
 		if err != nil {
 			return false, err
 		}
@@ -48,17 +49,56 @@ func IsPeerURLTLSEnabledForMembers(ctx context.Context, cl client.Client, logger
 	return tlsEnabledForAllMembers, nil
 }
 
-func parseAndGetTLSEnabledValue(lease coordinationv1.Lease, logger logr.Logger) (bool, error) {
-	if lease.Annotations != nil {
-		if tlsEnabledStr, ok := lease.Annotations[LeaseAnnotationKeyPeerURLTLSEnabled]; ok {
+// isPeerURLTLSDisabledForMembers checks if TLS has been disabled for all existing members of an etcd cluster identified by etcdName and in the provided namespace.
+func isPeerURLTLSDisabledForMembers(ctx context.Context, cl client.Client, logger logr.Logger, etcd *druidv1alpha1.Etcd, replicas int32) (bool, error) {
+	tlsDisabledForAllMembers := true
+	leaseObjMetaSlice, err := ListAllMemberLeaseObjectMeta(ctx, cl, etcd)
+	if err != nil {
+		return false, err
+	}
+	for _, leaseObjMeta := range leaseObjMetaSlice[:replicas] {
+		tlsEnabled, err := parseAndGetTLSEnabledValue(leaseObjMeta, logger)
+		if err != nil {
+			return false, err
+		}
+		tlsDisabledForAllMembers = tlsDisabledForAllMembers && !tlsEnabled
+	}
+	return tlsDisabledForAllMembers, nil
+}
+
+// ListAllMemberLeaseObjectMeta returns the list of all member leases for the given etcd cluster.
+func ListAllMemberLeaseObjectMeta(ctx context.Context, cl client.Client, etcd *druidv1alpha1.Etcd) ([]metav1.PartialObjectMetadata, error) {
+	objMetaList := &metav1.PartialObjectMetadataList{}
+	objMetaList.SetGroupVersionKind(coordinationv1.SchemeGroupVersion.WithKind("Lease"))
+	if err := cl.List(ctx,
+		objMetaList,
+		client.InNamespace(etcd.Namespace),
+	); err != nil {
+		return nil, err
+	}
+	// This OK to do as we do not support downscaling an etcd cluster.
+	// If and when we do that by then we should have already stabilised the labels and therefore this code itself will not be there.
+	allPossibleMemberNames := druidv1alpha1.GetMemberLeaseNames(etcd.ObjectMeta, etcd.Spec.Replicas)
+	leasesObjMeta := make([]metav1.PartialObjectMetadata, 0, len(objMetaList.Items))
+	for _, lease := range objMetaList.Items {
+		if metav1.IsControlledBy(&lease, &etcd.ObjectMeta) && slices.Contains(allPossibleMemberNames, lease.Name) {
+			leasesObjMeta = append(leasesObjMeta, lease)
+		}
+	}
+	return leasesObjMeta, nil
+}
+
+func parseAndGetTLSEnabledValue(leaseObjMeta metav1.PartialObjectMetadata, logger logr.Logger) (bool, error) {
+	if leaseObjMeta.Annotations != nil {
+		if tlsEnabledStr, ok := leaseObjMeta.Annotations[LeaseAnnotationKeyPeerURLTLSEnabled]; ok {
 			tlsEnabled, err := strconv.ParseBool(tlsEnabledStr)
 			if err != nil {
-				logger.Error(err, "tls-enabled value is not a valid boolean", "namespace", lease.Namespace, "leaseName", lease.Name)
+				logger.Error(err, "tls-enabled value is not a valid boolean", "namespace", leaseObjMeta.Namespace, "leaseName", leaseObjMeta.Name)
 				return false, err
 			}
 			return tlsEnabled, nil
 		}
-		logger.V(4).Info("tls-enabled annotation not present for lease.", "namespace", lease.Namespace, "leaseName", lease.Name)
+		logger.V(4).Info("tls-enabled annotation not present for lease.", "namespace", leaseObjMeta.Namespace, "leaseName", leaseObjMeta.Name)
 	}
 	return false, nil
 }

--- a/internal/utils/lease_test.go
+++ b/internal/utils/lease_test.go
@@ -28,11 +28,11 @@ import (
 func TestIsPeerURLTLSEnabledForAllMembers(t *testing.T) {
 	internalErr := errors.New("fake get internal error")
 	apiInternalErr := apierrors.NewInternalError(internalErr)
-	const etcdReplicas = 3
+	etcd := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).WithReplicas(3).WithPeerTLS().Build()
 	testCases := []struct {
 		name                         string
 		numETCDMembersWithTLSEnabled int
-		listErr                      *apierrors.StatusError
+		errors                       []testutils.ErrorsForGVK
 		expectedErr                  *apierrors.StatusError
 		expectedResult               bool
 	}{
@@ -52,8 +52,13 @@ func TestIsPeerURLTLSEnabledForAllMembers(t *testing.T) {
 			expectedResult:               true,
 		},
 		{
-			name:           "should return error when client list call fails",
-			listErr:        apiInternalErr,
+			name: "should return error when client list call fails",
+			errors: []testutils.ErrorsForGVK{
+				{
+					GVK:     coordinationv1.SchemeGroupVersion.WithKind("Lease"),
+					ListErr: apiInternalErr,
+				},
+			},
 			expectedErr:    apiInternalErr,
 			expectedResult: false,
 		},
@@ -66,15 +71,11 @@ func TestIsPeerURLTLSEnabledForAllMembers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			var existingObjects []client.Object
-			for _, l := range createLeases(testutils.TestNamespace, testutils.TestEtcdName, etcdReplicas, tc.numETCDMembersWithTLSEnabled) {
+			for _, l := range createLeases(etcd, tc.numETCDMembersWithTLSEnabled) {
 				existingObjects = append(existingObjects, l)
 			}
-			cl := testutils.CreateTestFakeClientForAllObjectsInNamespace(nil, tc.listErr, testutils.TestNamespace, map[string]string{
-				druidv1alpha1.LabelComponentKey: common.ComponentNameMemberLease,
-				druidv1alpha1.LabelPartOfKey:    testutils.TestEtcdName,
-				druidv1alpha1.LabelManagedByKey: druidv1alpha1.LabelManagedByValue,
-			}, existingObjects...)
-			tlsEnabled, err := IsPeerURLTLSEnabledForMembers(context.Background(), cl, logger, testutils.TestNamespace, testutils.TestEtcdName, etcdReplicas)
+			cl := testutils.CreateTestFakeClientForObjectsInNamespaceWithGVK(tc.errors, testutils.TestNamespace, existingObjects...)
+			tlsEnabled, err := IsPeerURLInSyncForAllMembers(context.Background(), cl, logger, etcd, etcd.Spec.Replicas)
 			if tc.expectedErr != nil {
 				g.Expect(err).To(Equal(tc.expectedErr))
 			} else {
@@ -84,15 +85,76 @@ func TestIsPeerURLTLSEnabledForAllMembers(t *testing.T) {
 	}
 }
 
-func createLeases(namespace, etcdName string, numLease, withTLSEnabled int) []*coordinationv1.Lease {
-	leases := make([]*coordinationv1.Lease, 0, numLease)
+func TestIsPeerURLTLSDisabledForAllMembers(t *testing.T) {
+	internalErr := errors.New("fake get internal error")
+	apiInternalErr := apierrors.NewInternalError(internalErr)
+	etcd := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).WithReplicas(3).Build()
+	testCases := []struct {
+		name                         string
+		numETCDMembersWithTLSEnabled int
+		errors                       []testutils.ErrorsForGVK
+		expectedErr                  *apierrors.StatusError
+		expectedResult               bool
+	}{
+		{
+			name:                         "should return true when all of the members have peer TLS disabled",
+			numETCDMembersWithTLSEnabled: 0,
+			expectedResult:               true,
+		},
+		{
+			name:                         "should return false when one of three still have peer TLS enabled",
+			numETCDMembersWithTLSEnabled: 1,
+			expectedResult:               false,
+		},
+		{
+			name:                         "should return false when none of the members have peer TLS disabled",
+			numETCDMembersWithTLSEnabled: 3,
+			expectedResult:               false,
+		},
+		{
+			name: "should return error when client list call fails",
+			errors: []testutils.ErrorsForGVK{
+				{
+					GVK:     coordinationv1.SchemeGroupVersion.WithKind("Lease"),
+					ListErr: apiInternalErr,
+				},
+			},
+			expectedErr:    apiInternalErr,
+			expectedResult: false,
+		},
+	}
+
+	g := NewWithT(t)
+	t.Parallel()
+	logger := logr.Discard()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var existingObjects []client.Object
+			for _, l := range createLeases(etcd, tc.numETCDMembersWithTLSEnabled) {
+				existingObjects = append(existingObjects, l)
+			}
+			cl := testutils.CreateTestFakeClientForObjectsInNamespaceWithGVK(tc.errors, testutils.TestNamespace, existingObjects...)
+			tlsEnabled, err := IsPeerURLInSyncForAllMembers(context.Background(), cl, logger, etcd, etcd.Spec.Replicas)
+			if tc.expectedErr != nil {
+				g.Expect(err).To(Equal(tc.expectedErr))
+			} else {
+				g.Expect(tlsEnabled).To(Equal(tc.expectedResult))
+			}
+		})
+	}
+}
+
+func createLeases(etcd *druidv1alpha1.Etcd, withTLSEnabled int) []*coordinationv1.Lease {
+	numLeases := int(etcd.Spec.Replicas)
+	leases := make([]*coordinationv1.Lease, 0, numLeases)
 	labels := map[string]string{
 		druidv1alpha1.LabelComponentKey: common.ComponentNameMemberLease,
-		druidv1alpha1.LabelPartOfKey:    etcdName,
+		druidv1alpha1.LabelPartOfKey:    etcd.Name,
 		druidv1alpha1.LabelManagedByKey: druidv1alpha1.LabelManagedByValue,
 	}
 	tlsEnabledCount := 0
-	for i := 0; i < numLease; i++ {
+	for i := 0; i < numLeases; i++ {
 		var annotations map[string]string
 		if tlsEnabledCount < withTLSEnabled {
 			annotations = map[string]string{
@@ -104,10 +166,11 @@ func createLeases(namespace, etcdName string, numLease, withTLSEnabled int) []*c
 		}
 		lease := &coordinationv1.Lease{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        fmt.Sprintf("%s-%d", etcdName, i),
-				Namespace:   namespace,
-				Annotations: annotations,
-				Labels:      labels,
+				Name:            fmt.Sprintf("%s-%d", etcd.Name, i),
+				Namespace:       etcd.Namespace,
+				Annotations:     annotations,
+				Labels:          labels,
+				OwnerReferences: []metav1.OwnerReference{druidv1alpha1.GetAsOwnerReference(etcd.ObjectMeta)},
 			},
 		}
 		leases = append(leases, lease)

--- a/main.go
+++ b/main.go
@@ -5,18 +5,14 @@
 package main
 
 import (
-	"github.com/gardener/etcd-druid/internal/utils"
-	"os"
-	"runtime"
-
 	druidmgr "github.com/gardener/etcd-druid/internal/manager"
+	"github.com/gardener/etcd-druid/internal/utils"
 	"github.com/gardener/etcd-druid/internal/version"
 	"github.com/go-logr/logr"
-	"go.uber.org/zap/zapcore"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	flag "github.com/spf13/pflag"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"os"
+	"runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	// +kubebuilder:scaffold:imports
 )
@@ -25,26 +21,18 @@ var logger = ctrl.Log.WithName("druid")
 
 func main() {
 	ctx := ctrl.SetupSignalHandler()
-
 	ctrl.SetLogger(utils.MustNewLogger(false, utils.LogFormatJSON))
-
 	printVersionInfo()
 
-	mgrConfig := druidmgr.Config{}
-	if err := mgrConfig.InitFromFlags(flag.CommandLine); err != nil {
-		logger.Error(err, "failed to initialize from flags")
+	mgrConfig, err := initializeManagerConfig()
+	if err != nil {
+		logger.Error(err, "failed to initialize manager config")
 		os.Exit(1)
 	}
-
-	flag.Parse()
-
-	printFlags(logger)
-
-	if err := mgrConfig.Validate(); err != nil {
+	if err = mgrConfig.Validate(); err != nil {
 		logger.Error(err, "validation of manager config failed")
 		os.Exit(1)
 	}
-
 	mgr, err := druidmgr.InitializeManager(&mgrConfig)
 	if err != nil {
 		logger.Error(err, "failed to create druid controller manager")
@@ -60,26 +48,36 @@ func main() {
 	}
 }
 
+func initializeManagerConfig() (druidmgr.Config, error) {
+	mgrConfig := druidmgr.Config{}
+	cmdLineFlagSet := flag.CommandLine
+	// This is required when moving from v0.22 to v0.23. Some command line flags have been renamed in v0.23.
+	// If the entity which deploys druid needs to handle both versions then in the caller both old and new flags can be set.
+	// Older version of druid will only work with older flags while ignoring the newer ones as unknowns. It is going to be a similar case for newer versions of druid as well.
+	// Once we stabilise the command line arguments then this will no longer be needed.
+	cmdLineFlagSet.ParseErrorsWhitelist.UnknownFlags = true
+	if err := mgrConfig.InitFromFlags(cmdLineFlagSet); err != nil {
+		logger.Error(err, "failed to initialize from flags")
+		return druidmgr.Config{}, err
+	}
+
+	if err := cmdLineFlagSet.Parse(os.Args[1:]); err != nil {
+		logger.Error(err, "failed to parse command line flags")
+		return druidmgr.Config{}, err
+	}
+	printFlags(cmdLineFlagSet, logger)
+	return mgrConfig, nil
+}
+
 func printVersionInfo() {
 	logger.Info("Etcd-druid build information", "Etcd-druid Version", version.Version, "Git SHA", version.GitSHA)
 	logger.Info("Golang runtime information", "Version", runtime.Version(), "OS", runtime.GOOS, "Arch", runtime.GOARCH)
 }
 
-func printFlags(logger logr.Logger) {
+func printFlags(fs *flag.FlagSet, logger logr.Logger) {
 	var flagKVs []interface{}
-	flag.VisitAll(func(f *flag.Flag) {
+	fs.VisitAll(func(f *flag.Flag) {
 		flagKVs = append(flagKVs, f.Name, f.Value.String())
 	})
-
 	logger.Info("Running with flags", flagKVs...)
-}
-
-func buildDefaultLoggerOpts() []zap.Opts {
-	var opts []zap.Opts
-	opts = append(opts, zap.UseDevMode(false))
-	opts = append(opts, zap.JSONEncoder(func(encoderConfig *zapcore.EncoderConfig) {
-		encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-		encoderConfig.EncodeDuration = zapcore.StringDurationEncoder
-	}))
-	return opts
 }


### PR DESCRIPTION
* fixes #881
* Added ability to handle unknown CLI args to allow switching between v0.22 and v0.23
* Added use-etcd-wrapper cli arg for etcdbr container
* removed etcd-cluster-size label to be added later with ability to restore while keep etcd.spec.replicas > 1

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Cherry-pick of #883 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```other user
Fixed the ready condition for the Etcd resource.
```

```other operator
Fixes for handling of pod template labels, label-selector, replicas and TLS changes to Etcd resource. StatefulSet does not allow update of label-selector. v0.23.x changes the label-selector, to get that reflected in the STS, it will be orphan deleted and subsequently created. Similarly for peer TLS and pod label changes an update of pods will be done. For single member etcd clusters this will cause a transient downtime. If replicas, TLS, label-selector are changed together then it will also cause transient quorum loss in multi-node etcd clusters.
```

```noteworthy operator
etcd-backup-restore has been bumped to v0.30.2 and etcd-wrapper has been bumped to v0.2.0.
```

```breaking operator
If you wish to downgrade from druid `v0.23.x` to versions =<`v0.22.7`, please ensure that you change the CLI flags for the druid command to remove the new CLI flags introduced in `v0.23.0`. If you are using the provided helm charts to deploy druid, you may ignore this and simply deploy the helm chart, which takes care of the CLI flag changes for you.
```

```noteworthy operator github.com/gardener/etcd-backup-restore #794 @ishan16696
etcd-backup-restore now triggers a restart of the etcd member after updating etcd's advertise peer URLs if found updated.
```

```noteworthy user github.com/gardener/etcd-backup-restore #794 @ishan16696
Introduced a CLI flag `--use-etcd-wrapper` (default: false) to enable/disable the backup-restore to use etcd-wrapper related functionality. Note: enable this flag only if etcd-wrapper is deployed.
```

```other operator github.com/gardener/etcd-wrapper #31 @ishan16696
Added a capability to stop the etcd-wrapper container by exposing an endpoint `/stop`. 
```

```other developer github.com/gardener/etcd-wrapper #32 @renormalize
Upgrade the Go dependency to `go1.23.1`.
```

```other operator github.com/gardener/etcd-wrapper #18 @unmarshall
ops/print-etcd-cert-paths.sh has been removed and is now replaced with ops/print-etcd-cheatsheet.sh
```
