### PR TITLE
Update golang version to 1.23.5

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,13 +42,13 @@ etcd-druid:
                 teamname: 'gardener/etcd-druid-maintainers'
     steps:
       check:
-        image: 'golang:1.23.4'
+        image: 'golang:1.23.5'
       test:
-        image: 'golang:1.23.4'
+        image: 'golang:1.23.5'
       test_integration:
-        image: 'golang:1.23.4'
+        image: 'golang:1.23.5'
       build:
-        image: 'golang:1.23.4'
+        image: 'golang:1.23.5'
         output_dir: 'binary'
 
   jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.4 as builder
+FROM golang:1.23.5 as builder
 WORKDIR /go/src/github.com/gardener/etcd-druid
 COPY . .
 


### PR DESCRIPTION
/area security compliance quality
/kind task

**What this PR does / why we need it**:
Update golang version to `1.23.5` which brings [security fixes](https://go.dev/doc/devel/release#go1.23.5).

**Release note**:
```other dependency
Update golang version to `1.23.5`.
```
