### PR TITLE
Etcd components webhook allows druid to always update its managed resources

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -44,7 +44,7 @@ if ${TEST_COVER:-false}; then
   output_dir=test/output
   coverprofile_file=coverprofile.out
   mkdir -p test/output
-  ginkgo $GINKGO_COMMON_FLAGS --coverprofile ${coverprofile_file} -covermode=set -outputdir ${output_dir} $@
+  ginkgo $GINKGO_COMMON_FLAGS --coverprofile ${coverprofile_file} -covermode=set -output-dir ${output_dir} $@
   ${SED_BIN} -i '/mode: set/d' ${output_dir}/${coverprofile_file}
   {( echo "mode: set"; cat ${output_dir}/${coverprofile_file} )} > ${output_dir}/${coverprofile_file}.temp
   mv ${output_dir}/${coverprofile_file}.temp ${output_dir}/${coverprofile_file}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

There are instances when druid's informer cache seems to be stale, and thus it sees older versions of resources. This causes a problem when druid picks up an Etcd resource for reconciliation since it sees that an operation-reconcile annotation has been added, and records the start of the operation on the Etcd status, but this change does not get reflected in the cache immediately, and subsequent update/patch calls to the druid-managed resources such as leases fails, because the etcd-components webhook prevents any updates to these resources unless the Etcd status shows that a reconciliation is in progress (but it doesn't, since the cache is stale at that point).

With this PR, etcd-components webhook allows druid to update its own managed resources at all times, allowing reconciliations to succeed even if the informer cache is stale, drastically reducing the probability of reconciliation failures.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Etcd components webhook now allows druid to always update its managed resources, to tackle issues with stale informer cache.
```
