### PR TITLE
Remove deprecated API fields, CLI flag and annotation

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -20,9 +20,6 @@ const (
 
 // Annotation keys that can be placed on an Etcd custom resource.
 const (
-	// IgnoreReconciliationAnnotation is an annotation set by an operator in order to stop reconciliation.
-	// Deprecated: Please use SuspendEtcdSpecReconcileAnnotation instead
-	IgnoreReconciliationAnnotation = "druid.gardener.cloud/ignore-reconciliation"
 	// SuspendEtcdSpecReconcileAnnotation is an annotation set by an operator to temporarily suspend any etcd spec reconciliation.
 	SuspendEtcdSpecReconcileAnnotation = "druid.gardener.cloud/suspend-etcd-spec-reconcile"
 	// DisableEtcdComponentProtectionAnnotation is an annotation set by an operator to disable protection of components created for

--- a/api/v1alpha1/etcd.go
+++ b/api/v1alpha1/etcd.go
@@ -383,24 +383,12 @@ type EtcdStatus struct {
 	// Conditions represents the latest available observations of an etcd's current state.
 	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`
-	// ServiceName is the name of the etcd service.
-	// Deprecated: this field will be removed in the future.
-	// +optional
-	ServiceName *string `json:"serviceName,omitempty"`
-	// LastError represents the last occurred error.
-	// Deprecated: Use LastErrors instead.
-	// +optional
-	LastError *string `json:"lastError,omitempty"`
 	// LastErrors captures errors that occurred during the last operation.
 	// +optional
 	LastErrors []LastError `json:"lastErrors,omitempty"`
 	// LastOperation indicates the last operation performed on this resource.
 	// +optional
 	LastOperation *LastOperation `json:"lastOperation,omitempty"`
-	// Cluster size is the current size of the etcd cluster.
-	// Deprecated: this field will not be populated with any value and will be removed in the future.
-	// +optional
-	ClusterSize *int32 `json:"clusterSize,omitempty"`
 	// CurrentReplicas is the current replica count for the etcd cluster.
 	// +optional
 	CurrentReplicas int32 `json:"currentReplicas,omitempty"`
@@ -413,10 +401,6 @@ type EtcdStatus struct {
 	// Ready is `true` if all etcd replicas are ready.
 	// +optional
 	Ready *bool `json:"ready,omitempty"`
-	// UpdatedReplicas is the count of updated replicas in the etcd cluster.
-	// Deprecated: this field will be removed in the future.
-	// +optional
-	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
 	// LabelSelector is a label query over pods that should match the replica count.
 	// It must match the pod template's labels.
 	// Deprecated: this field will be removed in the future.

--- a/api/v1alpha1/helper.go
+++ b/api/v1alpha1/helper.go
@@ -108,9 +108,6 @@ func GetSuspendEtcdSpecReconcileAnnotationKey(etcdObjMeta metav1.ObjectMeta) *st
 	if metav1.HasAnnotation(etcdObjMeta, SuspendEtcdSpecReconcileAnnotation) {
 		return ptr.To(SuspendEtcdSpecReconcileAnnotation)
 	}
-	if metav1.HasAnnotation(etcdObjMeta, IgnoreReconciliationAnnotation) {
-		return ptr.To(IgnoreReconciliationAnnotation)
-	}
 	return nil
 }
 

--- a/api/v1alpha1/helper_test.go
+++ b/api/v1alpha1/helper_test.go
@@ -129,16 +129,6 @@ func TestGetSuspendEtcdSpecReconcileAnnotationKey(t *testing.T) {
 			annotations:           map[string]string{SuspendEtcdSpecReconcileAnnotation: ""},
 			expectedAnnotationKey: ptr.To(SuspendEtcdSpecReconcileAnnotation),
 		},
-		{
-			name:                  "IgnoreReconciliationAnnotation is set",
-			annotations:           map[string]string{IgnoreReconciliationAnnotation: ""},
-			expectedAnnotationKey: ptr.To(IgnoreReconciliationAnnotation),
-		},
-		{
-			name:                  "Both annotations (SuspendEtcdSpecReconcileAnnotation and IgnoreReconciliationAnnotation) are set",
-			annotations:           map[string]string{SuspendEtcdSpecReconcileAnnotation: "", IgnoreReconciliationAnnotation: ""},
-			expectedAnnotationKey: ptr.To(SuspendEtcdSpecReconcileAnnotation),
-		},
 	}
 	g := NewWithT(t)
 	t.Parallel()

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -576,16 +576,6 @@ func (in *EtcdStatus) DeepCopyInto(out *EtcdStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.ServiceName != nil {
-		in, out := &in.ServiceName, &out.ServiceName
-		*out = new(string)
-		**out = **in
-	}
-	if in.LastError != nil {
-		in, out := &in.LastError, &out.LastError
-		*out = new(string)
-		**out = **in
-	}
 	if in.LastErrors != nil {
 		in, out := &in.LastErrors, &out.LastErrors
 		*out = make([]LastError, len(*in))
@@ -597,11 +587,6 @@ func (in *EtcdStatus) DeepCopyInto(out *EtcdStatus) {
 		in, out := &in.LastOperation, &out.LastOperation
 		*out = new(LastOperation)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.ClusterSize != nil {
-		in, out := &in.ClusterSize, &out.ClusterSize
-		*out = new(int32)
-		**out = **in
 	}
 	if in.Ready != nil {
 		in, out := &in.Ready, &out.Ready

--- a/charts/druid/charts/crds/templates/crd-druid.gardener.cloud_etcds.yaml
+++ b/charts/druid/charts/crds/templates/crd-druid.gardener.cloud_etcds.yaml
@@ -1841,12 +1841,6 @@ spec:
           status:
             description: EtcdStatus defines the observed state of Etcd.
             properties:
-              clusterSize:
-                description: |-
-                  Cluster size is the current size of the etcd cluster.
-                  Deprecated: this field will not be populated with any value and will be removed in the future.
-                format: int32
-                type: integer
               conditions:
                 description: Conditions represents the latest available observations
                   of an etcd's current state.
@@ -1956,11 +1950,6 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              lastError:
-                description: |-
-                  LastError represents the last occurred error.
-                  Deprecated: Use LastErrors instead.
-                type: string
               lastErrors:
                 description: LastErrors captures errors that occurred during the last
                   operation.
@@ -2073,17 +2062,6 @@ spec:
                 type: integer
               replicas:
                 description: Replicas is the replica count of the etcd cluster.
-                format: int32
-                type: integer
-              serviceName:
-                description: |-
-                  ServiceName is the name of the etcd service.
-                  Deprecated: this field will be removed in the future.
-                type: string
-              updatedReplicas:
-                description: |-
-                  UpdatedReplicas is the count of updated replicas in the etcd cluster.
-                  Deprecated: this field will be removed in the future.
                 format: int32
                 type: integer
             type: object

--- a/config/crd/bases/crd-druid.gardener.cloud_etcds.yaml
+++ b/config/crd/bases/crd-druid.gardener.cloud_etcds.yaml
@@ -1841,12 +1841,6 @@ spec:
           status:
             description: EtcdStatus defines the observed state of Etcd.
             properties:
-              clusterSize:
-                description: |-
-                  Cluster size is the current size of the etcd cluster.
-                  Deprecated: this field will not be populated with any value and will be removed in the future.
-                format: int32
-                type: integer
               conditions:
                 description: Conditions represents the latest available observations
                   of an etcd's current state.
@@ -1956,11 +1950,6 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              lastError:
-                description: |-
-                  LastError represents the last occurred error.
-                  Deprecated: Use LastErrors instead.
-                type: string
               lastErrors:
                 description: LastErrors captures errors that occurred during the last
                   operation.
@@ -2073,17 +2062,6 @@ spec:
                 type: integer
               replicas:
                 description: Replicas is the replica count of the etcd cluster.
-                format: int32
-                type: integer
-              serviceName:
-                description: |-
-                  ServiceName is the name of the etcd service.
-                  Deprecated: this field will be removed in the future.
-                type: string
-              updatedReplicas:
-                description: |-
-                  UpdatedReplicas is the count of updated replicas in the etcd cluster.
-                  Deprecated: this field will be removed in the future.
                 format: int32
                 type: integer
             type: object

--- a/docs/api-reference/etcd-druid-api.md
+++ b/docs/api-reference/etcd-druid-api.md
@@ -417,16 +417,12 @@ _Appears in:_
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this resource. |  |  |
 | `etcd` _[CrossVersionObjectReference](#crossversionobjectreference)_ |  |  |  |
 | `conditions` _[Condition](#condition) array_ | Conditions represents the latest available observations of an etcd's current state. |  |  |
-| `serviceName` _string_ | ServiceName is the name of the etcd service.<br />Deprecated: this field will be removed in the future. |  |  |
-| `lastError` _string_ | LastError represents the last occurred error.<br />Deprecated: Use LastErrors instead. |  |  |
 | `lastErrors` _[LastError](#lasterror) array_ | LastErrors captures errors that occurred during the last operation. |  |  |
 | `lastOperation` _[LastOperation](#lastoperation)_ | LastOperation indicates the last operation performed on this resource. |  |  |
-| `clusterSize` _integer_ | Cluster size is the current size of the etcd cluster.<br />Deprecated: this field will not be populated with any value and will be removed in the future. |  |  |
 | `currentReplicas` _integer_ | CurrentReplicas is the current replica count for the etcd cluster. |  |  |
 | `replicas` _integer_ | Replicas is the replica count of the etcd cluster. |  |  |
 | `readyReplicas` _integer_ | ReadyReplicas is the count of replicas being ready in the etcd cluster. |  |  |
 | `ready` _boolean_ | Ready is `true` if all etcd replicas are ready. |  |  |
-| `updatedReplicas` _integer_ | UpdatedReplicas is the count of updated replicas in the etcd cluster.<br />Deprecated: this field will be removed in the future. |  |  |
 | `labelSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | LabelSelector is a label query over pods that should match the replica count.<br />It must match the pod template's labels.<br />Deprecated: this field will be removed in the future. |  |  |
 | `members` _[EtcdMemberStatus](#etcdmemberstatus) array_ | Members represents the members of the etcd cluster |  |  |
 | `peerUrlTLSEnabled` _boolean_ | PeerUrlTLSEnabled captures the state of peer url TLS being enabled for the etcd member(s) |  |  |

--- a/docs/deployment/configure-etcd-druid.md
+++ b/docs/deployment/configure-etcd-druid.md
@@ -65,7 +65,6 @@ Following set of flags configures the reconcilers running within etcd-druid. To 
 | etcd-status-sync-period               | `Etcd.Status` is periodically updated. This interval defines the status sync frequency. | 15s     |
 | etcd-member-notready-threshold        | Threshold after which an etcd member is considered not ready if the status was unknown before. This is currently used to update [EtcdMemberConditionStatus](https://github.com/gardener/etcd-druid/blob/55efca1c8f6c852b0a4e97f08488ffec2eed0e68/api/v1alpha1/etcd.go#L360). | 5m      |
 | etcd-member-unknown-threshold         | Threshold after which an etcd member is considered unknown. This is currently used to update [EtcdMemberConditionStatus](https://github.com/gardener/etcd-druid/blob/55efca1c8f6c852b0a4e97f08488ffec2eed0e68/api/v1alpha1/etcd.go#L360). | 1m      |
-| ignore-operation-annotation           | Specifies whether to ignore or honour the annotation `gardener.cloud/operation: reconcile` on resources to be reconciled.<br />**Deprecated:** please use `--enable-etcd-spec-auto-reconcile` instead. | false   |
 
 #### Compaction Reconciler
 

--- a/docs/usage/managing-etcd-clusters.md
+++ b/docs/usage/managing-etcd-clusters.md
@@ -53,13 +53,12 @@ There are two ways to control reconciliation of any changes done to `Etcd` custo
 
 #### Auto reconciliation
 
-If `etcd-druid` has been deployed with auto-reconciliation then any change done to an `Etcd` resource will be automatically reconciled. 
-Prior to v0.23.0 you can do this by using `--ignore-operation-annotation` CLI flag. This flag has been marked as deprecated and will be removed in later versions of `etcd-druid`. With etcd-druid version v0.23.x it is recommended that you use `--enable-etcd-spec-auto-reconcile` CLI flag to enable auto-reconcile.
+If `etcd-druid` has been deployed with auto-reconciliation then any change done to an `Etcd` resource will be automatically reconciled. You use `--enable-etcd-spec-auto-reconcile` CLI flag to enable auto-reconciliation of the etcd spec.
 
 > For a complete list of CLI args you can see [this](../deployment/configure-etcd-druid.md) document.
 
 #### Explicit reconciliation
-If `--enable-etcd-spec-auto-reconcile` or `--ignore-operation-annotation` is set to false or not set at all, then any change to an `Etcd` resource will not be automatically reconciled. To trigger a reconcile you must set the following annotation on the `Etcd` resource:
+If `--enable-etcd-spec-auto-reconcile` is set to false or not set at all, then any change to an `Etcd` resource will not be automatically reconciled. To trigger a reconcile you must set the following annotation on the `Etcd` resource:
 
 ```bash
 kubectl annotate etcd <etcd-name> gardener.cloud/operation=reconcile -n <namespace>

--- a/internal/controller/etcd/config.go
+++ b/internal/controller/etcd/config.go
@@ -19,7 +19,6 @@ import (
 // Flag names
 const (
 	workersFlagName                            = "etcd-workers"
-	ignoreOperationAnnotationFlagName          = "ignore-operation-annotation"
 	enableEtcdSpecAutoReconcileFlagName        = "enable-etcd-spec-auto-reconcile"
 	disableEtcdServiceAccountAutomountFlagName = "disable-etcd-serviceaccount-automount"
 	etcdStatusSyncPeriodFlagName               = "etcd-status-sync-period"
@@ -29,7 +28,6 @@ const (
 
 const (
 	defaultWorkers                            = 3
-	defaultIgnoreOperationAnnotation          = false
 	defaultDisableEtcdServiceAccountAutomount = false
 	defaultEnableEtcdSpecAutoReconcile        = false
 	defaultEtcdStatusSyncPeriod               = 15 * time.Second
@@ -44,9 +42,6 @@ var featureList []featuregate.Feature
 type Config struct {
 	// Workers is the number of workers concurrently processing reconciliation requests.
 	Workers int
-	// IgnoreOperationAnnotation specifies whether to ignore or honour the operation annotation on resources to be reconciled.
-	// Deprecated: Use EnableEtcdSpecAutoReconcile instead.
-	IgnoreOperationAnnotation bool
 	// EnableEtcdSpecAutoReconcile controls how the Etcd Spec is reconciled. If set to true, then any change in Etcd spec
 	// will automatically trigger a reconciliation of the Etcd resource. If set to false, then an operator needs to
 	// explicitly set gardener.cloud/operation=reconcile annotation on the Etcd resource to trigger reconciliation
@@ -78,8 +73,6 @@ type MemberConfig struct {
 func (cfg *Config) InitFromFlags(fs *flag.FlagSet) {
 	fs.IntVar(&cfg.Workers, workersFlagName, defaultWorkers,
 		"Number of workers spawned for concurrent reconciles of etcd spec and status changes. If not specified then default of 3 is assumed.")
-	flag.BoolVar(&cfg.IgnoreOperationAnnotation, ignoreOperationAnnotationFlagName, defaultIgnoreOperationAnnotation,
-		fmt.Sprintf("Specifies whether to ignore or honour the annotation `%s: %s` on resources to be reconciled. Deprecated: please use `--%s` instead.", gardenerconstants.GardenerOperation, gardenerconstants.GardenerOperationReconcile, enableEtcdSpecAutoReconcileFlagName))
 	flag.BoolVar(&cfg.EnableEtcdSpecAutoReconcile, enableEtcdSpecAutoReconcileFlagName, defaultEnableEtcdSpecAutoReconcile,
 		fmt.Sprintf("If true then automatically reconciles Etcd Spec. If false, waits for explicit annotation `%s: %s` to be placed on the Etcd resource to trigger reconcile.", gardenerconstants.GardenerOperation, gardenerconstants.GardenerOperationReconcile))
 	fs.BoolVar(&cfg.DisableEtcdServiceAccountAutomount, disableEtcdServiceAccountAutomountFlagName, defaultDisableEtcdServiceAccountAutomount,

--- a/internal/controller/etcd/reconcile_spec.go
+++ b/internal/controller/etcd/reconcile_spec.go
@@ -166,9 +166,8 @@ func (r *Reconciler) recordIncompleteReconcileOperation(ctx component.OperatorCo
 //
 // Reconciliation decision follows these rules:
 // - Skipped if 'druid.gardener.cloud/suspend-etcd-spec-reconcile' annotation is present, signaling a pause in reconciliation.
-// - Also skipped if the deprecated 'druid.gardener.cloud/ignore-reconciliation' annotation is set.
 // - Automatic reconciliation occurs if EnableEtcdSpecAutoReconcile is true.
-// - If 'gardener.cloud/operation: reconcile' annotation exists and neither 'druid.gardener.cloud/suspend-etcd-spec-reconcile' nor the deprecated 'druid.gardener.cloud/ignore-reconciliation' is set to true, reconciliation proceeds upon Etcd spec changes.
+// - If 'gardener.cloud/operation: reconcile' annotation exists and 'druid.gardener.cloud/suspend-etcd-spec-reconcile' annotation is not set, reconciliation proceeds upon Etcd spec changes.
 // - Reconciliation is not initiated if EnableEtcdSpecAutoReconcile is false and none of the relevant annotations are present.
 func (r *Reconciler) canReconcileSpec(etcd *druidv1alpha1.Etcd) bool {
 	// Check if spec reconciliation has been suspended, if yes, then record the event and return false.
@@ -179,11 +178,6 @@ func (r *Reconciler) canReconcileSpec(etcd *druidv1alpha1.Etcd) bool {
 
 	// Prefer using EnableEtcdSpecAutoReconcile for automatic reconciliation.
 	if r.config.EnableEtcdSpecAutoReconcile {
-		return true
-	}
-
-	// Fallback to deprecated IgnoreOperationAnnotation if EnableEtcdSpecAutoReconcile is false.
-	if r.config.IgnoreOperationAnnotation {
 		return true
 	}
 

--- a/internal/controller/etcd/reconcile_status.go
+++ b/internal/controller/etcd/reconcile_status.go
@@ -70,13 +70,11 @@ func (r *Reconciler) inspectStatefulSetAndMutateETCDStatus(ctx component.Operato
 		ready, _ := utils.IsStatefulSetReady(expectedReplicas, sts)
 		etcd.Status.CurrentReplicas = sts.Status.CurrentReplicas
 		etcd.Status.ReadyReplicas = sts.Status.ReadyReplicas
-		etcd.Status.UpdatedReplicas = sts.Status.UpdatedReplicas
 		etcd.Status.Replicas = sts.Status.CurrentReplicas
 		etcd.Status.Ready = &ready
 	} else {
 		etcd.Status.CurrentReplicas = 0
 		etcd.Status.ReadyReplicas = 0
-		etcd.Status.UpdatedReplicas = 0
 		etcd.Status.Ready = ptr.To(false)
 	}
 	return ctrlutils.ContinueReconcile()

--- a/internal/controller/etcd/register.go
+++ b/internal/controller/etcd/register.go
@@ -93,7 +93,7 @@ func (r *Reconciler) hasReconcileAnnotation() predicate.Predicate {
 func (r *Reconciler) autoReconcileEnabled() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(_ event.UpdateEvent) bool {
-			return r.config.EnableEtcdSpecAutoReconcile || r.config.IgnoreOperationAnnotation
+			return r.config.EnableEtcdSpecAutoReconcile
 		},
 		CreateFunc: func(_ event.CreateEvent) bool {
 			return true

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -134,7 +134,6 @@ func (eb *EtcdBuilder) WithReadyStatus() *EtcdBuilder {
 		ReadyReplicas:   eb.etcd.Spec.Replicas,
 		Replicas:        eb.etcd.Spec.Replicas,
 		CurrentReplicas: eb.etcd.Spec.Replicas,
-		UpdatedReplicas: eb.etcd.Spec.Replicas,
 		Ready:           ptr.To(true),
 		Members:         members,
 		Conditions: []druidv1alpha1.Condition{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area usability
/kind cleanup task

**What this PR does / why we need it**:
This PR removes the following deprecated elements in etcd-druid:
- [x] API field `Status.ServiceName` - not useful from a consumer perspective
- [x] API field `Status.ClusterSize` - use the length of `Status.Members` instead
- [x] API field `Status.UpdatedReplicas` - use condition `AllMembersUpdated` instead, introduced in #987 
- [x] API field `Status.LastError` - use `Status.LastErrors` instead, which allows population of multiple errors from the reconciliation flow
- [x] CLI flag `ignore-operation-annotation` - use CLI flag `enable-etcd-spec-auto-reconcile` instead
- [x] Annotation `druid.gardener.cloud/ignore-reconciliation` - use `druid.gardener.cloud/suspend-etcd-spec-reconcile` annotation instead

Please note that although field `Status.LabelSelector` has been marked as deprecated, it has not been removed, due to the fact that we might need to re-look at its use for vertical pod autoscaling via the `/scale` subresource.

**Which issue(s) this PR fixes**:
Fixes #801 

**Special notes for your reviewer**:
/invite @unmarshall 
/assign @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Remove deprecated status fields `ServiceName`, `ClusterSize`, `UpdatedReplicas` and `LastError`.
```
```breaking operator
Remove deprecated CLI flag `ignore-operation-annotation`.
```
```breaking user
Remove support for deprecated annotation `druid.gardener.cloud/ignore-reconciliation`.
```
