### PR TITLE
Remove unit test, integration test steps from PR jobs in concourse

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -10,6 +10,11 @@ etcd-druid:
         attribute: image.repository
       - ref: ocm-resource:etcd-druid.tag
         attribute: image.tag
+    test-steps: &test-steps
+      test:
+        image: 'golang:1.24.1'
+      test_integration:
+        image: 'golang:1.24.1'
 
   base_definition:
     repo:
@@ -55,16 +60,13 @@ etcd-druid:
     steps:
       check:
         image: 'golang:1.24.1'
-      test:
-        image: 'golang:1.24.1'
-      test_integration:
-        image: 'golang:1.24.1'
       build:
         image: 'golang:1.24.1'
         output_dir: 'binary'
 
   jobs:
     head-update:
+      steps: *test-steps
       traits:
         draft_release: ~
         component_descriptor:
@@ -84,6 +86,7 @@ etcd-druid:
           helmcharts:
           - *etcd-druid-chart
     release:
+      steps: *test-steps
       traits:
         version:
           preprocess: 'finalize'


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind cleanup

**What this PR does / why we need it**:
Remove unit test, integration test steps from PR jobs in concourse, since these are being run stably in prow jobs, and we don't want to duplicate the execution of these unit and integration tests.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Remove unit test, integration test steps from PR jobs in concourse.
```
