### PR TITLE
Forbid container privilege escalations for ETCD Druid component containers

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -93,10 +93,10 @@ spec:
             name: tls
             readOnly: true
         {{- end }}
-        securityContext:
-          allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             readOnly: true
         {{- end }}
         securityContext:
-          allowPrivilegeEscalations
+          allowPrivilegeEscalation: false
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- with .Values.nodeSelector }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -93,6 +93,8 @@ spec:
             name: tls
             readOnly: true
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalations
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- with .Values.nodeSelector }}

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -256,9 +256,10 @@ func (b *stsBuilder) getPodInitContainers() []corev1.Container {
 					Args:            []string{fmt.Sprintf("chown -R %d:%d /home/nonroot/%s", nonRootUser, nonRootUser, *b.etcd.Spec.Backup.Store.Container)},
 					VolumeMounts:    []corev1.VolumeMount{*etcdBackupVolumeMount},
 					SecurityContext: &corev1.SecurityContext{
-						RunAsGroup:   ptr.To[int64](0),
-						RunAsNonRoot: ptr.To(false),
-						RunAsUser:    ptr.To[int64](0),
+						AllowPrivilegeEscalation: ptr.To(false),
+						RunAsGroup:               ptr.To[int64](0),
+						RunAsNonRoot:             ptr.To(false),
+						RunAsUser:                ptr.To[int64](0),
 					},
 				})
 			}

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -370,7 +370,10 @@ func (b *stsBuilder) getEtcdContainer() corev1.Container {
 				ContainerPort: b.clientPort,
 			},
 		},
-		Resources:    ptr.Deref(b.etcd.Spec.Etcd.Resources, defaultResourceRequirements),
+		Resources: ptr.Deref(b.etcd.Spec.Etcd.Resources, defaultResourceRequirements),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+		},
 		Env:          b.getEtcdContainerEnvVars(),
 		VolumeMounts: b.getEtcdContainerVolumeMounts(),
 	}
@@ -399,8 +402,11 @@ func (b *stsBuilder) getBackupRestoreContainer() (corev1.Container, error) {
 				ContainerPort: b.backupPort,
 			},
 		},
-		Env:          env,
-		Resources:    ptr.Deref(b.etcd.Spec.Backup.Resources, defaultResourceRequirements),
+		Env:       env,
+		Resources: ptr.Deref(b.etcd.Spec.Backup.Resources, defaultResourceRequirements),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+		},
 		VolumeMounts: b.getBackupRestoreContainerVolumeMounts(),
 	}, nil
 }

--- a/internal/controller/compaction/reconciler.go
+++ b/internal/controller/compaction/reconciler.go
@@ -305,6 +305,9 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 								v1.ResourceMemory: resource.MustParse("3Gi"),
 							},
 						},
+						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+						},
 					}},
 				},
 			},

--- a/internal/controller/etcdcopybackupstask/reconciler.go
+++ b/internal/controller/etcdcopybackupstask/reconciler.go
@@ -365,9 +365,10 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 				Args:         []string{fmt.Sprintf("%s%s%s%s", "chown -R 65532:65532 /home/nonroot/", *targetStore.Container, " /home/nonroot/", *sourceStore.Container)},
 				VolumeMounts: volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
-					RunAsGroup:   ptr.To[int64](0),
-					RunAsNonRoot: ptr.To(false),
-					RunAsUser:    ptr.To[int64](0),
+					AllowPrivilegeEscalation: ptr.To(false),
+					RunAsGroup:               ptr.To[int64](0),
+					RunAsNonRoot:             ptr.To(false),
+					RunAsUser:                ptr.To[int64](0),
 				},
 			},
 		}

--- a/internal/controller/etcdcopybackupstask/reconciler.go
+++ b/internal/controller/etcdcopybackupstask/reconciler.go
@@ -342,6 +342,9 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 							Args:            args,
 							Env:             env,
 							VolumeMounts:    volumeMounts,
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+							},
 						},
 					},
 					ShareProcessNamespace: ptr.To(true),

--- a/internal/health/etcdmember/check_ready_test.go
+++ b/internal/health/etcdmember/check_ready_test.go
@@ -265,6 +265,9 @@ func createMemberPod(name, namespace string, ready bool) *corev1.Pod {
 				{
 					Name:  "etcd",
 					Image: "etcd:3.4.26",
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+					},
 				},
 			},
 		},


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:
This PR sets `securityContext.allowPrivilegeEscalation` to false for every `Seed` and `Garden` cluster component container, which does not have `securityContext.Privileged` set to `true` or one of `CAP_SYS_ADMIN/SYS_ADMIN` capabilities added.

**Which issue(s) this PR 
Part of gardener/gardener#11139

**Special notes for your reviewer**:
cc @AleksandarSavchev @ialidzhikov 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Component containers, which do not require privilege escalations, now forbid privilege escalation explicitly.
```
