### PR TITLE
Re-introduce `/scale` subresource for Etcd CRD

### DIFF
--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -2092,9 +2092,20 @@ spec:
                 description: Replicas is the replica count of the etcd cluster.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  Selector is a label query over pods that should match the replica count.
+                  It must match the pod template's labels.
+                type: string
+            required:
+            - selector
             type: object
         type: object
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
@@ -1943,9 +1943,20 @@ spec:
                   description: Replicas is the replica count of the etcd cluster.
                   format: int32
                   type: integer
+                selector:
+                  description: |-
+                    Selector is a label query over pods that should match the replica count.
+                    It must match the pod template's labels.
+                  type: string
+              required:
+                - selector
               type: object
           type: object
       served: true
       storage: true
       subresources:
+        scale:
+          labelSelectorPath: .status.selector
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
         status: {}

--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -43,6 +43,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
 // +kubebuilder:printcolumn:name="Quorate",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="All Members Ready",type=string,JSONPath=`.status.conditions[?(@.type=="AllMembersReady")].status`
@@ -435,6 +436,9 @@ type EtcdStatus struct {
 	// PeerUrlTLSEnabled captures the state of peer url TLS being enabled for the etcd member(s)
 	// +optional
 	PeerUrlTLSEnabled *bool `json:"peerUrlTLSEnabled,omitempty"`
+	// Selector is a label query over pods that should match the replica count.
+	// It must match the pod template's labels.
+	Selector string `json:"selector"`
 }
 
 // LastOperationType is a string alias representing type of the last operation.

--- a/docs/api-reference/etcd-druid-api.md
+++ b/docs/api-reference/etcd-druid-api.md
@@ -428,6 +428,7 @@ _Appears in:_
 | `labelSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | LabelSelector is a label query over pods that should match the replica count.<br />It must match the pod template's labels.<br />Deprecated: this field will be removed in the future. |  |  |
 | `members` _[EtcdMemberStatus](#etcdmemberstatus) array_ | Members represents the members of the etcd cluster |  |  |
 | `peerUrlTLSEnabled` _boolean_ | PeerUrlTLSEnabled captures the state of peer url TLS being enabled for the etcd member(s) |  |  |
+| `selector` _string_ | Selector is a label query over pods that should match the replica count.<br />It must match the pod template's labels. |  |  |
 
 
 #### GarbageCollectionPolicy

--- a/docs/usage/managing-etcd-clusters.md
+++ b/docs/usage/managing-etcd-clusters.md
@@ -49,36 +49,36 @@ This will open up the linked editor where you can make the edits.
 
 ### Scale the Etcd cluster horizontally
 
-To scale the etcd cluster horizontally, you can update the `spec.replicas` field in the `Etcd` custom resource. For example, to scale the etcd cluster to 5 replicas, you can run:
+To scale an etcd cluster horizontally, you can update the `spec.replicas` field in the `Etcd` custom resource. For example, to scale an etcd cluster to 5 replicas, you can run:
 
 ```bash
 kubectl patch etcd <etcd-name> -n <namespace> --type merge -p '{"spec":{"replicas":5}}'
 ```
 
-Additionally, you can use the `/scale` subresource to scale the etcd cluster horizontally. For example, to scale the etcd cluster to 5 replicas, you can run:
+Alternatively, you can use the `/scale` subresource to scale an etcd cluster horizontally. For example, to scale an etcd cluster to 5 replicas, you can run:
 
 ```bash
 kubectl scale etcd <etcd-name> -n <namespace> --replicas=5
 ```
 
 !!! note
-    While the Etcd cluster can be scaled out, it cannot be scaled in, ie, the replicas cannot be decreased to a non-zero value. The Etcd cluster can still be scaled to 0 replicas, indicating that the cluster is to be "hibernated". This is beneficial for use-cases where the etcd cluster is not needed for a certain period of time, and the user does not want to pay for the compute resources. The hibernated etcd cluster can be resumed later by scaling it back to a non-zero value. Please note that the data volumes backing the Etcd cluster will be retained during hibernation, and will still be charged for.
+    While an Etcd cluster can be scaled out, it cannot be scaled in, i.e., the replicas cannot be decreased to a non-zero value. An Etcd cluster can still be scaled to 0 replicas, indicating that the cluster is to be "hibernated". This is beneficial for use-cases where an etcd cluster is not needed for a certain period of time, and the user does not want to pay for the compute resources. A hibernated etcd cluster can be resumed later by scaling it back to a non-zero value. Please note that the data volumes backing an Etcd cluster will be retained during hibernation, and will still be charged for.
 
 ### Scale the Etcd cluster vertically
 
-To scale the etcd cluster vertically, you can update the `spec.etcd.resources` and `spec.backup.resources` fields in the `Etcd` custom resource. For example, to scale the etcd container to 2 CPU and 4Gi memory, you can run:
+To scale an Etcd cluster vertically, you can update the `spec.etcd.resources` and `spec.backup.resources` fields in the `Etcd` custom resource. For example, to scale an Etcd cluster's `etcd` container to 2 CPU and 4Gi memory, you can run:
 
 ```bash
 kubectl patch etcd <etcd-name> -n <namespace> --type merge -p '{"spec":{"etcd":{"resources":{"requests":{"cpu":"2","memory":"4Gi"}}}}}'
 ```
 
-Additionally, you can use an external pod autoscaler such as [vertical pod autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) to scale the etcd cluster vertically. This is made possible by the `/scale` subresource on the Etcd custom resource.
+Additionally, you can use an external pod autoscaler such as [vertical pod autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) to scale an Etcd cluster vertically. This is made possible by the `/scale` subresource on the Etcd custom resource.
 
 !!! note
-    Scaling the Etcd cluster vertically can potentially result in downtime, based on its failure tolerance. This is due to the fact that the etcd cluster is actuated by pods, and the pods need to be restarted in order to apply the new resource values. A multi-member etcd cluster can tolerate a failure of one member, but if the number of replicas is set to 1, then the etcd cluster will not be able to tolerate any failures. Therefore, it is recommended to scale the etcd cluster vertically only when it is not under heavy load, and to monitor the cluster closely during the scaling process. A multi-member Etcd cluster is also accompanied by a pod disruption budget to ensure that the cluster can tolerate a certain number of failures. The pod disruption budget is automatically created and managed by etcd-druid, and it is recommended to not modify it manually.
+    Scaling an Etcd cluster vertically can potentially result in downtime, based on its failure tolerance. This is due to the fact that an etcd cluster is actuated by pods, and the pods need to be restarted in order to apply the new resource values. A multi-member etcd cluster can tolerate a failure of one member, but if the number of replicas is set to 1, then the etcd cluster will not be able to tolerate any failures. Therefore, it is recommended to scale a single-member etcd cluster vertically only when it is deemed necessary, and to monitor the cluster closely during the scaling process. A multi-member Etcd cluster can be scaled vertically, one member at a time. A pod disruption budget for this can ensure that the cluster can tolerate a certain number of failures. This pod disruption budget is automatically deployed and managed by etcd-druid for multi-member Etcd clusters, and it is recommended to not modify this PDB manually.
 
 !!! note
-    While the replicas and resources in the Etcd resource spec can be modified, please ensure to read the next section to understand when and how these changes are actuated by etcd-druid.
+    While the replicas and resources in an Etcd resource spec can be modified, please ensure to read the next section to understand when and how these changes are reconciled by etcd-druid.
 
 ### Reconcile
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area scalability auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Re-introduce `/scale` subresource for `Etcd` CRD, to enable usage of VPA to target Etcd resources instead of underlying statefulset resource.

**Which issue(s) this PR fixes**:
Fixes #1069 

**Special notes for your reviewer**:
Can be tested using the following steps (pre-requisites: kubectl, helm): 
```console
# deploy etcd-druid
make kind-up
make deploy

