### PR TITLE
Temporarily remove CEL validations for StorageCapacity

### DIFF
--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -1840,9 +1840,6 @@ spec:
                 description: StorageCapacity defines the size of persistent volume.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
-                x-kubernetes-validations:
-                - message: etcd.spec.storageCapacity is an immutable field
-                  rule: self == oldSelf
               storageClass:
                 description: |-
                   StorageClass defines the name of the StorageClass required by the claim.
@@ -1864,15 +1861,6 @@ spec:
             - labels
             - replicas
             type: object
-            x-kubernetes-validations:
-            - message: If backups are enabled, then value of etcd.spec.storageCapacity
-                must be 3 times the value of etcd.spec.etcd.quota or more. If backups
-                are disabled, then value of etcd.spec.storageCapacity must be the
-                value of etcd.spec.etcd.quota or more.
-              rule: 'has(self.storageCapacity) && has(self.etcd.quota) ? (has(self.backup.store)
-                ? ((quantity(self.storageCapacity).isLessThan(quantity(self.etcd.quota).add(quantity(self.etcd.quota)).add(quantity(self.etcd.quota)))
-                ) ? false : true): (quantity(self.storageCapacity).isLessThan(quantity(self.etcd.quota))
-                ? false : true)  ): true'
           status:
             description: EtcdStatus defines the observed state of Etcd.
             properties:

--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -288,7 +288,6 @@ type SchedulingConstraints struct {
 }
 
 // EtcdSpec defines the desired state of Etcd
-// +kubebuilder:validation:XValidation:message="If backups are enabled, then value of etcd.spec.storageCapacity must be 3 times the value of etcd.spec.etcd.quota or more. If backups are disabled, then value of etcd.spec.storageCapacity must be the value of etcd.spec.etcd.quota or more.",rule="has(self.storageCapacity) && has(self.etcd.quota) ? (has(self.backup.store) ? ((quantity(self.storageCapacity).isLessThan(quantity(self.etcd.quota).add(quantity(self.etcd.quota)).add(quantity(self.etcd.quota))) ) ? false : true): (quantity(self.storageCapacity).isLessThan(quantity(self.etcd.quota)) ? false : true)  ): true"
 type EtcdSpec struct {
 	// selector is a label query over pods that should match the replica count.
 	// It must match the pod template's labels.
@@ -321,7 +320,6 @@ type EtcdSpec struct {
 	StorageClass *string `json:"storageClass,omitempty"`
 	// StorageCapacity defines the size of persistent volume.
 	// +optional
-	// +kubebuilder:validation:XValidation:message="etcd.spec.storageCapacity is an immutable field",rule="self == oldSelf"
 	StorageCapacity *resource.Quantity `json:"storageCapacity,omitempty"`
 	// VolumeClaimTemplate defines the volume claim template to be created
 	// +optional

--- a/test/it/crdvalidation/etcd/helper.go
+++ b/test/it/crdvalidation/etcd/helper.go
@@ -27,7 +27,7 @@ var (
 )
 
 // common function used by all the test cases to create an etcd resource based on the individual test case's specifications.
-func validateEtcdCreation(t *testing.T, g *WithT, etcd *druidv1alpha1.Etcd, expectErr bool) {
+func validateEtcdCreation(g *WithT, etcd *druidv1alpha1.Etcd, expectErr bool) {
 	cl := itTestEnv.GetClient()
 	ctx := context.Background()
 
@@ -38,7 +38,7 @@ func validateEtcdCreation(t *testing.T, g *WithT, etcd *druidv1alpha1.Etcd, expe
 	g.Expect(cl.Create(ctx, etcd)).To(Succeed())
 }
 
-func validateEtcdUpdation(t *testing.T, g *WithT, etcd *druidv1alpha1.Etcd, expectErr bool, ctx context.Context, cl client.Client) {
+func validateEtcdUpdate(g *WithT, etcd *druidv1alpha1.Etcd, expectErr bool, ctx context.Context, cl client.Client) {
 	updateErr := cl.Update(ctx, etcd)
 	if expectErr {
 		g.Expect(updateErr).ToNot(BeNil())

--- a/test/it/crdvalidation/etcd/specbackup_test.go
+++ b/test/it/crdvalidation/etcd/specbackup_test.go
@@ -33,7 +33,7 @@ func TestValidateSpecBackupGarbageCollectionPolicy(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).WithReplicas(3).Build()
 			etcd.Spec.Backup.GarbageCollectionPolicy = (*druidv1alpha1.GarbageCollectionPolicy)(&test.garbageCollectionPolicy)
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 		})
 	}
 }
@@ -85,7 +85,7 @@ func TestValidateSpecBackupCompressionPolicy(t *testing.T) {
 			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).WithReplicas(3).Build()
 			etcd.Spec.Backup.SnapshotCompression = &druidv1alpha1.CompressionSpec{}
 			etcd.Spec.Backup.SnapshotCompression.Policy = (*druidv1alpha1.CompressionPolicy)(&test.policy)
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 		})
 	}
 }
