### PR TITLE
Fix to allow etcd-druid to patch STS when there is only a change of mount-path even if all pods are not up and running

### DIFF
--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -121,8 +121,14 @@ const (
 	VolumeNameEtcdClientTLS = "etcd-client-tls"
 	// VolumeNameEtcdPeerCA is the name of the volume that contains the CA certificate bundle and CA certificate key used to sign certificates for peer communication.
 	VolumeNameEtcdPeerCA = "etcd-peer-ca"
+	// OldVolumeNameEtcdPeerCA is the old name of the volume that contains the CA certificate bundle and CA certificate key used to sign certificates for peer communication.
+	// TODO: (i062009) remove this when all clusters have started to use the new volume names.
+	OldVolumeNameEtcdPeerCA = "peer-url-ca-etcd"
 	// VolumeNameEtcdPeerServerTLS is the name of the volume that contains the server certificate-key pair used to set up the peer server.
 	VolumeNameEtcdPeerServerTLS = "etcd-peer-server-tls"
+	// OldVolumeNameEtcdPeerServerTLS is the old name of the volume that contains the server certificate-key pair used to set up the peer server.
+	// TODO: (i062009) remove this when all clusters have started to use the new volume names.
+	OldVolumeNameEtcdPeerServerTLS = "peer-url-etcd-server-tls"
 	// VolumeNameBackupRestoreCA is the name of the volume that contains the CA certificate bundle and CA certificate key used to sign certificates for backup-restore communication.
 	VolumeNameBackupRestoreCA = "backup-restore-ca"
 	// VolumeNameBackupRestoreServerTLS is the name of the volume that contains the server certificate-key pair used to set up the backup-restore server.

--- a/internal/component/clientservice/clientservice.go
+++ b/internal/component/clientservice/clientservice.go
@@ -112,7 +112,7 @@ func buildResource(etcd *druidv1alpha1.Etcd, svc *corev1.Service) {
 	svc.Spec.Type = corev1.ServiceTypeClusterIP
 	svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
 	// Client service should only target StatefulSet pods. Default labels are going to be present on anything that is managed by etcd-druid and started for an etcd cluster.
-	// Therefore, only using this as a label selector can cause issues as we have already seen in https://github.com/gardener/etcd-druid/issues/914
+	// Therefore, only using default labels as label selector can cause issues as we have already seen in https://github.com/gardener/etcd-druid/issues/914
 	svc.Spec.Selector = utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	svc.Spec.Ports = getPorts(etcd)
 }

--- a/internal/component/clientservice/clientservice.go
+++ b/internal/component/clientservice/clientservice.go
@@ -111,6 +111,8 @@ func buildResource(etcd *druidv1alpha1.Etcd, svc *corev1.Service) {
 	svc.OwnerReferences = []metav1.OwnerReference{druidv1alpha1.GetAsOwnerReference(etcd.ObjectMeta)}
 	svc.Spec.Type = corev1.ServiceTypeClusterIP
 	svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
+	// Client service should only target StatefulSet pods. Default labels are going to be present on anything that is managed by etcd-druid and started for an etcd cluster.
+	// Therefore, only using this as a label selector can cause issues as we have see in https://github.com/gardener/etcd-druid/issues/914
 	svc.Spec.Selector = utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	svc.Spec.Ports = getPorts(etcd)
 }

--- a/internal/component/clientservice/clientservice.go
+++ b/internal/component/clientservice/clientservice.go
@@ -111,7 +111,7 @@ func buildResource(etcd *druidv1alpha1.Etcd, svc *corev1.Service) {
 	svc.OwnerReferences = []metav1.OwnerReference{druidv1alpha1.GetAsOwnerReference(etcd.ObjectMeta)}
 	svc.Spec.Type = corev1.ServiceTypeClusterIP
 	svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
-	svc.Spec.Selector = druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta)
+	svc.Spec.Selector = utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	svc.Spec.Ports = getPorts(etcd)
 }
 

--- a/internal/component/clientservice/clientservice.go
+++ b/internal/component/clientservice/clientservice.go
@@ -112,7 +112,7 @@ func buildResource(etcd *druidv1alpha1.Etcd, svc *corev1.Service) {
 	svc.Spec.Type = corev1.ServiceTypeClusterIP
 	svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
 	// Client service should only target StatefulSet pods. Default labels are going to be present on anything that is managed by etcd-druid and started for an etcd cluster.
-	// Therefore, only using this as a label selector can cause issues as we have see in https://github.com/gardener/etcd-druid/issues/914
+	// Therefore, only using this as a label selector can cause issues as we have already seen in https://github.com/gardener/etcd-druid/issues/914
 	svc.Spec.Selector = utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	svc.Spec.Ports = getPorts(etcd)
 }