# deploy Etcd resource, which should be reconciled immediately
kubectl apply -f examples/etcd/druid_v1alpha1_etcd.yaml

# check scale subresource 
kubectl get etcd etcd-test --subresource scale -oyaml

# -------- test vertical pod autoscaling --------

# install metrics server
kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml

# install VPA
helm repo add cowboysysop https://cowboysysop.github.io/charts/
helm install <release-name> cowboysysop/vertical-pod-autoscaler

# deploy VPA object for the Etcd resource
cat <<EOF | kubectl apply -f -
apiVersion: autoscaling.k8s.io/v1
kind: VerticalPodAutoscaler
metadata:
  name: etcd-test
spec:
  resourcePolicy:
    containerPolicies:
    - containerName: etcd
      controlledValues: RequestsOnly
      minAllowed:
        memory: 100M
      mode: Auto
    - containerName: backup-restore
      controlledValues: RequestsOnly
      mode: "Off"
  targetRef:
    apiVersion: druid.gardener.cloud/v1alpha1
    kind: Etcd
    name: etcd-test
  updatePolicy:
    evictionRequirements:
    - changeRequirement: TargetHigherThanRequests
      resources:
      - memory
      - cpu
    updateMode: Auto
EOF

# check vpa-updater logs to confirm that VPA sees the etcd pods and updates their resources accordingly
# check for etcd pod restarts caused by VPA updates, where pod resources are set to the
# target recommendations from the VPA object status
```
/invite @unmarshall 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Re-introduce `/scale` subresource for Etcd CRD.
```
