### PR TITLE
[CherryPick-915] Fix to allow etcd-druid to patch STS when there is only a change of m…

### DIFF
--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -121,8 +121,14 @@ const (
 	VolumeNameEtcdClientTLS = "etcd-client-tls"
 	// VolumeNameEtcdPeerCA is the name of the volume that contains the CA certificate bundle and CA certificate key used to sign certificates for peer communication.
 	VolumeNameEtcdPeerCA = "etcd-peer-ca"
+	// OldVolumeNameEtcdPeerCA is the old name of the volume that contains the CA certificate bundle and CA certificate key used to sign certificates for peer communication.
+	// TODO: (i062009) remove this when all clusters have started to use the new volume names.
+	OldVolumeNameEtcdPeerCA = "peer-url-ca-etcd"
 	// VolumeNameEtcdPeerServerTLS is the name of the volume that contains the server certificate-key pair used to set up the peer server.
 	VolumeNameEtcdPeerServerTLS = "etcd-peer-server-tls"
+	// OldVolumeNameEtcdPeerServerTLS is the old name of the volume that contains the server certificate-key pair used to set up the peer server.
+	// TODO: (i062009) remove this when all clusters have started to use the new volume names.
+	OldVolumeNameEtcdPeerServerTLS = "peer-url-etcd-server-tls"
 	// VolumeNameBackupRestoreCA is the name of the volume that contains the CA certificate bundle and CA certificate key used to sign certificates for backup-restore communication.
 	VolumeNameBackupRestoreCA = "backup-restore-ca"
 	// VolumeNameBackupRestoreServerTLS is the name of the volume that contains the server certificate-key pair used to set up the backup-restore server.

--- a/internal/component/clientservice/clientservice.go
+++ b/internal/component/clientservice/clientservice.go
@@ -111,7 +111,9 @@ func buildResource(etcd *druidv1alpha1.Etcd, svc *corev1.Service) {
 	svc.OwnerReferences = []metav1.OwnerReference{druidv1alpha1.GetAsOwnerReference(etcd.ObjectMeta)}
 	svc.Spec.Type = corev1.ServiceTypeClusterIP
 	svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
-	svc.Spec.Selector = druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta)
+	// Client service should only target StatefulSet pods. Default labels are going to be present on anything that is managed by etcd-druid and started for an etcd cluster.
+	// Therefore, only using default labels as label selector can cause issues as we have already seen in https://github.com/gardener/etcd-druid/issues/914
+	svc.Spec.Selector = utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	svc.Spec.Ports = getPorts(etcd)
 }
 

--- a/internal/component/clientservice/clientservice_test.go
+++ b/internal/component/clientservice/clientservice_test.go
@@ -272,6 +272,7 @@ func matchClientService(g *WithT, etcd *druidv1alpha1.Etcd, actualSvc corev1.Ser
 		expectedAnnotations = etcd.Spec.Etcd.ClientService.Annotations
 		expectedLabels = utils.MergeMaps(etcd.Spec.Etcd.ClientService.Labels, druidv1alpha1.GetDefaultLabels(etcdObjMeta))
 	}
