### PR TITLE
Enhance the `check` make target to ensure the Go version adheres to `x.y.0`.

### DIFF
--- a/hack/check.sh
+++ b/hack/check.sh
@@ -34,4 +34,19 @@ if [[ "$unformatted_files" ]]; then
   exit 1
 fi
 
+echo "Checking Go version"
+while IFS= read -r line
+do
+  if [[ $line =~ ^go.*$ ]]; then
+    if [[ $line =~ ^go\ [0-9]+\.[0-9]+\.0$ ]]; then
+        # Go version is valid, adheres to x.y.0 version
+        exit 0
+    else
+        echo "Go version is invalid, please adhere to x.y.0 version"
+        echo "See https://github.com/gardener/etcd-druid/pull/925"
+        exit 1
+    fi
+  fi
+done < "go.mod"
+
 echo "All checks successful"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind post-mortem

**What this PR does / why we need it**:

Enhance the `check` make target to ensure the Go version adheres to `x.y.0`.

This is needed since release v0.24.0 could not be directly consumed by gardener/gardener because of the Go version convention. This enhancement ensures that Go patch versions are not upgraded in `go.mod` henceforth.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Enhanced the `check` make target to ensure the Go version adheres to `x.y.0`.
```
