### PR TITLE
Update e2e test infra ubuntu image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ test-cov-clean:
 	@$(HACK_DIR)/test-cover-clean.sh
 
 .PHONY: test-e2e
-test-e2e: $(KUBECTL) $(HELM) $(SKAFFOLD) $(KUSTOMIZE)
+test-e2e: $(KUBECTL) $(HELM) $(SKAFFOLD) $(KUSTOMIZE) $(GINKGO)
 	@VERSION=$(VERSION) GIT_SHA=$(GIT_SHA) $(HACK_DIR)/e2e-test/run-e2e-test.sh $(PROVIDERS)
 
 .PHONY: ci-e2e-kind

--- a/hack/e2e-test/infrastructure/base/job.yaml
+++ b/hack/e2e-test/infrastructure/base/job.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: infra
-        image: ubuntu:23.10
+        image: ubuntu:24.04
         command: ["/bin/bash"]
         args: ["-c", "/var/lib/infra/data/run/run.sh"]
         volumeMounts:

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -638,7 +638,7 @@ func getPurgeLocalSnapstoreJob(storeContainer, storePrefix string) *batchv1.Job 
 			Containers: []corev1.Container{
 				{
 					Name:    "infra",
-					Image:   "ubuntu:23.10",
+					Image:   "ubuntu:24.04",
 					Command: []string{"/bin/bash"},
 					Args: []string{"-c",
 						fmt.Sprintf("rm -rf /host-dir-etc/gardener/local-backupbuckets/%s/%s/*", storeContainer, storePrefix),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task

**What this PR does / why we need it**:
- [x] Update ubuntu image used by e2e test infra job from 23.10 to 24.04 (LTS) - currently 23.10 is facing errors with `apt update` updating packages from ubuntu package repositories, due to which infra job fails
- [x] Add ginkgo as dependency to `make test-e2e` so that the latest version of ginkgo is installed, matching the ginkgo version used in go.mod

**Which issue(s) this PR fixes**:
Fixes #932 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
