### PR TITLE
CEL expression to invalidate setting/unsetting of immutable fields.

### DIFF
--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -1861,6 +1861,11 @@ spec:
             - labels
             - replicas
             type: object
+            x-kubernetes-validations:
+            - message: etcd.spec.storageClass is an immutable field.
+              rule: has(oldSelf.storageClass) ==  has(self.storageClass)
+            - message: etcd.spec.volumeClaimTemplate is an immutable field.
+              rule: has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)
           status:
             description: EtcdStatus defines the observed state of Etcd.
             properties:

--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -288,6 +288,8 @@ type SchedulingConstraints struct {
 }
 
 // EtcdSpec defines the desired state of Etcd
+// +kubebuilder:validation:XValidation:message="etcd.spec.storageClass is an immutable field.",rule="has(oldSelf.storageClass) ==  has(self.storageClass)"
+// +kubebuilder:validation:XValidation:message="etcd.spec.volumeClaimTemplate is an immutable field.",rule="has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)"
 type EtcdSpec struct {
 	// selector is a label query over pods that should match the replica count.
 	// It must match the pod template's labels.


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
1) Added immutability rule to prevent setting/unsetting the immutable fields in `etcd.Spec` after creation. This was overlooked in the previous [PR for CEL Validation](https://github.com/gardener/etcd-druid/pull/995).
2) Added integration tests for the same. 

**Which issue(s) this PR fixes**:
Fixes #1048 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added CEL expression to prevent unsetting and setting of immutable fields in etcd.Spec after creation.
```