+	expectedLabelSelector := utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcdObjMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 
 	g.Expect(actualSvc).To(MatchFields(IgnoreExtras, Fields{
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{
@@ -284,7 +285,7 @@ func matchClientService(g *WithT, etcd *druidv1alpha1.Etcd, actualSvc corev1.Ser
 		"Spec": MatchFields(IgnoreExtras, Fields{
 			"Type":            Equal(corev1.ServiceTypeClusterIP),
 			"SessionAffinity": Equal(corev1.ServiceAffinityNone),
-			"Selector":        Equal(druidv1alpha1.GetDefaultLabels(etcdObjMeta)),
+			"Selector":        Equal(expectedLabelSelector),
 			"Ports": ConsistOf(
 				Equal(corev1.ServicePort{
 					Name:       "client",

--- a/internal/component/peerservice/peerservice.go
+++ b/internal/component/peerservice/peerservice.go
@@ -111,7 +111,9 @@ func buildResource(etcd *druidv1alpha1.Etcd, svc *corev1.Service) {
 	svc.Spec.Type = corev1.ServiceTypeClusterIP
 	svc.Spec.ClusterIP = corev1.ClusterIPNone
 	svc.Spec.SessionAffinity = corev1.ServiceAffinityNone
-	svc.Spec.Selector = druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta)
+	// Peer service should only target StatefulSet pods. Default labels are going to be present on anything that is managed by etcd-druid and started for an etcd cluster.
+	// Therefore, only using default labels as label selector can cause issues as we have already seen in https://github.com/gardener/etcd-druid/issues/914
+	svc.Spec.Selector = utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	svc.Spec.PublishNotReadyAddresses = true
 	svc.Spec.Ports = getPorts(etcd)
 }

--- a/internal/component/peerservice/peerservice_test.go
+++ b/internal/component/peerservice/peerservice_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gardener/etcd-druid/internal/common"
 	"github.com/gardener/etcd-druid/internal/component"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
+	"github.com/gardener/etcd-druid/internal/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	"github.com/go-logr/logr"
@@ -246,6 +247,7 @@ func newPeerService(etcd *druidv1alpha1.Etcd) *corev1.Service {
 func matchPeerService(g *WithT, etcd *druidv1alpha1.Etcd, actualSvc corev1.Service) {
 	peerPort := ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)
 	etcdObjMeta := etcd.ObjectMeta
+	expectedLabelSelector := utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcdObjMeta), map[string]string{druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet})
 	g.Expect(actualSvc).To(MatchFields(IgnoreExtras, Fields{
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 			"Name":            Equal(druidv1alpha1.GetPeerServiceName(etcdObjMeta)),
@@ -257,7 +259,7 @@ func matchPeerService(g *WithT, etcd *druidv1alpha1.Etcd, actualSvc corev1.Servi
 			"Type":            Equal(corev1.ServiceTypeClusterIP),
 			"ClusterIP":       Equal(corev1.ClusterIPNone),
 			"SessionAffinity": Equal(corev1.ServiceAffinityNone),
-			"Selector":        Equal(druidv1alpha1.GetDefaultLabels(etcdObjMeta)),
+			"Selector":        Equal(expectedLabelSelector),
 			"Ports": ConsistOf(
 				Equal(corev1.ServicePort{
 					Name:       "peer",

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -708,8 +708,22 @@ func getEtcdContainerSecretVolumeMounts(etcd *druidv1alpha1.Etcd) []corev1.Volum
 			},
 		)
 	}
-	if etcd.Spec.Etcd.PeerUrlTLS != nil {
+	secretVolumeMounts = append(secretVolumeMounts, getEtcdContainerPeerVolumeMounts(etcd)...)
+	if etcd.Spec.Backup.TLS != nil {
 		secretVolumeMounts = append(secretVolumeMounts,
+			corev1.VolumeMount{
+				Name:      common.VolumeNameBackupRestoreCA,
+				MountPath: common.VolumeMountPathBackupRestoreCA,
+			},
+		)
+	}
+	return secretVolumeMounts
+}
+
+func getEtcdContainerPeerVolumeMounts(etcd *druidv1alpha1.Etcd) []corev1.VolumeMount {
+	peerTLSVolMounts := make([]corev1.VolumeMount, 0, 2)
+	if etcd.Spec.Etcd.PeerUrlTLS != nil {
+		peerTLSVolMounts = append(peerTLSVolMounts,
 			corev1.VolumeMount{
 				Name:      common.VolumeNameEtcdPeerCA,
 				MountPath: common.VolumeMountPathEtcdPeerCA,
@@ -720,15 +734,7 @@ func getEtcdContainerSecretVolumeMounts(etcd *druidv1alpha1.Etcd) []corev1.Volum
 			},
 		)
 	}
-	if etcd.Spec.Backup.TLS != nil {
-		secretVolumeMounts = append(secretVolumeMounts,
-			corev1.VolumeMount{
-				Name:      common.VolumeNameBackupRestoreCA,
-				MountPath: common.VolumeMountPathBackupRestoreCA,
-			},
-		)
-	}
-	return secretVolumeMounts
+	return peerTLSVolMounts
 }
 
 // getPodVolumes gets volumes that needs to be mounted onto the etcd StatefulSet pods

--- a/internal/utils/statefulset.go
+++ b/internal/utils/statefulset.go
@@ -92,13 +92,47 @@ func FetchPVCWarningMessagesForStatefulSet(ctx context.Context, cl client.Client
 }
 
 var (
-	etcdTLSVolumeMountNames   = sets.New[string](common.VolumeNameEtcdCA, common.VolumeNameEtcdServerTLS, common.VolumeNameEtcdClientTLS, common.VolumeNameEtcdPeerCA, common.VolumeNameEtcdPeerServerTLS, common.VolumeNameBackupRestoreCA)
-	etcdbrTLSVolumeMountNames = sets.New[string](common.VolumeNameBackupRestoreServerTLS, common.VolumeNameEtcdCA, common.VolumeNameEtcdClientTLS)
+	etcdTLSVolumeMountNames = sets.New[string](common.VolumeNameEtcdCA,
+		common.VolumeNameEtcdServerTLS,
+		common.VolumeNameEtcdClientTLS,
+		common.VolumeNameEtcdPeerCA,
+		common.VolumeNameEtcdPeerServerTLS,
+		common.VolumeNameBackupRestoreCA)
+	possiblePeerTLSVolumeMountNames = sets.New[string](common.VolumeNameEtcdPeerCA,
+		common.OldVolumeNameEtcdPeerCA,
+		common.VolumeNameEtcdPeerServerTLS,
+		common.OldVolumeNameEtcdPeerServerTLS)
+	etcdbrTLSVolumeMountNames = sets.New[string](common.VolumeNameBackupRestoreServerTLS,
+		common.VolumeNameEtcdCA,
+		common.VolumeNameEtcdClientTLS)
 )
+
+// GetEtcdContainerPeerTLSVolumeMounts returns the volume mounts for the etcd container that are related to peer TLS.
+// It will look at both older names (present in version <= v0.22) and new names (present in version >= v0.23) to create the slice.
+func GetEtcdContainerPeerTLSVolumeMounts(sts *appsv1.StatefulSet) []corev1.VolumeMount {
+	volumeMounts := make([]corev1.VolumeMount, 0, 2)
+	if sts == nil {
+		return volumeMounts
+	}
+	for _, container := range sts.Spec.Template.Spec.Containers {
+		if container.Name == common.ContainerNameEtcd {
+			for _, volMount := range container.VolumeMounts {
+				if possiblePeerTLSVolumeMountNames.Has(volMount.Name) {
+					volumeMounts = append(volumeMounts, volMount)
+				}
+			}
+			break
+		}
+	}
+	return volumeMounts
+}
 
 // GetStatefulSetContainerTLSVolumeMounts returns a map of container name to TLS volume mounts for the given StatefulSet.
 func GetStatefulSetContainerTLSVolumeMounts(sts *appsv1.StatefulSet) map[string][]corev1.VolumeMount {
 	containerVolMounts := make(map[string][]corev1.VolumeMount, 2) // each pod is a 2 container pod. Init containers are not counted as containers.
+	if sts == nil {
+		return containerVolMounts
+	}
 	for _, container := range sts.Spec.Template.Spec.Containers {
 		if _, ok := containerVolMounts[container.Name]; !ok {
 			// Assuming 6 volume mounts per container. If there are more in future then this map's capacity will be increased by the golang runtime.


### PR DESCRIPTION
…ount-path even if all pods are not up and running (#915)

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Cherry pick of PR #915 

**Which issue(s) this PR fixes**:
Fixes #908 and #914

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes etcd client and peer service label selector, ensuring that only Etcd statefulset pods are selected.
```
```bugfix operator
etcd controller now differentiates between TLS configuration change and peer TLS enablement. Only if peer TLS has been enabled and not yet reflected it will wait for all pods to come up else it will allow patching of statefulset.
```
