### PR TITLE
Upgrade etcd-backup-restore from v0.35.1 to v0.35.2 (#1075)

### DIFF
--- a/internal/images/images.yaml
+++ b/internal/images/images.yaml
@@ -8,7 +8,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.35.1"
+  tag: "v0.35.2"
 - name: alpine
   repository: europe-docker.pkg.dev/gardener-project/public/3rd/alpine
   tag: "3.21.3"


### PR DESCRIPTION


**What this PR does / why we need it**:
Cherry pick PR of https://github.com/gardener/etcd-druid/pull/1075

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
**Release Notes**:
```improvement operator github.com/gardener/etcd-backup-restore #870 @ishan16696
Support non-HA autonomous clusters by skipping creation of Kubernetes clientset.
⚠️ To completely prevent the creation of the Kubernetes `clientSet` in the non-HA etcd-backup-restore, please also set the following CLI flags to `false`: `--enable-member-lease-renewal` and `--enable-snapshot-lease-renewal`.
```
