### PR TITLE
[hotfix-v0.24] Use `x.y.0` versions of the Go Toolchain only. (#925)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/etcd-druid
 
-go 1.23.3
+go 1.23.0
 
 require (
 	github.com/gardener/etcd-backup-restore v0.31.1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind task

**What this PR does / why we need it**:

Cherry-pick of #925 

Adhere to https://github.com/gardener/gardener/pull/9564

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

@gardener/etcd-druid-maintainers 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
`etcd-druid` will henceforth stick to Go versions `x.y.0` only to be in line with gardener/gardener, kubernetes, controller-runtime.
```
