### PR TITLE
Refactor skaffold profiles to use manifests field instead of patches

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -95,76 +95,74 @@ deploy:
                 fi
                 kubectl wait --for=condition=Complete job -l role=infra-job --timeout=5m $namespace_flag
             os: [ darwin, linux ]
-manifests:
-  kustomize: { }
 profiles:
   # Profile to create the required S3 backup bucket for an e2e test.
   - name: aws-setup
-    patches:
-      - op: add
-        path: /manifests/kustomize/paths
-        value: [ hack/e2e-test/infrastructure/overlays/aws/setup ]
+    manifests:
+      kustomize:
+        paths:
+          - hack/e2e-test/infrastructure/overlays/aws/setup
   # Profile to delete the S3 backup bucket from an e2e test.
   - name: aws-cleanup
-    patches:
-      - op: add
-        path: /manifests/kustomize/paths
-        value: [ hack/e2e-test/infrastructure/overlays/aws/cleanup ]
+    manifests:
+      kustomize:
+        paths:
+          - hack/e2e-test/infrastructure/overlays/aws/cleanup
   # Profile to create the required Azure storage container for an e2e test.
   - name: azure-setup
-    patches:
-      - op: add
-        path: /manifests/kustomize/paths
-        value: [ hack/e2e-test/infrastructure/overlays/azure/setup ]
+    manifests:
+      kustomize:
+        paths:
+          - hack/e2e-test/infrastructure/overlays/azure/setup
   # Profile to delete the Azure storage container from an e2e test.
   - name: azure-cleanup
-    patches:
-      - op: add
-        path: /manifests/kustomize/paths
-        value: [ hack/e2e-test/infrastructure/overlays/azure/cleanup ]
+    manifests:
+      kustomize:
+        paths:
+          - hack/e2e-test/infrastructure/overlays/azure/cleanup
   # Profile to create the required GCP backup bucket for an e2e test.
   - name: gcp-setup
-    patches:
-      - op: add
-        path: /manifests/kustomize/paths
-        value: [ hack/e2e-test/infrastructure/overlays/gcp/setup ]
-      - op: add
-        path: /manifests/kustomize/hooks/before/-
-        value: {
-          "host": {
-            "command": [ sh, -c, '
-      echo "Copying GCP service account json" &&
-      touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" &&
-      cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"' ],
-            "os": [ darwin, linux ]
-          }
-        }
+    manifests:
+      kustomize:
+        paths:
+          - hack/e2e-test/infrastructure/overlays/gcp/setup
+      hooks:
+        before:
+          - host:
+              command:
+                - sh
+                - -c
+                - |
+                  echo "Copying GCP service account json" &&
+                  touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" && 
+                  cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"
+              os: [ darwin, linux ]
   # Profile to delete the GCP backup bucket from an e2e test.
   - name: gcp-cleanup
-    patches:
-      - op: add
-        path: /manifests/kustomize/paths
-        value: [ hack/e2e-test/infrastructure/overlays/gcp/cleanup ]
-      - op: add
-        path: /manifests/kustomize/hooks/before/-
-        value: {
-          "host": {
-            "command": [ sh, -c, '
-      echo "Copying GCP service account json" &&
-      touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" &&
-      cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"' ],
-            "os": [ darwin, linux ]
-          }
-        }
+    manifests:
+      kustomize:
+        paths:
+          - hack/e2e-test/infrastructure/overlays/gcp/cleanup
+      hooks:
+        before:
+          - host:
+              command:
+                - sh
+                - -c
+                - |
+                  echo "Copying GCP service account json" && 
+                  touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" && 
+                  cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"
+              os: [ darwin, linux ]
   # Profile to create the required Local storage container for an e2e test.
   - name: local-setup
-    patches:
-      - op: add
-        path: /manifests/kustomize/paths
-        value: [ hack/e2e-test/infrastructure/overlays/local/setup ]
+    manifests:
+      kustomize:
+        paths:
+          - hack/e2e-test/infrastructure/overlays/local/setup
   # Profile to delete the Local storage container from an e2e test.
   - name: local-cleanup
-    patches:
-      - op: add
-        path: /manifests/kustomize/paths
-        value: [ hack/e2e-test/infrastructure/overlays/local/cleanup ]
+    manifests:
+      kustomize:
+        paths:
+          - hack/e2e-test/infrastructure/overlays/local/cleanup


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup



**What this PR does / why we need it**:
This PR refactors the Skaffold configuration to use the manifests field instead of applying patches. This change simplifies the configuration, making it more readable and easier to maintain

There were few issues with indentation and skaffold errors and those got fixed

```
Property echo "Copying GCP service account json" && touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" && cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"' ], "os" is not allowed.yaml-schema: skaffold.yaml
```
- `parsing skaffold config: error parsing skaffold configuration file: unknown skaffold config API version "skaffold/v4beta10". Set the config 'apiVersion' to a known value. Check https://skaffold.dev/docs/references/yaml/ for the list of valid API versions. Otherwise, check that your skaffold version is up-to-date.`



**Which issue(s) this PR fixes**:
Fixes #938

**Special notes for your reviewer**:
cc: @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