@@ -104,7 +104,7 @@ func TestValidateSpecBackupDeltaSnapshotRetentionPeriod(t *testing.T) {
 			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).WithReplicas(3).Build()
 			etcd.Spec.Backup.DeltaSnapshotRetentionPeriod = duration
 
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 		})
 	}
 }
@@ -121,7 +121,7 @@ func TestValidateSpecBackupEtcdSnapshotTimeout(t *testing.T) {
 			}
 			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).WithReplicas(3).Build()
 			etcd.Spec.Backup.EtcdSnapshotTimeout = duration
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 		})
 	}
 }
@@ -140,7 +140,7 @@ func TestValidateSpecBackupLeaderElectionReelectionPeriod(t *testing.T) {
 			etcd.Spec.Backup.LeaderElection = &druidv1alpha1.LeaderElectionSpec{}
 			etcd.Spec.Backup.LeaderElection.ReelectionPeriod = duration
 
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 		})
 	}
 }
@@ -159,7 +159,7 @@ func TestValidateSpecBackupLeaderElectionEtcdConnectionTimeout(t *testing.T) {
 			etcd.Spec.Backup.LeaderElection = &druidv1alpha1.LeaderElectionSpec{}
 			etcd.Spec.Backup.LeaderElection.EtcdConnectionTimeout = duration
 
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 		})
 	}
 }
@@ -177,7 +177,7 @@ func TestValidateSpecBackupGarbageCollectionPeriod(t *testing.T) {
 			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).WithReplicas(3).Build()
 			etcd.Spec.Backup.GarbageCollectionPeriod = duration
 
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 		})
 	}
 }
@@ -195,7 +195,7 @@ func TestValidateSpecBackupDeltaSnapshotPeriod(t *testing.T) {
 			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).WithReplicas(3).Build()
 			etcd.Spec.Backup.DeltaSnapshotPeriod = duration
 
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 		})
 	}
 }
@@ -250,7 +250,7 @@ func TestValidateSpecBackupGCDeltaSnapshotPeriodRelation(t *testing.T) {
 			etcd.Spec.Backup.GarbageCollectionPeriod = garbageCollectionDuration
 			etcd.Spec.Backup.DeltaSnapshotPeriod = deltaSnapshotDuration
 
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 
 		})
 	}
@@ -265,7 +265,7 @@ func TestValidateSpecBackupFullSnapshotSchedule(t *testing.T) {
 			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).WithReplicas(3).Build()
 			etcd.Spec.Backup.FullSnapshotSchedule = &test.value
 
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 		})
 	}
 }

--- a/test/it/crdvalidation/etcd/specsharedconfig_test.go
+++ b/test/it/crdvalidation/etcd/specsharedconfig_test.go
@@ -55,7 +55,7 @@ func TestValidateSpecSharedConfigAutoCompactionMode(t *testing.T) {
 			etcd.Spec.Common = druidv1alpha1.SharedConfig{}
 			etcd.Spec.Common.AutoCompactionMode = (*druidv1alpha1.CompactionMode)(&test.autoCompactionMode)
 
-			validateEtcdCreation(t, g, etcd, test.expectErr)
+			validateEtcdCreation(g, etcd, test.expectErr)
 		})
 	}
 }

--- a/test/it/crdvalidation/etcd/specupdate_test.go
+++ b/test/it/crdvalidation/etcd/specupdate_test.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/gardener/etcd-druid/test/utils"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	. "github.com/onsi/gomega"
 )
 
