### PR TITLE
Change GetAll CRD API to return a Map with keys as CRD name

### DIFF
--- a/api/core/crds/crd.go
+++ b/api/core/crds/crd.go
@@ -20,16 +20,18 @@ var (
 )
 
 const (
-	// KindEtcd is the kind of the etcd CRD.
-	KindEtcd = "Etcd"
-	// KindEtcdCopyBackupsTask is the kind of the etcd-copy-backup-task CRD.
-	KindEtcdCopyBackupsTask = "EtcdCopyBackupsTask"
+	// ResourceNameEtcd is the name of the etcd CRD.
+	ResourceNameEtcd = "etcds.druid.gardener.cloud"
+	// ResourceNameEtcdCopyBackupsTask is the name of the etcd-copy-backup-task CRD.
+	ResourceNameEtcdCopyBackupsTask = "etcdcopybackupstasks.druid.gardener.cloud"
 )
 
 // GetAll returns all CRDs for the given k8s version.
+// The function will return a map with the CRD name as key and the CRD content as value.
 // There are currently two sets of CRDs maintained.
 // 1. One set is for Kubernetes version 1.29 and above. These CRDs contain embedded CEL validation expressions. CEL expressions are only GA since Kubernetes 1.29 onwards.
 // 2. The other set is for Kubernetes versions below 1.29. These CRDs do not contain embedded CEL validation expressions.
+// If there are any errors in parsing the k8s version, the function will return an error.
 func GetAll(k8sVersion string) (map[string]string, error) {
 	k8sVersionAbove129, err := IsK8sVersionEqualToOrAbove129(k8sVersion)
 	if err != nil {
@@ -42,8 +44,8 @@ func GetAll(k8sVersion string) (map[string]string, error) {
 		selectedEtcdCRD = etcdCRDWithoutCEL
 	}
 	return map[string]string{
-		KindEtcd:                selectedEtcdCRD,
-		KindEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
+		ResourceNameEtcd:                selectedEtcdCRD,
+		ResourceNameEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
 	}, nil
 }
 

--- a/api/core/crds/crd_test.go
+++ b/api/core/crds/crd_test.go
@@ -20,48 +20,48 @@ func TestGetAll(t *testing.T) {
 			name:       "k8s version is 1.29",
 			k8sVersion: "1.29",
 			expectedCRDs: map[string]string{
-				KindEtcd:                etcdCRD,
-				KindEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
+				ResourceNameEtcd:                etcdCRD,
+				ResourceNameEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
 			},
 		},
 		{
 			name:       "k8s version is v1.29.0",
 			k8sVersion: "v1.29.0",
 			expectedCRDs: map[string]string{
-				KindEtcd:                etcdCRD,
-				KindEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
+				ResourceNameEtcd:                etcdCRD,
+				ResourceNameEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
 			},
 		},
 		{
 			name:       "k8s version is below 1.29",
 			k8sVersion: "1.28",
 			expectedCRDs: map[string]string{
-				KindEtcd:                etcdCRDWithoutCEL,
-				KindEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
+				ResourceNameEtcd:                etcdCRDWithoutCEL,
+				ResourceNameEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
 			},
 		},
 		{
 			name:       "k8s version is below v1.29",
 			k8sVersion: "v1.28.3",
 			expectedCRDs: map[string]string{
-				KindEtcd:                etcdCRDWithoutCEL,
-				KindEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
+				ResourceNameEtcd:                etcdCRDWithoutCEL,
+				ResourceNameEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
 			},
 		},
 		{
 			name:       "k8s version is above 1.29",
 			k8sVersion: "1.30",
 			expectedCRDs: map[string]string{
-				KindEtcd:                etcdCRD,
-				KindEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
+				ResourceNameEtcd:                etcdCRD,
+				ResourceNameEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
 			},
 		},
 		{
 			name:       "k8s version is above v1.29",
 			k8sVersion: "v1.30.1",
 			expectedCRDs: map[string]string{
-				KindEtcd:                etcdCRD,
-				KindEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
+				ResourceNameEtcd:                etcdCRD,
+				ResourceNameEtcdCopyBackupsTask: etcdCopyBackupsTaskCRD,
 			},
 		},
 	}

--- a/test/it/assets/assets.go
+++ b/test/it/assets/assets.go
@@ -25,7 +25,7 @@ func GetK8sVersionFromEnv() (string, error) {
 	}
 }
 
