### PR TITLE
Reverted one change which was introduced to reduce flakiness in e2e tests.

### DIFF
--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -116,11 +116,9 @@ var (
 			"memory": resource.MustParse("256Mi"),
 		},
 	}
-	backupGarbageCollectionPolicy = druidv1alpha1.GarbageCollectionPolicy(druidv1alpha1.GarbageCollectionPolicyExponential)
-	backupGarbageCollectionPeriod = metav1.Duration{Duration: 5 * time.Minute}
-	//TODO: i062009 revert this to 1s once issue in etcd-backup-restore (https://github.com/gardener/etcd-backup-restore/issues/844) is fixed.
-	// This is done to reduce flakiness of e2e tests (specifically etcd_backup_test.go/Should create, test backup and delete etcd with backup).
-	backupDeltaSnapshotPeriod      = metav1.Duration{Duration: 3 * time.Second}
+	backupGarbageCollectionPolicy  = druidv1alpha1.GarbageCollectionPolicy(druidv1alpha1.GarbageCollectionPolicyExponential)
+	backupGarbageCollectionPeriod  = metav1.Duration{Duration: 5 * time.Minute}
+	backupDeltaSnapshotPeriod      = metav1.Duration{Duration: 1 * time.Second}
 	backupDeltaSnapshotMemoryLimit = resource.MustParse("100Mi")
 	gzipCompression                = druidv1alpha1.GzipCompression
 	backupCompression              = druidv1alpha1.CompressionSpec{


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:
`backupDeltaSnapshotPeriod` was increased to `3sec` from `1sec` to reduce the flakiness of druid e2e tests.
With the fix of this PR: https://github.com/gardener/etcd-backup-restore/pull/845, the flakiness in druid e2e tests will no longer be the case, so I'm reverting this temporary change which was introduced to fix flakiness in druid e2e tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