--- a/internal/component/clientservice/clientservice_test.go
+++ b/internal/component/clientservice/clientservice_test.go
@@ -272,6 +272,7 @@ func matchClientService(g *WithT, etcd *druidv1alpha1.Etcd, actualSvc corev1.Ser
 		expectedAnnotations = etcd.Spec.Etcd.ClientService.Annotations
 		expectedLabels = utils.MergeMaps(etcd.Spec.Etcd.ClientService.Labels, druidv1alpha1.GetDefaultLabels(etcdObjMeta))
 	}
+	expectedLabelSelector := utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcdObjMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 
 	g.Expect(actualSvc).To(MatchFields(IgnoreExtras, Fields{
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{
@@ -284,7 +285,7 @@ func matchClientService(g *WithT, etcd *druidv1alpha1.Etcd, actualSvc corev1.Ser
 		"Spec": MatchFields(IgnoreExtras, Fields{
 			"Type":            Equal(corev1.ServiceTypeClusterIP),
 			"SessionAffinity": Equal(corev1.ServiceAffinityNone),
-			"Selector":        Equal(druidv1alpha1.GetDefaultLabels(etcdObjMeta)),
+			"Selector":        Equal(expectedLabelSelector),
 			"Ports": ConsistOf(
 				Equal(corev1.ServicePort{
 					Name:       "client",

--- a/internal/component/peerservice/peerservice.go
+++ b/internal/component/peerservice/peerservice.go
@@ -112,7 +112,7 @@ func buildResource(etcd *druidv1alpha1.Etcd, svc *corev1.Service) {
 	svc.Spec.ClusterIP = corev1.ClusterIPNone
 	svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
 	// Peer service should only target StatefulSet pods. Default labels are going to be present on anything that is managed by etcd-druid and started for an etcd cluster.
-	// Therefore, only using this as a label selector can cause issues as we have already seen in https://github.com/gardener/etcd-druid/issues/914
+	// Therefore, only using default labels as label selector can cause issues as we have already seen in https://github.com/gardener/etcd-druid/issues/914
 	svc.Spec.Selector = utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	svc.Spec.PublishNotReadyAddresses = true
 	svc.Spec.Ports = getPorts(etcd)

--- a/internal/component/peerservice/peerservice.go
+++ b/internal/component/peerservice/peerservice.go
@@ -112,7 +112,7 @@ func buildResource(etcd *druidv1alpha1.Etcd, svc *corev1.Service) {
 	svc.Spec.ClusterIP = corev1.ClusterIPNone
 	svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
 	// Peer service should only target StatefulSet pods. Default labels are going to be present on anything that is managed by etcd-druid and started for an etcd cluster.
-	// Therefore, only using this as a label selector can cause issues as we have see in https://github.com/gardener/etcd-druid/issues/914
+	// Therefore, only using this as a label selector can cause issues as we have already seen in https://github.com/gardener/etcd-druid/issues/914
 	svc.Spec.Selector = utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	svc.Spec.PublishNotReadyAddresses = true
 	svc.Spec.Ports = getPorts(etcd)

--- a/internal/component/peerservice/peerservice.go
+++ b/internal/component/peerservice/peerservice.go
@@ -111,7 +111,7 @@ func buildResource(etcd *druidv1alpha1.Etcd, svc *corev1.Service) {
 	svc.Spec.Type = corev1.ServiceTypeClusterIP
 	svc.Spec.ClusterIP = corev1.ClusterIPNone
 	svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
-	svc.Spec.Selector = druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta)
+	svc.Spec.Selector = utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	svc.Spec.PublishNotReadyAddresses = true
 	svc.Spec.Ports = getPorts(etcd)
 }

--- a/internal/component/peerservice/peerservice.go
+++ b/internal/component/peerservice/peerservice.go
@@ -111,6 +111,8 @@ func buildResource(etcd *druidv1alpha1.Etcd, svc *corev1.Service) {
 	svc.Spec.Type = corev1.ServiceTypeClusterIP
 	svc.Spec.ClusterIP = corev1.ClusterIPNone
 	svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
+	// Peer service should only target StatefulSet pods. Default labels are going to be present on anything that is managed by etcd-druid and started for an etcd cluster.
+	// Therefore, only using this as a label selector can cause issues as we have see in https://github.com/gardener/etcd-druid/issues/914
 	svc.Spec.Selector = utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	svc.Spec.PublishNotReadyAddresses = true
 	svc.Spec.Ports = getPorts(etcd)

--- a/internal/component/peerservice/peerservice_test.go
+++ b/internal/component/peerservice/peerservice_test.go
@@ -7,13 +7,13 @@ package peerservice
 import (
 	"context"
 	"errors"
-	"github.com/gardener/etcd-druid/internal/utils"
 	"testing"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/common"
 	"github.com/gardener/etcd-druid/internal/component"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
+	"github.com/gardener/etcd-druid/internal/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	"github.com/go-logr/logr"

--- a/internal/component/peerservice/peerservice_test.go
+++ b/internal/component/peerservice/peerservice_test.go
@@ -7,6 +7,7 @@ package peerservice
 import (
 	"context"
 	"errors"
+	"github.com/gardener/etcd-druid/internal/utils"
 	"testing"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
@@ -246,6 +247,7 @@ func newPeerService(etcd *druidv1alpha1.Etcd) *corev1.Service {
 func matchPeerService(g *WithT, etcd *druidv1alpha1.Etcd, actualSvc corev1.Service) {
 	peerPort := ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)
 	etcdObjMeta := etcd.ObjectMeta
+	expectedLabelSelector := utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcdObjMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	g.Expect(actualSvc).To(MatchFields(IgnoreExtras, Fields{
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 			"Name":            Equal(druidv1alpha1.GetPeerServiceName(etcdObjMeta)),
@@ -257,7 +259,7 @@ func matchPeerService(g *WithT, etcd *druidv1alpha1.Etcd, actualSvc corev1.Servi
 			"Type":            Equal(corev1.ServiceTypeClusterIP),
 			"ClusterIP":       Equal(corev1.ClusterIPNone),
 			"SessionAffinity": Equal(corev1.ServiceAffinityNone),
-			"Selector":        Equal(druidv1alpha1.GetDefaultLabels(etcdObjMeta)),
+			"Selector":        Equal(expectedLabelSelector),
 			"Ports": ConsistOf(
 				Equal(corev1.ServicePort{
 					Name:       "peer",

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -708,8 +708,22 @@ func getEtcdContainerSecretVolumeMounts(etcd *druidv1alpha1.Etcd) []corev1.Volum
 			},
 		)
 	}
-	if etcd.Spec.Etcd.PeerUrlTLS != nil {
+	secretVolumeMounts = append(secretVolumeMounts, getEtcdContainerPeerVolumeMounts(etcd)...)
+	if etcd.Spec.Backup.TLS != nil {
 		secretVolumeMounts = append(secretVolumeMounts,
+			corev1.VolumeMount{
+				Name:      common.VolumeNameBackupRestoreCA,
+				MountPath: common.VolumeMountPathBackupRestoreCA,
+			},
+		)
+	}
+	return secretVolumeMounts
+}
+
+func getEtcdContainerPeerVolumeMounts(etcd *druidv1alpha1.Etcd) []corev1.VolumeMount {
+	peerTLSVolMounts := make([]corev1.VolumeMount, 0, 2)
+	if etcd.Spec.Etcd.PeerUrlTLS != nil {
+		peerTLSVolMounts = append(peerTLSVolMounts,
 			corev1.VolumeMount{
 				Name:      common.VolumeNameEtcdPeerCA,
 				MountPath: common.VolumeMountPathEtcdPeerCA,
@@ -720,15 +734,7 @@ func getEtcdContainerSecretVolumeMounts(etcd *druidv1alpha1.Etcd) []corev1.Volum
 			},
 		)
 	}
-	if etcd.Spec.Backup.TLS != nil {
-		secretVolumeMounts = append(secretVolumeMounts,
-			corev1.VolumeMount{
-				Name:      common.VolumeNameBackupRestoreCA,
-				MountPath: common.VolumeMountPathBackupRestoreCA,
-			},
-		)
-	}
-	return secretVolumeMounts
+	return peerTLSVolMounts
 }
 
 // getPodVolumes gets volumes that needs to be mounted onto the etcd StatefulSet pods

--- a/internal/component/statefulset/statefulset.go
+++ b/internal/component/statefulset/statefulset.go
@@ -266,7 +266,7 @@ func (r _resource) handleTLSChanges(ctx component.OperatorContext, etcd *druidv1
 		// and the cluster will be stuck in a bad state. Updating peer URL is a cluster wide operation as all members will need to know that a peer TLS has changed.
 		// If not all members are ready then rolling-update of StatefulSet can potentially cause a healthy node to be restarted causing loss of quorum from which
 		// there will not be an automatic recovery.
-		if shouldRequeueForMultiNodeEtcdIfPodsNotReady(existingSts) {
+		if hasTLSEnablementForPeerURLReflectedOnSTS(etcd, existingSts) && shouldRequeueForMultiNodeEtcdIfPodsNotReady(existingSts) {
 			return druiderr.New(
 				druiderr.ErrRequeueAfter,
 				component.OperationSync,
@@ -309,10 +309,22 @@ func shouldRequeueForMultiNodeEtcdIfPodsNotReady(sts *appsv1.StatefulSet) bool {
 		sts.Status.ReadyReplicas < *sts.Spec.Replicas
 }
 
-func isStatefulSetTLSConfigInSync(etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) bool {
+func hasTLSEnablementForPeerURLReflectedOnSTS(etcd *druidv1alpha1.Etcd, existingSts *appsv1.StatefulSet) bool {
+	newEtcdWrapperPeerTLSVolMounts := getEtcdContainerPeerVolumeMounts(etcd)
+	containerTLSVolMounts := utils.GetStatefulSetContainerTLSVolumeMounts(existingSts)
+	containerPeerTLSVolMounts := make([]corev1.VolumeMount, 0, 2)
+	for _, volMount := range containerTLSVolMounts[common.ContainerNameEtcd] {
+		if volMount.Name == common.VolumeNameEtcdPeerCA || volMount.Name == common.VolumeNameEtcdPeerServerTLS {
+			containerPeerTLSVolMounts = append(containerPeerTLSVolMounts, volMount)
+		}
+	}
+	return len(containerPeerTLSVolMounts) != len(newEtcdWrapperPeerTLSVolMounts)
+}
+
+func isStatefulSetTLSConfigInSync(etcd *druidv1alpha1.Etcd, existingSts *appsv1.StatefulSet) bool {
 	newEtcdbrTLSVolMounts := getBackupRestoreContainerSecretVolumeMounts(etcd)
 	newEtcdWrapperTLSVolMounts := getEtcdContainerSecretVolumeMounts(etcd)
-	containerTLSVolMounts := utils.GetStatefulSetContainerTLSVolumeMounts(sts)
+	containerTLSVolMounts := utils.GetStatefulSetContainerTLSVolumeMounts(existingSts)
 	return !hasTLSVolumeMountsChanged(containerTLSVolMounts[common.ContainerNameEtcd], newEtcdWrapperTLSVolMounts) &&
 		!hasTLSVolumeMountsChanged(containerTLSVolMounts[common.ContainerNameEtcdBackupRestore], newEtcdbrTLSVolMounts)
 }

--- a/internal/utils/statefulset.go
+++ b/internal/utils/statefulset.go
@@ -111,6 +111,9 @@ var (
 // It will look at both older names (present in version <= v0.22) and new names (present in version >= v0.23) to create the slice.
 func GetEtcdContainerPeerTLSVolumeMounts(sts *appsv1.StatefulSet) []corev1.VolumeMount {
 	volumeMounts := make([]corev1.VolumeMount, 0, 2)
+	if sts == nil {
+		return volumeMounts
+	}
 	for _, container := range sts.Spec.Template.Spec.Containers {
 		if container.Name == common.ContainerNameEtcd {
 			for _, volMount := range container.VolumeMounts {
@@ -127,6 +130,9 @@ func GetEtcdContainerPeerTLSVolumeMounts(sts *appsv1.StatefulSet) []corev1.Volum
 // GetStatefulSetContainerTLSVolumeMounts returns a map of container name to TLS volume mounts for the given StatefulSet.
 func GetStatefulSetContainerTLSVolumeMounts(sts *appsv1.StatefulSet) map[string][]corev1.VolumeMount {
 	containerVolMounts := make(map[string][]corev1.VolumeMount, 2) // each pod is a 2 container pod. Init containers are not counted as containers.
+	if sts == nil {
+		return containerVolMounts
+	}
 	for _, container := range sts.Spec.Template.Spec.Containers {
 		if _, ok := containerVolMounts[container.Name]; !ok {
 			// Assuming 6 volume mounts per container. If there are more in future then this map's capacity will be increased by the golang runtime.

--- a/internal/utils/statefulset_test.go
+++ b/internal/utils/statefulset_test.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gardener/etcd-druid/internal/common"
 	"strings"
 	"testing"
 
 	"github.com/gardener/etcd-druid/internal/client/kubernetes"
+	"github.com/gardener/etcd-druid/internal/common"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -304,6 +304,7 @@ func TestGetEtcdContainerPeerTLSVolumeMounts(t *testing.T) {
 	t.Parallel()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			var sts *appsv1.StatefulSet
 			if tc.isSTSNil {
 				g.Expect(GetEtcdContainerPeerTLSVolumeMounts(sts)).To(HaveLen(0))
@@ -371,6 +372,7 @@ func TestGetStatefulSetContainerTLSVolumeMounts(t *testing.T) {
 	t.Parallel()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			var sts *appsv1.StatefulSet
 			if tc.isSTSNil {
 				g.Expect(GetStatefulSetContainerTLSVolumeMounts(sts)).To(HaveLen(0))

--- a/internal/utils/statefulset_test.go
+++ b/internal/utils/statefulset_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/gardener/etcd-druid/internal/common"
 	"strings"
 	"testing"
 
@@ -266,6 +267,131 @@ func TestFetchPVCWarningMessagesForStatefulSet(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(strings.Contains(messages, tc.expectedMsg)).To(BeTrue())
+			}
+		})
+	}
+}
+
+func TestGetEtcdContainerPeerTLSVolumeMounts(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		isSTSNil             bool
+		oldVolMountNames     bool
+		expectedVolumeMounts []corev1.VolumeMount
+	}{
+		{
+			name:                 "sts is nil",
+			isSTSNil:             true,
+			expectedVolumeMounts: []corev1.VolumeMount{},
+		},
+		{
+			name:             "sts with old volume mount names",
+			oldVolMountNames: true,
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{Name: common.OldVolumeNameEtcdPeerCA, MountPath: common.VolumeMountPathEtcdPeerCA},
+				{Name: common.OldVolumeNameEtcdPeerServerTLS, MountPath: common.VolumeMountPathEtcdPeerServerTLS},
+			},
+		},
+		{
+			name: "sts with new volume mount names",
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{Name: common.VolumeNameEtcdPeerCA, MountPath: common.VolumeMountPathEtcdPeerCA},
+				{Name: common.VolumeNameEtcdPeerServerTLS, MountPath: common.VolumeMountPathEtcdPeerServerTLS},
+			},
+		},
+	}
+	g := NewWithT(t)
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sts *appsv1.StatefulSet
+			if tc.isSTSNil {
+				g.Expect(GetEtcdContainerPeerTLSVolumeMounts(sts)).To(HaveLen(0))
+			} else {
+				sts = testutils.CreateStatefulSet("test-sts", "test-ns", uuid.NewUUID(), 3)
+				sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, corev1.Container{Name: common.ContainerNameEtcd})
+				if tc.oldVolMountNames {
+					sts.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+						{Name: common.OldVolumeNameEtcdPeerCA, MountPath: common.VolumeMountPathEtcdPeerCA},
+						{Name: common.OldVolumeNameEtcdPeerServerTLS, MountPath: common.VolumeMountPathEtcdPeerServerTLS},
+					}
+				} else {
+					sts.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+						{Name: common.VolumeNameEtcdPeerCA, MountPath: common.VolumeMountPathEtcdPeerCA},
+						{Name: common.VolumeNameEtcdPeerServerTLS, MountPath: common.VolumeMountPathEtcdPeerServerTLS},
+					}
+				}
+				g.Expect(GetEtcdContainerPeerTLSVolumeMounts(sts)).To(Equal(tc.expectedVolumeMounts))
+			}
+		})
+	}
+}
+
+func TestGetStatefulSetContainerTLSVolumeMounts(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		isSTSNil             bool
+		peerTLSEnabled       bool
+		expectedVolumeMounts map[string][]corev1.VolumeMount
+	}{
+		{
+			name:                 "sts is nil",
+			isSTSNil:             true,
+			expectedVolumeMounts: map[string][]corev1.VolumeMount{},
+		},
+		{
+			name:           "sts with peer TLS enabled",
+			peerTLSEnabled: true,
+			expectedVolumeMounts: map[string][]corev1.VolumeMount{
+				common.ContainerNameEtcd: {
+					{Name: common.VolumeNameEtcdPeerCA, MountPath: common.VolumeMountPathEtcdPeerCA},
+					{Name: common.VolumeNameEtcdPeerServerTLS, MountPath: common.VolumeMountPathEtcdPeerServerTLS},
+				},
+				common.ContainerNameEtcdBackupRestore: {
+					{Name: common.VolumeNameBackupRestoreServerTLS, MountPath: common.VolumeMountPathBackupRestoreServerTLS},
+					{Name: common.VolumeNameEtcdCA, MountPath: common.VolumeMountPathEtcdCA},
+					{Name: common.VolumeNameEtcdClientTLS, MountPath: common.VolumeMountPathEtcdClientTLS},
+				},
+			},
+		},
+		{
+			name:           "sts with peer TLS disabled",
+			peerTLSEnabled: false,
+			expectedVolumeMounts: map[string][]corev1.VolumeMount{
+				common.ContainerNameEtcd: {},
+				common.ContainerNameEtcdBackupRestore: {
+					{Name: common.VolumeNameBackupRestoreServerTLS, MountPath: common.VolumeMountPathBackupRestoreServerTLS},
+					{Name: common.VolumeNameEtcdCA, MountPath: common.VolumeMountPathEtcdCA},
+					{Name: common.VolumeNameEtcdClientTLS, MountPath: common.VolumeMountPathEtcdClientTLS},
+				},
+			},
+		},
+	}
+	g := NewWithT(t)
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sts *appsv1.StatefulSet
+			if tc.isSTSNil {
+				g.Expect(GetStatefulSetContainerTLSVolumeMounts(sts)).To(HaveLen(0))
+			} else {
+				sts = testutils.CreateStatefulSet("test-sts", "test-ns", uuid.NewUUID(), 3)
+				sts.Spec.Template.Spec.Containers = []corev1.Container{
+					{Name: common.ContainerNameEtcd},
+					{Name: common.ContainerNameEtcdBackupRestore},
+				}
+				if tc.peerTLSEnabled {
+					sts.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+						{Name: common.VolumeNameEtcdPeerCA, MountPath: common.VolumeMountPathEtcdPeerCA},
+						{Name: common.VolumeNameEtcdPeerServerTLS, MountPath: common.VolumeMountPathEtcdPeerServerTLS},
+					}
+				}
+				sts.Spec.Template.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{
+					{Name: common.VolumeNameBackupRestoreServerTLS, MountPath: common.VolumeMountPathBackupRestoreServerTLS},
+					{Name: common.VolumeNameEtcdCA, MountPath: common.VolumeMountPathEtcdCA},
+					{Name: common.VolumeNameEtcdClientTLS, MountPath: common.VolumeMountPathEtcdClientTLS},
+				}
+				g.Expect(GetStatefulSetContainerTLSVolumeMounts(sts)).To(Equal(tc.expectedVolumeMounts))
 			}
 		})
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The issue is described well in https://github.com/gardener/etcd-druid/issues/908. This PR allows etcd-druid to patch the StatefulSet allowing the unhealthy pod to come up eventually if what has changed is only TLS volume mount path.

> **NOTE:** If the TLS has been enabled for peer URL and is still not been reflected in StatefulSet then to ensure that the cluster  comes up post update of StatefulSet, it is essential that all members be up and running in a 3 member cluster. Therefore that  restriction will still be in place. What this PR does is relax this restriction in case only the mount paths have changed.
v0.23.x changes the mount paths for TLS volumes.

Additionally it also now adds an additional label to the etcd client and peer service to ensure that only statefulset pods are selected by it.

**Which issue(s) this PR fixes**:
Fixes #908 and #914

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes etcd client and peer service label selector, ensuring that only Etcd statefulset pods are selected.
```
```bugfix operator
etcd controller now differentiates between TLS configuration change and peer TLS enablement. Only if peer TLS has been enabled and not yet reflected it will wait for all pods to come up else it will allow patching of statefulset.
```
