### PR TITLE
Do not specify a value for `nodeSelector` in `charts/values.yaml`.

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -11,8 +11,7 @@ resources:
     cpu: 50m
     memory: 128Mi
 
-nodeSelector:
-  kubernetes.io/os: linux
+nodeSelector: {}
 
 affinity: {}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area delivery open-source
/kind cleanup

**What this PR does / why we need it**:

* `nodeSelector` was specified to be `kubernetes.io/os: linux` after #1043. However, this is not really general, and therefore is being removed `charts/values.yaml`. Consumers must specify their own `nodeSelector`, since `charts/values.yaml` is a very minimal example of configuration for etcd-druid.

**Special notes for your reviewer**:

cc @shreyas-s-rao

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
