### PR TITLE
Upgrade `.ci/pipeline_definitions` and `Dockerfile` to Go 1.24.2. (#1073)

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -12,9 +12,9 @@ etcd-druid:
         attribute: image.tag
     test-steps: &test-steps
       test:
-        image: 'golang:1.24.1'
+        image: 'golang:1.24.2'
       test_integration:
-        image: 'golang:1.24.1'
+        image: 'golang:1.24.2'
 
   base_definition:
     repo:
@@ -59,9 +59,9 @@ etcd-druid:
                 teamname: 'gardener/etcd-druid-maintainers'
     steps:
       check:
-        image: 'golang:1.24.1'
+        image: 'golang:1.24.2'
       build:
-        image: 'golang:1.24.1'
+        image: 'golang:1.24.2'
         output_dir: 'binary'
 
   jobs:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -10,6 +10,11 @@ etcd-druid:
         attribute: image.repository
       - ref: ocm-resource:etcd-druid.tag
         attribute: image.tag
+    test-steps: &test-steps
+      test:
+        image: 'golang:1.24.1'
+      test_integration:
+        image: 'golang:1.24.1'
 
   base_definition:
     repo:
@@ -55,16 +60,13 @@ etcd-druid:
     steps:
       check:
         image: 'golang:1.24.1'
-      test:
-        image: 'golang:1.24.1'
-      test_integration:
-        image: 'golang:1.24.1'
       build:
         image: 'golang:1.24.1'
         output_dir: 'binary'
 
   jobs:
     head-update:
+      steps: *test-steps
       traits:
         draft_release: ~
         component_descriptor:
@@ -84,6 +86,7 @@ etcd-druid:
           helmcharts:
           - *etcd-druid-chart
     release:
+      steps: *test-steps
       traits:
         version:
           preprocess: 'finalize'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.1 as builder
+FROM golang:1.24.2 as builder
 WORKDIR /go/src/github.com/gardener/etcd-druid
 COPY . .
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area quality security
/kind enhancement

**What this PR does / why we need it**:

Cherry-picks #1056 and #1073.

Upgrade `.ci/pipeline_definitions` and `Dockerfile` to Go 1.24.2.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
