### PR TITLE
[hotfix-v0.24] Upgrade dependency on `github.com/gardener/etcd-backup-restore` to `v0.31.1`. (#927)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gardener/etcd-druid
 go 1.23.3
 
 require (
-	github.com/gardener/etcd-backup-restore v0.31.0
+	github.com/gardener/etcd-backup-restore v0.31.1
 	github.com/gardener/gardener v1.99.1
 	github.com/go-logr/logr v1.4.2
 	github.com/golang-jwt/jwt/v5 v5.2.1

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gardener/cert-management v0.15.0 h1:ohm1eWae2rQSkwFGWXTt+lBv4rLBhtJsJgqvaXJBs6o=
 github.com/gardener/cert-management v0.15.0/go.mod h1:3BK2VEtGwv2ijf3bSziTLMCUvYnPzIQrQ/uPeZzL4m0=
-github.com/gardener/etcd-backup-restore v0.31.0 h1:ViOdO0AF605QvjHQuZVpxmpEemWhKNQubr44Ci7xa2U=
-github.com/gardener/etcd-backup-restore v0.31.0/go.mod h1:GuH9nJjOwXFsh4nifDLY2McgEXArdhS22msBliYJ6y4=
+github.com/gardener/etcd-backup-restore v0.31.1 h1:l53jFhD0zzJKKwZYuDjj3O340jVY1zNNdabz/4pHA90=
+github.com/gardener/etcd-backup-restore v0.31.1/go.mod h1:5kakxyoDtx/vwWjQIOIGN6dTrx2TxRb8eLHtgrwBkMw=
 github.com/gardener/gardener v1.99.1 h1:c/wVXYgt4j7eHCMwxpQPPpaLXt1BY/IPYStfCtNsR8Q=
 github.com/gardener/gardener v1.99.1/go.mod h1:XboPwJptOg9ZfXTjuohGk7X8kxnF0o88gJnz6Ed7Vqc=
 github.com/gardener/hvpa-controller/api v0.15.0 h1:igsalL5Z6kFMn1+Kv1Eq0cRjYW+4oBA1aEY/yDO2QtI=

--- a/internal/images/images.yaml
+++ b/internal/images/images.yaml
@@ -14,7 +14,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.31.0"
+  tag: "v0.31.1"
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/area delivery
/kind enhancement

**What this PR does / why we need it**:

Cherry-pick of #927 

* Upgrade dependency on `github.com/gardener/etcd-backup-restore` to `v0.31.1`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
Upgraded `github.com/gardener/etcd-backup-restore` dependency from `0.31.0` to `0.31.1`.
```

```noteworthy operator
Upgraded `etcd-backup-restore` image version to `v0.31.1`.
```
