### PR TITLE
Fix charts by placing `volumeMounts` in the `containers` section of the pod spec.

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -88,8 +88,11 @@ spec:
         {{- if .Values.webhooks.etcdComponents.exemptServiceAccounts }}
         - --etcd-components-webhook-exempt-service-accounts={{ join "," .Values.webhooks.etcdComponents.exemptServiceAccounts }}
         {{- end }}
+        volumeMounts:
+          - mountPath: /etc/webhook-server-tls
+            name: tls
+            readOnly: true
         {{- end }}
-
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- with .Values.nodeSelector }}
@@ -109,10 +112,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- if .Values.webhooks.etcdComponents.enabled }}
-        volumeMounts:
-          - mountPath: /etc/webhook-server-tls
-            name: tls
-            readOnly: true
       volumes:
         - name: tls
           secret:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area delivery
/kind regression

**What this PR does / why we need it**:

#1043 caused a regression in the chart rendering. This PR fixes it.
`volumeMounts` must be present in the `containers` section of the pod spec. The charts currently render it under `nodeSelector`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
