### PR TITLE
Remove `UseEtcdWrapper` feature gate

### DIFF
--- a/docs/concepts/etcd-cluster-components.md
+++ b/docs/concepts/etcd-cluster-components.md
@@ -8,21 +8,21 @@ For every `Etcd` cluster that is provisioned by `etcd-druid` it deploys a set of
 
 * Replicas for the StatefulSet are derived from `Etcd.Spec.Replicas` in the custom resource.
 
-* Each pod comprises of two containers:
+* Each pod comprises two containers:
   * `etcd-wrapper` : This is the main container which runs an etcd process.
   
   * `etcd-backup-restore` : This is a side-container which does the following:
     
     * Orchestrates the initialization of etcd. This includes validation of any existing etcd data directory, restoration in case of corrupt etcd data directory files for a single-member etcd cluster.
-    * Periodically renewes member lease.
-    * Optionally takes schedule and thresold based delta and full snapshots and pushes them to a configured object store.
+    * Periodically renews member lease.
+    * Optionally takes schedule and threshold based delta and full snapshots and pushes them to a configured object store.
     * Orchestrates scheduled etcd-db defragmentation.
     
     > NOTE: This is not a complete list of functionalities offered out of `etcd-backup-restore`. 
 
 **Code reference:** [StatefulSet-Component](https://github.com/gardener/etcd-druid/tree/480213808813c5282b19aff5f3fd6868529e779c/internal/component/statefulset)
 
-> For detailed information on each container you can visit [etcd-wrapper](https://github.com/gardener/etcd-wrapper) and [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) respositories.
+> For detailed information on each container you can visit [etcd-wrapper](https://github.com/gardener/etcd-wrapper) and [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) repositories.
 
 ## ConfigMap
 

--- a/docs/deployment/feature-gates.md
+++ b/docs/deployment/feature-gates.md
@@ -25,11 +25,12 @@ The following tables are a summary of the feature gates that you can set on etcd
 
 ## Feature Gates for Graduated or Deprecated Features
 
-| Feature          | Default | Stage   | Since  | Until  |
-|------------------|---------|---------|--------|--------|
-| `UseEtcdWrapper` | `false` | `Alpha` | `0.19` | `0.21` |
-| `UseEtcdWrapper` | `true`  | `Beta`  | `0.22` | `0.24` |
-| `UseEtcdWrapper` | `true`  | `GA`    | `0.25` |        |
+| Feature          | Default | Stage     | Since  | Until  |
+|------------------|---------|-----------|--------|--------|
+| `UseEtcdWrapper` | `false` | `Alpha`   | `0.19` | `0.21` |
+| `UseEtcdWrapper` | `true`  | `Beta`    | `0.22` | `0.24` |
+| `UseEtcdWrapper` | `true`  | `GA`      | `0.25` | `0.27` |
+| `UseEtcdWrapper` |         | `Removed` | `0.28` |        |
 
 ## Using a Feature
 

--- a/docs/deployment/version-compatibility-matrix.md
+++ b/docs/deployment/version-compatibility-matrix.md
@@ -7,15 +7,15 @@
 We strongly recommend using `etcd-druid` with the supported kubernetes versions, published in this document.
 The following is a list of kubernetes versions supported by the respective `etcd-druid` versions.
 
-| etcd-druid version | Kubernetes version |
-|------|------|
-| >=v0.20 | >=v1.21 |
-| >=v0.14 && <0.20 | All versions supported |
-| <v0.14 | < v1.25 |
+| etcd-druid version | Kubernetes version     |
+|--------------------|------------------------|
+| >=v0.20            | >=v1.21                |
+| >=v0.14 && <0.20   | All versions supported |
+| <v0.14             | < v1.25                |
 
 ## etcd-backup-restore & etcd-wrapper
 
 | etcd-druid version | etcd-backup-restore version | etcd-wrapper version |
-| ------------------ | --------------------------- | -------------------- |
+|--------------------|-----------------------------|----------------------|
 | >=v0.23.1          | >=v0.30.2                   | >=v0.2.0             |
 

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -468,7 +468,6 @@ func (b *stsBuilder) getBackupRestoreContainerCommandArgs() []string {
 	commandArgs = append(commandArgs, fmt.Sprintf("--snapstore-temp-directory=%s/temp", common.VolumeMountPathEtcdData))
 	commandArgs = append(commandArgs, fmt.Sprintf("--etcd-connection-timeout=%s", defaultEtcdConnectionTimeout))
 	commandArgs = append(commandArgs, "--enable-member-lease-renewal=true")
-	// Enable/Disable use Etcd Wrapper in BackupRestore container. Once `use-etcd-wrapper` feature-gate is GA then this value will always be true.
 	commandArgs = append(commandArgs, "--use-etcd-wrapper=true")
 
 	var quota = defaultQuota

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -9,28 +9,15 @@ import (
 )
 
 const (
-	// Every feature should add method here following this template:
-	//
-	// // MyFeature enables Foo.
-	// // owner: @username
-	// // alpha: v0.X
-	// MyFeature featuregate.Feature = "MyFeature"
-
-	// UseEtcdWrapper enables the use of etcd-wrapper image and a compatible version
-	// of etcd-backup-restore, along with component-specific configuration
-	// changes required for the usage of the etcd-wrapper image.
-	// owner @unmarshall @aaronfern
-	// alpha: v0.19
-	// beta:  v0.22
-	// GA:    v0.25
-	UseEtcdWrapper featuregate.Feature = "UseEtcdWrapper"
+// Every feature should add method here following this template:
+//
+// // MyFeature enables Foo.
+// // owner: @username
+// // alpha: v0.X
+// MyFeature featuregate.Feature = "MyFeature"
 )
-
-var defaultFeatures = map[featuregate.Feature]featuregate.FeatureSpec{
-	UseEtcdWrapper: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-}
 
 // GetDefaultFeatures returns the default feature gates known to etcd-druid.
 func GetDefaultFeatures() map[featuregate.Feature]featuregate.FeatureSpec {
-	return defaultFeatures
+	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area usability
/kind cleanup

**What this PR does / why we need it**:
Remove `UseEtcdWrapper` feature gate, since it has now moved out of GA and is unconditionally part of the code base.

**Which issue(s) this PR fixes**:
Fixes #935 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove `UseEtcdWrapper` feature gate since it is now out of GA and always enabled.
```
