### PR TITLE
Promote `UseEtcdWrapper` feature gate to GA

### DIFF
--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -11,8 +11,7 @@ resources:
     cpu: 50m
     memory: 128Mi
 
-featureGates:
-  UseEtcdWrapper: true
+featureGates: {}
 
 controllerManager:
   server:

--- a/docs/deployment/feature-gates.md
+++ b/docs/deployment/feature-gates.md
@@ -20,15 +20,16 @@ The following tables are a summary of the feature gates that you can set on etcd
 
 ## Feature Gates for Alpha or Beta Features
 
-| Feature          | Default | Stage   | Since  | Until |
-|------------------|---------|---------|--------|-------|
-| `UseEtcdWrapper` | `false` | `Alpha` | `0.19` | `0.21`|
-| `UseEtcdWrapper` | `true`  | `Beta`  | `0.22` |       |
+| Feature | Default | Stage | Since | Until |
+|---------|---------|-------|-------|-------|
 
 ## Feature Gates for Graduated or Deprecated Features
 
-| Feature | Default | Stage | Since | Until |
-|---------|---------|-------|-------|-------|
+| Feature          | Default | Stage   | Since  | Until  |
+|------------------|---------|---------|--------|--------|
+| `UseEtcdWrapper` | `false` | `Alpha` | `0.19` | `0.21` |
+| `UseEtcdWrapper` | `true`  | `Beta`  | `0.22` | `0.24` |
+| `UseEtcdWrapper` | `true`  | `GA`    | `0.25` |        |
 
 ## Using a Feature
 

--- a/internal/controller/compaction/config.go
+++ b/internal/controller/compaction/config.go
@@ -8,16 +8,13 @@ import (
 	"time"
 
 	"github.com/gardener/etcd-druid/internal/controller/utils"
-	"github.com/gardener/etcd-druid/internal/features"
 
 	flag "github.com/spf13/pflag"
 	"k8s.io/component-base/featuregate"
 )
 
 // featureList holds the feature gate names that are relevant for the Compaction Controller.