-// Duplicating some code here that can be replaced with a call to the API module of etcd-druid.  
+// Duplicating some code here that can be replaced with a call to the API module of etcd-druid.
 // This will be removed once Kubernetes 1.29 becomes the minimum supported version.
 
 // GetEtcdCrdPath returns the path to the Etcd CRD for k8s versions >= 1.29 or the path to the Etcd CRD without CEL expressions (For versions < 1.29)

--- a/test/it/assets/assets.go
+++ b/test/it/assets/assets.go
@@ -15,13 +15,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// returns the kubernetes version used from the environment variable
+// GetK8sVersionFromEnv returns the kubernetes version used from the environment variable
 func GetK8sVersionFromEnv() (string, error) {
 	k8sVersion, isPresent := os.LookupEnv("ENVTEST_K8S_VERSION")
 	if isPresent {
 		return k8sVersion, nil
 	} else {
-		return "", errors.New("Error fetching k8s version from environment")
+		return "", errors.New("error fetching k8s version from environment")
 	}
 }
 

--- a/test/it/crdvalidation/etcd/helper.go
+++ b/test/it/crdvalidation/etcd/helper.go
@@ -12,12 +12,12 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/test/it/setup"
 	"github.com/gardener/etcd-druid/test/utils"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
 )
-
 
 const testNamespacePrefix = "etcd-validation-test"
 
@@ -46,6 +46,7 @@ func validateEtcdUpdation(t *testing.T, g *WithT, etcd *druidv1alpha1.Etcd, expe
 		g.Expect(updateErr).To(BeNil())
 	}
 }
+
 var cronFieldTestCases = []struct {
 	name      string
 	etcdName  string

--- a/test/it/crdvalidation/etcd/specetcd_test.go
+++ b/test/it/crdvalidation/etcd/specetcd_test.go
@@ -123,7 +123,7 @@ func TestValidateSpecStorageCapacitySpecEtcdQuotaRelation(t *testing.T) {
 		etcdName        string
 		storageCapacity resource.Quantity
 		quota           resource.Quantity
-		backupEnabled          bool
+		backupEnabled   bool
 		expectErr       bool
 	}{
 		{
@@ -131,7 +131,7 @@ func TestValidateSpecStorageCapacitySpecEtcdQuotaRelation(t *testing.T) {
 			etcdName:        "etcd-valid-1",
 			storageCapacity: resource.MustParse("27Gi"),
 			quota:           resource.MustParse("8Gi"),
-			backupEnabled:          true,
+			backupEnabled:   true,
 			expectErr:       false,
 		},
 		{
@@ -139,7 +139,7 @@ func TestValidateSpecStorageCapacitySpecEtcdQuotaRelation(t *testing.T) {
 			etcdName:        "etcd-valid-2",
 			storageCapacity: resource.MustParse("12Gi"),
 			quota:           resource.MustParse("8Gi"),
-			backupEnabled:          false,
+			backupEnabled:   false,
 			expectErr:       false,
 		},
 		{
@@ -147,7 +147,7 @@ func TestValidateSpecStorageCapacitySpecEtcdQuotaRelation(t *testing.T) {
 			etcdName:        "etcd-invalid-1",
 			storageCapacity: resource.MustParse("15Gi"),
 			quota:           resource.MustParse("8Gi"),
-			backupEnabled:          true,
+			backupEnabled:   true,
 			expectErr:       true,
 		},
 		{
@@ -155,7 +155,7 @@ func TestValidateSpecStorageCapacitySpecEtcdQuotaRelation(t *testing.T) {
 			etcdName:        "etcd-invalid-2",
 			storageCapacity: resource.MustParse("9Gi"),
 			quota:           resource.MustParse("10Gi"),
-			backupEnabled:          false,
+			backupEnabled:   false,
 			expectErr:       true,
 		},
 	}

--- a/test/it/crdvalidation/etcd/specsharedconfig_test.go
+++ b/test/it/crdvalidation/etcd/specsharedconfig_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gardener/etcd-druid/test/utils"
 )
 
-
 // validates whether the value passed to the etcd.spec.sharedConfig.autoCompactionMode is either set as "periodic" or "revision"
 func TestValidateSpecSharedConfigAutoCompactionMode(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Changes the `GetAll` CRD API to return a map with keys being the CRD name instead of Kind.

**Which issue(s) this PR fixes**:
Fixes #1023 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Change the GetAll CRD API to return a map with keys having CRD names instead of Kind.
```
