### PR TITLE
Housekeeping: fix links, remove deprecated labels in examples, use stdlib `maps.Copy`, etc

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ If you are looking to try out druid then you can use a [Kind](https://kind.sigs.
   <source src="https://github.com/user-attachments/assets/cfe0d891-f709-4d7f-b975-4300c6de67e4" type="video/mp4">
 </video>
 
-For detailed documentation, see our `/docs` folder. Please find the [index](README.md) here.
+For detailed documentation, see our `/docs` folder. Please find the [index](./README.md) here.
 
 ## Contributions
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1,12 +1,12 @@
 # Monitoring
 
-etcd-druid uses [Prometheus][prometheus] for metrics reporting. The metrics can be used for real-time monitoring and debugging of compaction jobs.
+etcd-druid uses [Prometheus](https://prometheus.io/) for metrics reporting. The metrics can be used for real-time monitoring and debugging of compaction jobs.
 
 The simplest way to see the available metrics is to cURL the metrics endpoint `/metrics`. The format is described [here](http://prometheus.io/docs/instrumenting/exposition_formats/).
 
-Follow the [Prometheus getting started doc][prometheus-getting-started] to spin up a Prometheus server to collect etcd metrics.
+Follow the [Prometheus getting started doc](https://prometheus.io/docs/prometheus/latest/getting_started/) to spin up a Prometheus server to collect etcd metrics.
 
-The naming of metrics follows the suggested [Prometheus best practices][prometheus-naming]. All compaction related metrics are put under namespace `etcddruid` and the respective subsystems.
+The naming of metrics follows the suggested [Prometheus best practices](https://prometheus.io/docs/practices/naming/). All compaction related metrics are put under namespace `etcddruid` and the respective subsystems.
 
 ## Snapshot Compaction
 

--- a/examples/objstore-emulator/etcd-secret-azurite.yaml
+++ b/examples/objstore-emulator/etcd-secret-azurite.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    garden.sapcloud.io/role: controlplane
     role: main
   name: etcd-backup-azurite
 type: Opaque

--- a/examples/objstore-emulator/etcd-secret-localstack.yaml
+++ b/examples/objstore-emulator/etcd-secret-localstack.yaml
@@ -9,7 +9,6 @@ data:
 kind: Secret
 metadata:
   labels:
-    garden.sapcloud.io/role: controlplane
     role: main
   name: etcd-backup-aws
 type: Opaque

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -51,7 +51,7 @@ func GenerateLabelCombinations(labelValues map[string][]string) []map[string]str
 	output := make([]map[string]string, len(combinations))
 	for i, combination := range combinations {
 		labelVals := make(map[string]string, len(labels))
-		for j := 0; j < len(labels); j++ {
+		for j := range labels {
 			labelVals[labels[j]] = combination[j]
 		}
 		output[i] = labelVals
@@ -78,15 +78,15 @@ func getCombinations(valuesList [][]string) [][]string {
 // Output => [[p,q,1,2],[p,q,3,4],[r,s,1,2],[r,s,3,4]]
 func cartesianProduct(a [][]string, b [][]string) [][]string {
 	output := make([][]string, len(a)*len(b))
-	for i := 0; i < len(a); i++ {
-		for j := 0; j < len(b); j++ {
+	for i := range a {
+		for j := range b {
 			arr := make([]string, len(a[i])+len(b[j]))
 			ctr := 0
-			for ii := 0; ii < len(a[i]); ii++ {
+			for ii := range a[i] {
 				arr[ctr] = a[i][ii]
 				ctr++
 			}
-			for jj := 0; jj < len(b[j]); jj++ {
+			for jj := range b[j] {
 				arr[ctr] = b[j][jj]
 				ctr++
 			}
@@ -101,7 +101,7 @@ func cartesianProduct(a [][]string, b [][]string) [][]string {
 // Ex: [p,q,r] -> [[p],[q],[r]]
 func wrapInSlice(s []string) [][]string {
 	output := make([][]string, len(s))
-	for i := 0; i < len(output); i++ {
+	for i := range output {
 		elem := make([]string, 1)
 		elem[0] = s[i]
 		output[i] = elem

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"strings"
@@ -158,9 +159,7 @@ func getDefaultEtcd(name, namespace, container, prefix string, provider TestProv
 	etcd.Spec.Annotations = stsAnnotations
 
 	labelsCopy := make(map[string]string)
-	for k, v := range labels {
-		labelsCopy[k] = v
-	}
+	maps.Copy(labels, labelsCopy)
 	labelsCopy[roleLabelKey] = provider.Suffix
 	etcd.Labels = labelsCopy
 	etcd.Spec.Selector = &metav1.LabelSelector{
@@ -168,9 +167,7 @@ func getDefaultEtcd(name, namespace, container, prefix string, provider TestProv
 	}
 
 	stsLabelsCopy := make(map[string]string)
-	for k, v := range stsLabels {
-		stsLabelsCopy[k] = v
-	}
+	maps.Copy(stsLabels, stsLabelsCopy)
 	stsLabelsCopy[roleLabelKey] = provider.Suffix
 	etcd.Spec.Labels = stsLabelsCopy
 
@@ -678,7 +675,7 @@ func getPurgeLocalSnapstoreJob(storeContainer, storePrefix string) *batchv1.Job 
 	)
 }
 
-func populateEtcd(ctx context.Context, logger logr.Logger, kubeconfigPath, namespace, etcdName, podName, containerName, keyPrefix, valuePrefix string, startKeyNo, endKeyNo int, delay time.Duration) error {
+func populateEtcd(ctx context.Context, logger logr.Logger, kubeconfigPath, namespace, etcdName, podName, containerName, keyPrefix, valuePrefix string, startKeyNo, endKeyNo int, _ time.Duration) error {
 	var (
 		cmd     string
 		stdout  string

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -159,7 +159,7 @@ func getDefaultEtcd(name, namespace, container, prefix string, provider TestProv
 	etcd.Spec.Annotations = stsAnnotations
 
 	labelsCopy := make(map[string]string)
-	maps.Copy(labels, labelsCopy)
+	maps.Copy(labelsCopy, labels)
 	labelsCopy[roleLabelKey] = provider.Suffix
 	etcd.Labels = labelsCopy
 	etcd.Spec.Selector = &metav1.LabelSelector{
@@ -167,7 +167,7 @@ func getDefaultEtcd(name, namespace, container, prefix string, provider TestProv
 	}
 
 	stsLabelsCopy := make(map[string]string)
-	maps.Copy(stsLabels, stsLabelsCopy)
+	maps.Copy(stsLabelsCopy, stsLabels)
 	stsLabelsCopy[roleLabelKey] = provider.Suffix
 	etcd.Spec.Labels = stsLabelsCopy
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -81,14 +81,12 @@ var (
 	defaultRoleLabelValue = "main"
 
 	labels = map[string]string{
-		"app":                     "etcd-statefulset",
-		"garden.sapcloud.io/role": "controlplane",
-		roleLabelKey:              defaultRoleLabelValue,
+		"app":        "etcd-statefulset",
+		roleLabelKey: defaultRoleLabelValue,
 	}
 
 	stsLabels = map[string]string{
 		"app":                              "etcd-statefulset",
-		"garden.sapcloud.io/role":          "controlplane",
 		roleLabelKey:                       defaultRoleLabelValue,
 		"networking.gardener.cloud/to-dns": "allowed",
 		"networking.gardener.cloud/to-private-networks": "allowed",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area documentation dev-productivity
/kind cleanup

**What this PR does / why we need it**:

* Fix ambiguous markdown link, add missing links in `docs/monitoring/metrics.md`.

* Remove deprecated labels from examples and tests.

* Use `maps.Copy()`; `replace < len()` loops with `range` loops.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
