### PR TITLE
Upgrade the `alpine` image version to `3.20.3`.

### DIFF
--- a/internal/images/images.yaml
+++ b/internal/images/images.yaml
@@ -21,4 +21,4 @@ images:
   tag: "v0.2.0"
 - name: alpine
   repository: europe-docker.pkg.dev/gardener-project/public/3rd/alpine
-  tag: "3.18.4"
+  tag: "3.20.3"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:

Upgrade `alpine` image version to the (latest as of writing) `3.20.3`, used by the init container when the `UseEtcdWrapper` feature gate is enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrade the `alpine` image version to `3.20.3`
```
