### PR TITLE
Remove the direct depedency on `gopkg.in/yaml.v2`.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d
 	golang.org/x/tools v0.29.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
@@ -81,7 +80,6 @@ require (
 	github.com/gophercloud/utils v0.0.0-20200204043447-9864b6f1f12f // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -127,6 +125,7 @@ require (
 	google.golang.org/protobuf v1.36.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.32.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
-github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/gnostic-models v0.6.9 h1:MU/8wDLif2qCXZmzncUQ/BOfxWfthHi63KqpoNbWqVw=
 github.com/google/gnostic-models v0.6.9/go.mod h1:CiWsm0s6BSQd1hRn8/QmxqB6BesYcbSZxsz9b0KuDBw=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/internal/component/configmap/configmap.go
+++ b/internal/component/configmap/configmap.go
@@ -14,12 +14,12 @@ import (
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
 	"github.com/gardener/etcd-druid/internal/utils"
 
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/internal/component/configmap/etcdconfig.go
+++ b/internal/component/configmap/etcdconfig.go
@@ -47,8 +47,8 @@ type etcdConfig struct {
 	ListenClientUrls        string                       `json:"listen-client-urls"`
 	AdvertisePeerUrls       map[string][]string          `json:"initial-advertise-peer-urls"`
 	AdvertiseClientUrls     map[string][]string          `json:"advertise-client-urls"`
-	ClientSecurity          securityConfig               `json:"client-transport-security,omitempty"`
-	PeerSecurity            securityConfig               `json:"peer-transport-security,omitempty"`
+	ClientSecurity          *securityConfig              `json:"client-transport-security,omitempty"`
+	PeerSecurity            *securityConfig              `json:"peer-transport-security,omitempty"`
 }
 
 type securityConfig struct {
@@ -80,12 +80,8 @@ func createEtcdConfig(etcd *druidv1alpha1.Etcd) *etcdConfig {
 		AdvertisePeerUrls:       getAdvertiseURLs(etcd, advertiseURLTypePeer, peerScheme, peerSvcName),
 		AdvertiseClientUrls:     getAdvertiseURLs(etcd, advertiseURLTypeClient, clientScheme, peerSvcName),
 	}
-	if peerSecurityConfig != nil {
-		cfg.PeerSecurity = *peerSecurityConfig
-	}
-	if clientSecurityConfig != nil {
-		cfg.ClientSecurity = *clientSecurityConfig
-	}
+	cfg.PeerSecurity = peerSecurityConfig
+	cfg.ClientSecurity = clientSecurityConfig
 
 	return cfg
 }

--- a/internal/component/configmap/etcdconfig.go
+++ b/internal/component/configmap/etcdconfig.go
@@ -32,31 +32,31 @@ var (
 )
 
 type etcdConfig struct {
-	Name                    string                       `yaml:"name"`
-	DataDir                 string                       `yaml:"data-dir"`
-	Metrics                 druidv1alpha1.MetricsLevel   `yaml:"metrics"`
-	SnapshotCount           int64                        `yaml:"snapshot-count"`
-	EnableV2                bool                         `yaml:"enable-v2"`
-	QuotaBackendBytes       int64                        `yaml:"quota-backend-bytes"`
-	InitialClusterToken     string                       `yaml:"initial-cluster-token"`
-	InitialClusterState     string                       `yaml:"initial-cluster-state"`
-	InitialCluster          string                       `yaml:"initial-cluster"`
-	AutoCompactionMode      druidv1alpha1.CompactionMode `yaml:"auto-compaction-mode"`
-	AutoCompactionRetention string                       `yaml:"auto-compaction-retention"`
-	ListenPeerUrls          string                       `yaml:"listen-peer-urls"`
-	ListenClientUrls        string                       `yaml:"listen-client-urls"`
-	AdvertisePeerUrls       map[string][]string          `yaml:"initial-advertise-peer-urls"`
-	AdvertiseClientUrls     map[string][]string          `yaml:"advertise-client-urls"`
-	ClientSecurity          securityConfig               `yaml:"client-transport-security,omitempty"`
-	PeerSecurity            securityConfig               `yaml:"peer-transport-security,omitempty"`
+	Name                    string                       `json:"name"`
+	DataDir                 string                       `json:"data-dir"`
+	Metrics                 druidv1alpha1.MetricsLevel   `json:"metrics"`
+	SnapshotCount           int64                        `json:"snapshot-count"`
+	EnableV2                bool                         `json:"enable-v2"`
+	QuotaBackendBytes       int64                        `json:"quota-backend-bytes"`
+	InitialClusterToken     string                       `json:"initial-cluster-token"`
+	InitialClusterState     string                       `json:"initial-cluster-state"`
+	InitialCluster          string                       `json:"initial-cluster"`
+	AutoCompactionMode      druidv1alpha1.CompactionMode `json:"auto-compaction-mode"`
+	AutoCompactionRetention string                       `json:"auto-compaction-retention"`
+	ListenPeerUrls          string                       `json:"listen-peer-urls"`
+	ListenClientUrls        string                       `json:"listen-client-urls"`
+	AdvertisePeerUrls       map[string][]string          `json:"initial-advertise-peer-urls"`
+	AdvertiseClientUrls     map[string][]string          `json:"advertise-client-urls"`
+	ClientSecurity          securityConfig               `json:"client-transport-security,omitempty"`
+	PeerSecurity            securityConfig               `json:"peer-transport-security,omitempty"`
 }
 
 type securityConfig struct {
-	CertFile       string `yaml:"cert-file,omitempty"`
-	KeyFile        string `yaml:"key-file,omitempty"`
-	ClientCertAuth bool   `yaml:"client-cert-auth,omitempty"`
-	TrustedCAFile  string `yaml:"trusted-ca-file,omitempty"`
-	AutoTLS        bool   `yaml:"auto-tls"`
+	CertFile       string `json:"cert-file,omitempty"`
+	KeyFile        string `json:"key-file,omitempty"`
+	ClientCertAuth bool   `json:"client-cert-auth,omitempty"`
+	TrustedCAFile  string `json:"trusted-ca-file,omitempty"`
+	AutoTLS        bool   `json:"auto-tls"`
 }
 
 func createEtcdConfig(etcd *druidv1alpha1.Etcd) *etcdConfig {

--- a/internal/component/configmap/etcdconfig.go
+++ b/internal/component/configmap/etcdconfig.go
@@ -122,7 +122,7 @@ func prepareInitialCluster(etcd *druidv1alpha1.Etcd, peerScheme string) string {
 	domainName := fmt.Sprintf("%s.%s.%s", druidv1alpha1.GetPeerServiceName(etcd.ObjectMeta), etcd.Namespace, "svc")
 	serverPort := strconv.Itoa(int(ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)))
 	builder := strings.Builder{}
-	for i := 0; i < int(etcd.Spec.Replicas); i++ {
+	for i := range int(etcd.Spec.Replicas) {
 		podName := druidv1alpha1.GetOrdinalPodName(etcd.ObjectMeta, i)
 		builder.WriteString(fmt.Sprintf("%s=%s://%s.%s:%s,", podName, peerScheme, podName, domainName, serverPort))
 	}
@@ -140,7 +140,7 @@ func getAdvertiseURLs(etcd *druidv1alpha1.Etcd, advertiseURLType, scheme, peerSv
 		return nil
 	}
 	advUrlsMap := make(map[string][]string)
-	for i := 0; i < int(etcd.Spec.Replicas); i++ {
+	for i := range int(etcd.Spec.Replicas) {
 		podName := druidv1alpha1.GetOrdinalPodName(etcd.ObjectMeta, i)
 		advUrlsMap[podName] = []string{fmt.Sprintf("%s://%s.%s.%s.svc:%d", scheme, podName, peerSvcName, etcd.Namespace, port)}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

* `gopkg.in/yaml.v2` was a direct dependency only because one file `internal/component/configmap/configmap.go` used it to marshal yaml. This direct depdendency is removed by replacing it with the package `sigs.k8s.io/yaml` used everywhere else in the repository to maintain consistency.

* Replace `yaml` with `json` struct tags since `sigs.k8s.io/yaml` first marshals the `struct` to a json, and then yaml. When `yaml` tags are specified, the specified tags are not used when marshalling to `json`, which causes the intermediate json values to have the keys as the `struct` field names, causing the final yaml also to have the struct field names as the keys.

* Make `omitempty` fields pointers. The general convention for fields which are `omitempty` is to make them pointers. If not, the fields will be their zero values which is not the intended marshalled output.

* Replace C-like for loops with range for loops for readability.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Remove the direct depedency on `gopkg.in/yaml.v2`.
```