### PR TITLE
Cleanup older configmaps with the naming format `etcd-bootstrap-UID[:6]`

### DIFF
--- a/api/core/v1alpha1/helper.go
+++ b/api/core/v1alpha1/helper.go
@@ -29,6 +29,12 @@ func GetServiceAccountName(etcdObjMeta metav1.ObjectMeta) string {
 	return etcdObjMeta.Name
 }
 
+// GetOldConfigMapName returns the name of the old configmap for the Etcd.
+// TODO: @anveshreddy18: Remove this function after 3 releases, i.e in v0.31.0
+func GetOldConfigMapName(etcdObjMeta metav1.ObjectMeta) string {
+	return fmt.Sprintf("etcd-bootstrap-%s", string(etcdObjMeta.UID[:6]))
+}
+
 // GetConfigMapName returns the name of the configmap for the Etcd.
 func GetConfigMapName(etcdObjMeta metav1.ObjectMeta) string {
 	return fmt.Sprintf("%s-config", etcdObjMeta.Name)

--- a/internal/component/configmap/configmap.go
+++ b/internal/component/configmap/configmap.go
@@ -71,14 +71,14 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 	ctx.Logger.Info("PreSync: Deleting old configmap", "name", oldConfigMap.Name)
 	if err := r.client.Delete(ctx, oldConfigMap); err != nil {
 		if errors.IsNotFound(err) {
-			ctx.Logger.Info("No old configmap found, PreSync is a No-Op", "name", oldConfigMap.Name)
+			ctx.Logger.Info("No old configmap found, ConfigMap PreSync is a no-op", "name", oldConfigMap.Name)
 			return nil
 		}
 		return druiderr.WrapError(
 			err,
 			ErrDeleteConfigMap,
 			component.OperationPreSync,
-			"Failed to delete old configmap",
+			fmt.Sprintf("Failed to delete old configmap %s", oldConfigMap.Name),
 		)
 	}
 	ctx.Logger.Info("deleted", "component", "configmap", "name", oldConfigMap.Name)

--- a/internal/component/types.go
+++ b/internal/component/types.go
@@ -17,6 +17,8 @@ import (
 // However, it can also be used where ever operation context is required to be specified.
 // Each component can in turn define their own fine-grained operation labels as well.
 const (
+	// OperationPreSync is the PreSync operation of the Operator.
+	OperationPreSync = "PreSync"
 	// OperationSync is the Sync operation of the Operator.
 	OperationSync = "Sync"
 	// OperationTriggerDelete is the TriggerDelete operation of the Operator.

--- a/internal/controller/etcd/reconcile_spec.go
+++ b/internal/controller/etcd/reconcile_spec.go
@@ -169,7 +169,9 @@ func (r *Reconciler) recordEtcdSpecReconcileSuspension(etcd *druidv1alpha1.Etcd,
 }
 
 func (r *Reconciler) getOrderedOperatorsForPreSync() []component.Kind {
-	return []component.Kind{}
+	return []component.Kind{
+		component.ConfigMapKind,
+	}
 }
 
 func (r *Reconciler) getOrderedOperatorsForSync() []component.Kind {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:

This PR cleans up the unused configmaps with the naming format `etcd-bootstrap-UID[:6]` that were created by `etcd-druid` until `v0.24.0`. The name of the configmap was changed to `{etcd.Name}-config` from `v0.25.0` onwards but the older configmaps were not deleted, this PR removes them. Refer to the issue #931 for more details. 

**Which issue(s) this PR fixes**:
Fixes #931 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
cleanup unused older configmaps with the naming format `etcd-bootstrap-UID[:6]` from the cluster.
```
