### PR TITLE
Use full snapshot interval to compute Backup Ready conditions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ironcore-dev/vgopath v0.1.4
 	github.com/prometheus/client_golang v1.18.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240707233637-46b078467d37
@@ -34,8 +35,6 @@ require (
 	github.com/onsi/gomega v1.33.1
 	go.uber.org/mock v0.4.0
 )
-
-require github.com/robfig/cron/v3 v3.0.1
 
 require (
 	cloud.google.com/go v0.112.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,8 @@ require (
 	go.uber.org/mock v0.4.0
 )
 
+require github.com/robfig/cron/v3 v3.0.1
+
 require (
 	cloud.google.com/go v0.112.0 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
@@ -111,7 +113,6 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.11.0 // indirect

--- a/internal/utils/miscellaneous.go
+++ b/internal/utils/miscellaneous.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"time"
 
+	cron "github.com/robfig/cron/v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -62,4 +64,20 @@ func IfConditionOr[T any](condition bool, trueVal, falseVal T) T {
 		return trueVal
 	}
 	return falseVal
+}
+
+// ComputeScheduleInterval computes the interval between two activations for the given cron schedule.
+// Assumes that every cron activation is at equal intervals apart, based on cron schedules such as
+// "once every X hours", "once every Y days", "at 1:00pm on every Tuesday", etc.
+// TODO: write a new function to accurately compute the previous activation time from the cron schedule
+// in order to compute when the previous activation of the cron schedule was supposed to have occurred,
+// instead of relying on the assumption that all the cron activations are evenly spaced.
+func ComputeScheduleInterval(cronSchedule string) (time.Duration, error) {
+	schedule, err := cron.ParseStandard(cronSchedule)
+	if err != nil {
+		return 0, err
+	}
+	nextScheduledTime := schedule.Next(time.Now())
+	nextNextScheduledTime := schedule.Next(nextScheduledTime)
+	return nextNextScheduledTime.Sub(nextScheduledTime), nil
 }

--- a/internal/utils/miscellaneous.go
+++ b/internal/utils/miscellaneous.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	cron "github.com/robfig/cron/v3"
+	"github.com/robfig/cron/v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/area monitoring
/kind bug

**What this PR does / why we need it**:

Backup ready condition is determined based on the snapshot intervals and the time the snapshot is taken. Currently, the full snapshot interval is hardcoded as `24hr` in the code [here](https://github.com/gardener/etcd-druid/blob/df3ff21d8cd9d3d785309223f543d72518dbeed2/internal/health/condition/check_backup_ready.go#L70) & [here](https://github.com/gardener/etcd-druid/blob/df3ff21d8cd9d3d785309223f543d72518dbeed2/internal/health/condition/check_backup_ready.go#L85) which can lead to a false positive `BackupReady : true` if the user has configured the full snapshot schedule to be less than `24hr` OR can lead to a false negative `BackupReady : false` condition if the user has configured the schedule to be more than `24hr`. 

This PR uses the full snapshot interval fetched from the etcd spec at `etcd.Spec.Backup.FullSnapshotSchedule` instead of assuming it as `24hrs`. 

**Which issue(s) this PR fixes**:
Fixes #905

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix a minor bug in wrongly assuming `24hr` as full snapshot interval to compute backup ready condition by getting it from full snapshot schedule.
```
