### PR TITLE
Update the doc with correct annotation to disable druid managed resource protection via the webhook.

### DIFF
--- a/api/v1alpha1/helper.go
+++ b/api/v1alpha1/helper.go
@@ -114,7 +114,7 @@ func GetSuspendEtcdSpecReconcileAnnotationKey(etcdObjMeta metav1.ObjectMeta) *st
 	return nil
 }
 
-// AreManagedResourcesProtected returns false if the Etcd resource has the `druid.gardener.cloud/disable-resource-protection` annotation set,
+// AreManagedResourcesProtected returns false if the Etcd resource has the `druid.gardener.cloud/disable-etcd-component-protection` annotation set,
 // else returns true.
 func AreManagedResourcesProtected(etcdObjMeta metav1.ObjectMeta) bool {
 	return !metav1.HasAnnotation(etcdObjMeta, DisableEtcdComponentProtectionAnnotation)

--- a/docs/usage/managing-etcd-clusters.md
+++ b/docs/usage/managing-etcd-clusters.md
@@ -144,7 +144,7 @@ We provide a generic way to suspend etcd cluster reconciliation via etcd-druid, 
 2. Add another annotation to the target `Etcd` resource disabling managed resource protection via the webhook. You can do this by invoking the following command:
 
    ```bash
-   kubectl annotate etcd etcd-main -n <namespace> druid.gardener.cloud/disable-resource-protection=
+   kubectl annotate etcd etcd-main -n <namespace> druid.gardener.cloud/disable-etcd-component-protection=
    ```
 
 Now you are free to make changes to any managed etcd cluster resource.

--- a/docs/usage/recovering-etcd-clusters.md
+++ b/docs/usage/recovering-etcd-clusters.md
@@ -50,7 +50,7 @@ The above annotation will prevent any reconciliation by etcd-druid for this `Etc
 Add another annotation to the `Etcd` resource:
 
 ```bash
-kubectl annotate etcd etcd-main -n <namespace> druid.gardener.cloud/disable-resource-protection=
+kubectl annotate etcd etcd-main -n <namespace> druid.gardener.cloud/disable-etcd-component-protection=
 ```
 
 The above annotation will allow manual edits to `Etcd` cluster resources that are managed by etcd-druid.
@@ -122,7 +122,7 @@ If both containers report readiness (as seen above), then the etcd-cluster is co
 All manual changes are now done. We must now re-enable etcd-cluster resource protection and also enable reconciliation by etcd-druid by doing the following:
 ```bash
 kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/suspend-etcd-spec-reconcile-
-kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/disable-resource-protection-
+kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/disable-etcd-component-protection-
 ```
 
 #### 09-Scale-up Etcd Cluster to 3 and trigger reconcile

--- a/internal/webhook/etcdcomponents/handler.go
+++ b/internal/webhook/etcdcomponents/handler.go
@@ -77,7 +77,7 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Allowed(fmt.Sprintf("resource: %v  is not part of any Etcd, skipping validations", util.CreateObjectKey(partialObjMeta))).WithWarnings(warnings...)
 	}
 
-	// allow changes to resources if Etcd has annotation druid.gardener.cloud/disable-resource-protection is set.
+	// allow changes to resources if Etcd has annotation druid.gardener.cloud/disable-etcd-component-protection is set.
 	if !druidv1alpha1.AreManagedResourcesProtected(etcd.ObjectMeta) {
 		return admission.Allowed(fmt.Sprintf("changes allowed, since Etcd %s has annotation %s", etcd.Name, druidv1alpha1.DisableEtcdComponentProtectionAnnotation))
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
This PR fixes the documentation with correct annotation `druid.gardener.cloud/disable-etcd-component-protection` to disable the webhook to protect druid managed resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