-var featureList = []featuregate.Feature{
-	features.UseEtcdWrapper,
-}
+var featureList []featuregate.Feature
 
 const (
 	enableBackupCompactionFlagName    = "enable-backup-compaction"

--- a/internal/controller/etcd/config.go
+++ b/internal/controller/etcd/config.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/gardener/etcd-druid/internal/controller/utils"
-	"github.com/gardener/etcd-druid/internal/features"
 
 	gardenerconstants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	flag "github.com/spf13/pflag"
@@ -39,9 +38,7 @@ const (
 )
 
 // featureList holds the feature gate names that are relevant for the Etcd Controller.
-var featureList = []featuregate.Feature{
-	features.UseEtcdWrapper,
-}
+var featureList []featuregate.Feature
 
 // Config defines the configuration for the Etcd Controller.
 type Config struct {

--- a/internal/controller/etcd/reconciler.go
+++ b/internal/controller/etcd/reconciler.go
@@ -126,7 +126,7 @@ func createAndInitializeOperatorRegistry(client client.Client, config *Config, i
 	reg.Register(component.PodDisruptionBudgetKind, poddistruptionbudget.New(client))
 	reg.Register(component.RoleKind, role.New(client))
 	reg.Register(component.RoleBindingKind, rolebinding.New(client))
-	reg.Register(component.StatefulSetKind, statefulset.New(client, imageVector, config.FeatureGates))
+	reg.Register(component.StatefulSetKind, statefulset.New(client, imageVector))
 	return reg
 }
 

--- a/internal/controller/etcdcopybackupstask/config.go
+++ b/internal/controller/etcdcopybackupstask/config.go
@@ -6,16 +6,13 @@ package etcdcopybackupstask
 
 import (
 	"github.com/gardener/etcd-druid/internal/controller/utils"
-	"github.com/gardener/etcd-druid/internal/features"
 
 	flag "github.com/spf13/pflag"
 	"k8s.io/component-base/featuregate"
 )
 
 // featureList holds the feature gate names that are relevant for the EtcdCopyBackupTask Controller.
-var featureList = []featuregate.Feature{
-	features.UseEtcdWrapper,
-}
+var featureList []featuregate.Feature
 
 const (
 	workersFlagName = "etcd-copy-backups-task-workers"

--- a/internal/controller/etcdcopybackupstask/reconciler_test.go
+++ b/internal/controller/etcdcopybackupstask/reconciler_test.go
@@ -460,7 +460,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 				})
 
 				It("should create the correct volume mounts", func() {
-					volumeMounts := createVolumeMountsFromStore(storeSpec, provider, volumeMountPrefix, false)
+					volumeMounts := createVolumeMountsFromStore(storeSpec, provider, volumeMountPrefix)
 					Expect(volumeMounts).To(HaveLen(1))
 
 					expectedMountPath := ""
@@ -469,7 +469,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 					switch provider {
 					case druidstore.Local:
 						expectedMountName = volumeMountPrefix + "host-storage"
-						expectedMountPath = *storeSpec.Container
+						expectedMountPath = "/home/nonroot/" + *storeSpec.Container
 					case druidstore.GCS:
 						expectedMountName = volumeMountPrefix + common.VolumeNameProviderBackupSecret
 						expectedMountPath = getGCSSecretVolumeMountPathWithPrefixAndSuffix(volumeMountPrefix, "/")

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -22,11 +22,12 @@ const (
 	// owner @unmarshall @aaronfern
 	// alpha: v0.19
 	// beta:  v0.22
+	// GA:    v0.25
 	UseEtcdWrapper featuregate.Feature = "UseEtcdWrapper"
 )
 
 var defaultFeatures = map[featuregate.Feature]featuregate.FeatureSpec{
-	UseEtcdWrapper: {Default: true, PreRelease: featuregate.Beta},
+	UseEtcdWrapper: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 }
 
 // GetDefaultFeatures returns the default feature gates known to etcd-druid.

--- a/internal/images/images.yaml
+++ b/internal/images/images.yaml
@@ -1,24 +1,14 @@
 images:
+- name: etcd-wrapper
+  sourceRepository: github.com/gardener/etcd-wrapper
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
+  tag: "v0.3.0"
 - name: etcd-backup-restore
   resourceId:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.24.9"
-- name: etcd
-  sourceRepository: github.com/gardener/etcd-custom-image
-  repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd
-  tag: "v3.4.26-7"
-- name: etcd-backup-restore-distroless
-  resourceId:
-    name: 'etcdbrctl'
-  sourceRepository: github.com/gardener/etcd-backup-restore
-  repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
   tag: "v0.32.0"
-- name: etcd-wrapper
-  sourceRepository: github.com/gardener/etcd-wrapper
-  repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
-  tag: "v0.3.0"
 - name: alpine
   repository: europe-docker.pkg.dev/gardener-project/public/3rd/alpine
   tag: "3.20.3"

--- a/internal/utils/image.go
+++ b/internal/utils/image.go
@@ -17,8 +17,8 @@ import (
 // It will give preference to images that are set in the etcd spec and only if the image is not found in it should
 // it be picked up from the image vector if it's set there.
 // A return value of nil for either of the images indicates that the image is not set.
-func GetEtcdImages(etcd *druidv1alpha1.Etcd, iv imagevector.ImageVector, useEtcdWrapper bool) (string, string, string, error) {
-	etcdImageKey, etcdBRImageKey, initContainerImageKey := getEtcdImageKeys(useEtcdWrapper)
+func GetEtcdImages(etcd *druidv1alpha1.Etcd, iv imagevector.ImageVector) (string, string, string, error) {
+	etcdImageKey, etcdBRImageKey, initContainerImageKey := getEtcdImageKeys()
 	etcdImage, err := chooseImage(etcdImageKey, etcd.Spec.Etcd.Image, iv)
 	if err != nil {
 		return "", "", "", err
@@ -35,16 +35,8 @@ func GetEtcdImages(etcd *druidv1alpha1.Etcd, iv imagevector.ImageVector, useEtcd
 	return *etcdImage, *etcdBackupRestoreImage, *initContainerImage, nil
 }
 
-func getEtcdImageKeys(useEtcdWrapper bool) (etcdImageKey string, etcdBRImageKey string, alpine string) {
-	alpine = common.ImageKeyAlpine
-	if useEtcdWrapper {
-		etcdImageKey = common.ImageKeyEtcdWrapper
-		etcdBRImageKey = common.ImageKeyEtcdBackupRestoreDistroless
-	} else {
-		etcdImageKey = common.ImageKeyEtcd
-		etcdBRImageKey = common.ImageKeyEtcdBackupRestore
-	}
-	return
+func getEtcdImageKeys() (string, string, string) {
+	return common.ImageKeyEtcdWrapper, common.ImageKeyEtcdBackupRestore, common.ImageKeyAlpine
 }
 
 // chooseImage selects an image based on the given key, specImage, and image vector.
@@ -62,8 +54,8 @@ func chooseImage(key string, specImage *string, iv imagevector.ImageVector) (*st
 }
 
 // GetEtcdBackupRestoreImage returns the image for backup-restore from the given image vector.
-func GetEtcdBackupRestoreImage(iv imagevector.ImageVector, useEtcdWrapper bool) (*string, error) {
-	_, etcdbrImageKey, _ := getEtcdImageKeys(useEtcdWrapper)
+func GetEtcdBackupRestoreImage(iv imagevector.ImageVector) (*string, error) {
+	_, etcdbrImageKey, _ := getEtcdImageKeys()
 	return chooseImage(etcdbrImageKey, nil, iv)
 }
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -62,14 +62,6 @@ profiles:
         value:
           etcdcomponents:
             enabled: true
-  - name: do-not-use-feature-gates
-    activation:
-      - env: "USE_ETCD_DRUID_FEATURE_GATES=false"
-    patches:
-      - op: add
-        path: /deploy/helm/releases/0/setValues/featureGates
-        value:
-          UseEtcdWrapper: false
 ---
 apiVersion: skaffold/v4beta10
 kind: Config

--- a/test/it/controller/etcd/helper.go
+++ b/test/it/controller/etcd/helper.go
@@ -13,7 +13,6 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/controller/etcd"
-	"github.com/gardener/etcd-druid/internal/features"
 	"github.com/gardener/etcd-druid/internal/utils"
 	"github.com/gardener/etcd-druid/test/it/controller/assets"
 	"github.com/gardener/etcd-druid/test/it/setup"
@@ -54,9 +53,7 @@ func initializeEtcdReconcilerTestEnv(t *testing.T, itTestEnv setup.DruidTestEnvi
 				EnableEtcdSpecAutoReconcile:        autoReconcile,
 				DisableEtcdServiceAccountAutomount: false,
 				EtcdStatusSyncPeriod:               2 * time.Second,
-				FeatureGates: map[featuregate.Feature]bool{
-					features.UseEtcdWrapper: true,
-				},
+				FeatureGates:                       map[featuregate.Feature]bool{},
 				EtcdMember: etcd.MemberConfig{
 					NotReadyThreshold: 5 * time.Minute,
 					UnknownThreshold:  1 * time.Minute,

--- a/test/utils/constants.go
+++ b/test/utils/constants.go
@@ -14,14 +14,10 @@ const (
 const (
 	// TestImageRepo is a constant for image repository name
 	TestImageRepo = "test-repo"
-	// ETCDImageSourceTag is the ImageSource tag for etcd image.
-	ETCDImageSourceTag = "etcd-test-tag"
 	// ETCDWrapperImageTag is the ImageSource tag for etcd-wrapper image.
 	ETCDWrapperImageTag = "etcd-wrapper-test-tag"
 	// ETCDBRImageTag is the ImageSource tag for etcd-backup-restore image.
 	ETCDBRImageTag = "backup-restore-test-tag"
-	// ETCDBRDistrolessImageTag is the ImageSource tag for etc-backup-restore distroless image.
-	ETCDBRDistrolessImageTag = "backup-restore-distroless-test-tag"
 	// InitContainerTag is the ImageSource tag for the init container image.
 	InitContainerTag = "init-container-test-tag"
 )

--- a/test/utils/imagevector.go
+++ b/test/utils/imagevector.go
@@ -12,13 +12,13 @@ import (
 )
 
 // CreateImageVector creates an image vector initializing it will different image sources.
-func CreateImageVector(withEtcdImage, withBackupRestoreImage, withEtcdWrapperImage, withBackupRestoreDistrolessImage bool) imagevector.ImageVector {
+func CreateImageVector(withEtcdWrapperImage, withBackupRestoreImage bool) imagevector.ImageVector {
 	var imageSources []*imagevector.ImageSource
-	if withEtcdImage {
+	if withEtcdWrapperImage {
 		imageSources = append(imageSources, &imagevector.ImageSource{
-			Name:       common.ImageKeyEtcd,
+			Name:       common.ImageKeyEtcdWrapper,
 			Repository: TestImageRepo,
-			Tag:        ptr.To(ETCDImageSourceTag),
+			Tag:        ptr.To(ETCDWrapperImageTag),
 		})
 	}
 	if withBackupRestoreImage {
@@ -28,20 +28,6 @@ func CreateImageVector(withEtcdImage, withBackupRestoreImage, withEtcdWrapperIma
 			Tag:        ptr.To(ETCDBRImageTag),
 		})
 
-	}
-	if withEtcdWrapperImage {
-		imageSources = append(imageSources, &imagevector.ImageSource{
-			Name:       common.ImageKeyEtcdWrapper,
-			Repository: TestImageRepo,
-			Tag:        ptr.To(ETCDWrapperImageTag),
-		})
-	}
-	if withBackupRestoreDistrolessImage {
-		imageSources = append(imageSources, &imagevector.ImageSource{
-			Name:       common.ImageKeyEtcdBackupRestoreDistroless,
-			Repository: TestImageRepo,
-			Tag:        ptr.To(ETCDBRDistrolessImageTag),
-		})
 	}
 	imageSources = append(imageSources, &imagevector.ImageSource{
 		Name:       common.ImageKeyAlpine,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality open-source usability
/kind task

**What this PR does / why we need it**:
The feature gate `UseEtcdWrapper` has now been promoted to GA, and locked to true. The related code has been cleaned up. The feature gate will finally be removed in #935 .

**Which issue(s) this PR fixes**:
Fixes partially #776 

**Special notes for your reviewer**:
/assign @seshachalam-yv @ishan16696 
/cc @unmarshall @aaronfern 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The `UseEtcdWrapper` feature gate has been promoted to GA and locked to `true`.
```