@@ -24,21 +22,21 @@ func TestValidateUpdateSpecStorageClass(t *testing.T) {
 	tests := []struct {
 		name                    string
 		etcdName                string
-		initalStorageClassName  string
+		initialStorageClassName string
 		updatedStorageClassName string
 		expectErr               bool
 	}{
 		{
 			name:                    "Valid #1: Unchanged storageClass",
 			etcdName:                "etcd-valid-1",
-			initalStorageClassName:  "gardener.cloud-fast",
+			initialStorageClassName: "gardener.cloud-fast",
 			updatedStorageClassName: "gardener.cloud-fast",
 			expectErr:               false,
 		},
 		{
 			name:                    "Invalid #1: Updated storageClass",
 			etcdName:                "etcd-invalid-1",
-			initalStorageClassName:  "gardener.cloud-fast",
+			initialStorageClassName: "gardener.cloud-fast",
 			updatedStorageClassName: "default",
 			expectErr:               true,
 		},
@@ -47,14 +45,14 @@ func TestValidateUpdateSpecStorageClass(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).WithReplicas(3).Build()
-			etcd.Spec.StorageClass = &test.initalStorageClassName
+			etcd.Spec.StorageClass = &test.initialStorageClassName
 
 			cl := itTestEnv.GetClient()
 			ctx := context.Background()
 			g.Expect(cl.Create(ctx, etcd)).To(Succeed())
 
 			etcd.Spec.StorageClass = &test.updatedStorageClassName
-			validateEtcdUpdation(t, g, etcd, test.expectErr, ctx, cl)
+			validateEtcdUpdate(g, etcd, test.expectErr, ctx, cl)
 		})
 	}
 }
@@ -70,21 +68,21 @@ func TestValidateUpdateSpecReplicas(t *testing.T) {
 		expectErr       bool
 	}{
 		{
-			name:            "Valid updation of replicas #1",
+			name:            "Valid update to replicas #1",
 			etcdName:        "etcd-valid-inc",
 			initialReplicas: 3,
 			updatedReplicas: 5,
 			expectErr:       false,
 		},
 		{
-			name:            "Valid updation of replicas #2",
+			name:            "Valid update to replicas #2",
 			etcdName:        "etcd-valid-zero",
 			initialReplicas: 3,
 			updatedReplicas: 0,
 			expectErr:       false,
 		},
 		{
-			name:            "Invalid updation of replicas #1",
+			name:            "Invalid update to replicas #1",
 			etcdName:        "etcd-invalid-dec",
 			initialReplicas: 5,
 			updatedReplicas: 3,
@@ -102,49 +100,7 @@ func TestValidateUpdateSpecReplicas(t *testing.T) {
 			g.Expect(cl.Create(ctx, etcd)).To(Succeed())
 
 			etcd.Spec.Replicas = int32(test.updatedReplicas)
-			validateEtcdUpdation(t, g, etcd, test.expectErr, ctx, cl)
-		})
-	}
-}
-
-// checks the immutablility of the etcd.spec.StorageCapacity field
-func TestValidateUpdateSpecStorageCapacity(t *testing.T) {
-	skipCELTestsForOlderK8sVersions(t)
-	testNs, g := setupTestEnvironment(t)
-	tests := []struct {
-		name                   string
-		etcdName               string
-		initalStorageCapacity  resource.Quantity
-		updatedStorageCapacity resource.Quantity
-		expectErr              bool
-	}{
-		{
-			name:                   "Valid #1: Unchanged storageCapacity",
-			etcdName:               "etcd-valid-1-storagecap",
-			initalStorageCapacity:  resource.MustParse("25Gi"),
-			updatedStorageCapacity: resource.MustParse("25Gi"),
-			expectErr:              false,
-		},
-		{
-			name:                   "Invalid #1: Updated storageCapacity",
-			etcdName:               "etcd-invalid-1-storagecap",
-			initalStorageCapacity:  resource.MustParse("15Gi"),
-			updatedStorageCapacity: resource.MustParse("20Gi"),
-			expectErr:              true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).WithReplicas(3).Build()
-			etcd.Spec.StorageCapacity = &test.initalStorageCapacity
-
-			cl := itTestEnv.GetClient()
-			ctx := context.Background()
-			g.Expect(cl.Create(ctx, etcd)).To(Succeed())
-
-			etcd.Spec.StorageCapacity = &test.updatedStorageCapacity
-			validateEtcdUpdation(t, g, etcd, test.expectErr, ctx, cl)
+			validateEtcdUpdate(g, etcd, test.expectErr, ctx, cl)
 		})
 	}
 }
@@ -186,7 +142,7 @@ func TestValidateUpdateSpecVolumeClaimTemplate(t *testing.T) {
 			g.Expect(cl.Create(ctx, etcd)).To(Succeed())
 
 			etcd.Spec.VolumeClaimTemplate = &test.updatedVolClaimTemp
-			validateEtcdUpdation(t, g, etcd, test.expectErr, ctx, cl)
+			validateEtcdUpdate(g, etcd, test.expectErr, ctx, cl)
 		})
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Temporarily removes the CEL validations for `StorageCapacity`.

**Which issue(s) this PR fixes**:
Fixes #1031 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Temporarily removes CEL validations for StorageCapacity to allow users to correctly configure volume size to be at least 3 times that of etcd DB size.
```
