### PR TITLE
Fix indentation of skaffold.yaml

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -133,9 +133,9 @@ profiles:
         value: {
           "host": {
             "command": [ sh, -c, '
-      echo "Copying GCP service account json" &&
-      touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" &&
-      cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"' ],
+            echo "Copying GCP service account json" &&
+            touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" && 
+            cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"' ],
             "os": [ darwin, linux ]
           }
         }
@@ -150,9 +150,9 @@ profiles:
         value: {
           "host": {
             "command": [ sh, -c, '
-      echo "Copying GCP service account json" &&
-      touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" &&
-      cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"' ],
+            echo "Copying GCP service account json" && 
+            touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" && 
+            cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"' ],
             "os": [ darwin, linux ]
           }
         }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
This PR fixes the indentation problem of `skaffold.yaml` to run druid e2e tests with `make ci-e2e-kind`.


**Which issue(s) this PR fixes**:
Fixes #938 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
