### PR TITLE
Configurable ports

### DIFF
--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -636,6 +636,9 @@ spec:
                       More info: https://etcd.io/docs/v3.4/op-guide/maintenance/#raft-log-retention
                     format: int64
                     type: integer
+                  wrapperPort:
+                    format: int32
+                    type: integer
                 type: object
               labels:
                 additionalProperties:

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
@@ -580,6 +580,9 @@ spec:
                         More info: https://etcd.io/docs/v3.4/op-guide/maintenance/#raft-log-retention
                       format: int64
                       type: integer
+                    wrapperPort:
+                      format: int32
+                      type: integer
                   type: object
                 labels:
                   additionalProperties:

--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -215,6 +215,8 @@ type EtcdConfig struct {
 	ServerPort *int32 `json:"serverPort,omitempty"`
 	// +optional
 	ClientPort *int32 `json:"clientPort,omitempty"`
+	// +optional
+	WrapperPort *int32 `json:"wrapperPort,omitempty"`
 	// Image defines the etcd container image and tag
 	// +optional
 	Image *string `json:"image,omitempty"`

--- a/api/core/v1alpha1/etcd_test.go
+++ b/api/core/v1alpha1/etcd_test.go
@@ -121,6 +121,7 @@ func createEtcd(name, namespace string) *Etcd {
 		clientPort    int32 = 2379
 		serverPort    int32 = 2380
 		backupPort    int32 = 8080
+		wrapperPort   int32 = 9095
 		metricLevel         = Basic
 		snapshotCount int64 = 75000
 	)
@@ -241,6 +242,7 @@ func createEtcd(name, namespace string) *Etcd {
 				},
 				ClientPort:    &clientPort,
 				ServerPort:    &serverPort,
+				WrapperPort:   &wrapperPort,
 				SnapshotCount: &snapshotCount,
 				ClientUrlTLS:  clientTlsConfig,
 				PeerUrlTLS:    peerTlsConfig,

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -266,6 +266,11 @@ func (in *EtcdConfig) DeepCopyInto(out *EtcdConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.WrapperPort != nil {
+		in, out := &in.WrapperPort, &out.WrapperPort
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(string)

--- a/docs/api-reference/etcd-druid-api.md
+++ b/docs/api-reference/etcd-druid-api.md
@@ -251,6 +251,7 @@ _Appears in:_
 | `defragmentationSchedule` _string_ | DefragmentationSchedule defines the cron standard schedule for defragmentation of etcd. |  | Pattern: `^(\*\|[1-5]?[0-9]\|[1-5]?[0-9]-[1-5]?[0-9]\|(?:[1-9]\|[1-4][0-9]\|5[0-9])\/(?:[1-9]\|[1-4][0-9]\|5[0-9]\|60)\|\*\/(?:[1-9]\|[1-4][0-9]\|5[0-9]\|60))\s+(\*\|[0-9]\|1[0-9]\|2[0-3]\|[0-9]-(?:[0-9]\|1[0-9]\|2[0-3])\|1[0-9]-(?:1[0-9]\|2[0-3])\|2[0-3]-2[0-3]\|(?:[1-9]\|1[0-9]\|2[0-3])\/(?:[1-9]\|1[0-9]\|2[0-4])\|\*\/(?:[1-9]\|1[0-9]\|2[0-4]))\s+(\*\|[1-9]\|[12][0-9]\|3[01]\|[1-9]-(?:[1-9]\|[12][0-9]\|3[01])\|[12][0-9]-(?:[12][0-9]\|3[01])\|3[01]-3[01]\|(?:[1-9]\|[12][0-9]\|30)\/(?:[1-9]\|[12][0-9]\|3[01])\|\*\/(?:[1-9]\|[12][0-9]\|3[01]))\s+(\*\|[1-9]\|1[0-2]\|[1-9]-(?:[1-9]\|1[0-2])\|1[0-2]-1[0-2]\|(?:[1-9]\|1[0-2])\/(?:[1-9]\|1[0-2])\|\*\/(?:[1-9]\|1[0-2]))\s+(\*\|[1-7]\|[1-6]-[1-7]\|[1-6]\/[1-7]\|\*\/[1-7])$` <br /> |
 | `serverPort` _integer_ |  |  |  |
 | `clientPort` _integer_ |  |  |  |
+| `wrapperPort` _integer_ |  |  |  |
 | `image` _string_ | Image defines the etcd container image and tag |  |  |
 | `authSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  |  |
 | `metrics` _[MetricsLevel](#metricslevel)_ | Metrics defines the level of detail for exported metrics of etcd, specify 'extensive' to include histogram metrics. |  | Enum: [basic extensive] <br /> |

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -61,6 +61,7 @@ func main() {
 				DefragmentationSchedule: ptr.To("0 */24 * * *"),
 				ServerPort:              ptr.To[int32](2380),
 				ClientPort:              ptr.To[int32](2379),
+				WrapperPort:             ptr.To[int32](9095),
 				Resources: &corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						"cpu":    resource.MustParse("500m"),

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -607,6 +607,9 @@ func (b *stsBuilder) getEtcdContainerCommandArgs() []string {
 		commandArgs = append(commandArgs, fmt.Sprintf("--etcd-client-cert-path=%s/tls.crt", common.VolumeMountPathEtcdClientTLS))
 		commandArgs = append(commandArgs, fmt.Sprintf("--etcd-client-key-path=%s/tls.key", common.VolumeMountPathEtcdClientTLS))
 	}
+	if port := b.clientPort; port != 0 {
+		commandArgs = append(commandArgs, fmt.Sprintf("--etcd-client-port=%d", port))
+	}
 	return commandArgs
 }
 

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -417,6 +417,7 @@ func (b *stsBuilder) getBackupRestoreContainer() (corev1.Container, error) {
 
 func (b *stsBuilder) getBackupRestoreContainerCommandArgs() []string {
 	commandArgs := []string{"server"}
+	commandArgs = append(commandArgs, fmt.Sprintf("--server-port=%d", b.backupPort))
 
 	// Backup store related command line args
 	// -----------------------------------------------------------------------------------------------------------------

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -65,9 +65,10 @@ type stsBuilder struct {
 	sts                    *appsv1.StatefulSet
 	logger                 logr.Logger
 
-	clientPort int32
-	serverPort int32
-	backupPort int32
+	clientPort  int32
+	serverPort  int32
+	backupPort  int32
+	wrapperPort int32
 	// skipSetOrUpdateForbiddenFields if its true then it will set/update values to fields which are forbidden to be updated for an existing StatefulSet.
 	// Updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden.
 	// Only for a new StatefulSet should this be set to true.
@@ -102,6 +103,7 @@ func newStsBuilder(client client.Client,
 		clientPort:                     ptr.Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient),
 		serverPort:                     ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer),
 		backupPort:                     ptr.Deref(etcd.Spec.Backup.Port, common.DefaultPortEtcdBackupRestore),
+		wrapperPort:                    ptr.Deref(etcd.Spec.Etcd.WrapperPort, common.DefaultPortEtcdWrapper),
 		skipSetOrUpdateForbiddenFields: skipSetOrUpdateForbiddenFields,
 	}, nil
 }
@@ -609,6 +611,9 @@ func (b *stsBuilder) getEtcdContainerCommandArgs() []string {
 	}
 	if port := b.clientPort; port != 0 {
 		commandArgs = append(commandArgs, fmt.Sprintf("--etcd-client-port=%d", port))
+	}
+	if port := b.wrapperPort; port != 0 {
+		commandArgs = append(commandArgs, fmt.Sprintf("--etcd-wrapper-port=%d", port))
 	}
 	return commandArgs
 }

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -584,7 +584,7 @@ func (b *stsBuilder) getEtcdContainerReadinessHandler() corev1.ProbeHandler {
 
 	scheme := utils.IfConditionOr(b.etcd.Spec.Backup.TLS == nil, corev1.URISchemeHTTP, corev1.URISchemeHTTPS)
 	path := utils.IfConditionOr(multiNodeCluster, "/readyz", "/healthz")
-	port := utils.IfConditionOr(multiNodeCluster, common.DefaultPortEtcdWrapper, common.DefaultPortEtcdBackupRestore)
+	port := utils.IfConditionOr(multiNodeCluster, b.wrapperPort, b.backupPort)
 
 	return corev1.ProbeHandler{
 		HTTPGet: &corev1.HTTPGetAction{

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -597,7 +597,7 @@ func (b *stsBuilder) getEtcdContainerReadinessHandler() corev1.ProbeHandler {
 
 func (b *stsBuilder) getEtcdContainerCommandArgs() []string {
 	commandArgs := []string{"start-etcd"}
-	commandArgs = append(commandArgs, fmt.Sprintf("--backup-restore-host-port=%s-local:%d", b.etcd.Name, common.DefaultPortEtcdBackupRestore))
+	commandArgs = append(commandArgs, fmt.Sprintf("--backup-restore-host-port=%s-local:%d", b.etcd.Name, b.backupPort))
 	commandArgs = append(commandArgs, fmt.Sprintf("--etcd-server-name=%s-local", b.etcd.Name))
 
 	if b.etcd.Spec.Etcd.ClientUrlTLS == nil {

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -291,6 +291,7 @@ func (s StatefulSetMatcher) matchEtcdContainerCmdArgs() gomegatypes.GomegaMatche
 		cmdArgs = append(cmdArgs, "--etcd-client-key-path=/var/etcd/ssl/client/tls.key")
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--backup-restore-ca-cert-bundle-path=/var/etcdbr/ssl/ca/%s", dataKey))
 	}
+	cmdArgs = append(cmdArgs, fmt.Sprintf("--etcd-client-port=%d", s.clientPort))
 	return HaveExactElements(cmdArgs)
 }
 

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -249,7 +249,7 @@ func (s StatefulSetMatcher) matchBackupRestoreContainer() gomegatypes.GomegaMatc
 func (s StatefulSetMatcher) matchEtcdContainerReadinessHandler() gomegatypes.GomegaMatcher {
 	scheme := utils.IfConditionOr(s.etcd.Spec.Backup.TLS == nil, corev1.URISchemeHTTP, corev1.URISchemeHTTPS)
 	path := utils.IfConditionOr(s.etcd.Spec.Replicas > 1, "/readyz", "/healthz")
-	port := utils.IfConditionOr(s.etcd.Spec.Replicas > 1, int32(9095), int32(8080))
+	port := utils.IfConditionOr(s.etcd.Spec.Replicas > 1, s.wrapperPort, s.backupPort)
 	return MatchFields(IgnoreExtras|IgnoreMissing, Fields{
 		"HTTPGet": PointTo(MatchFields(IgnoreExtras|IgnoreMissing, Fields{
 			"Path": Equal(path),

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -282,7 +282,7 @@ func (s StatefulSetMatcher) matchEtcdContainerReadinessProbeCmd() gomegatypes.Go
 func (s StatefulSetMatcher) matchEtcdContainerCmdArgs() gomegatypes.GomegaMatcher {
 	cmdArgs := make([]string, 0, 8)
 	cmdArgs = append(cmdArgs, "start-etcd")
-	cmdArgs = append(cmdArgs, fmt.Sprintf("--backup-restore-host-port=%s-local:8080", s.etcd.Name))
+	cmdArgs = append(cmdArgs, fmt.Sprintf("--backup-restore-host-port=%s-local:%d", s.etcd.Name, s.backupPort))
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--etcd-server-name=%s-local", s.etcd.Name))
 	if s.etcd.Spec.Etcd.ClientUrlTLS == nil {
 		cmdArgs = append(cmdArgs, "--backup-restore-tls-enabled=false")

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -49,6 +49,7 @@ type StatefulSetMatcher struct {
 	clientPort         int32
 	serverPort         int32
 	backupPort         int32
+	wrapperPort        int32
 }
 
 // NewStatefulSetMatcher constructs a new instance of StatefulSetMatcher.
@@ -70,6 +71,7 @@ func NewStatefulSetMatcher(g *WithT,
 		clientPort:         ptr.Deref(etcd.Spec.Etcd.ClientPort, 2379),
 		serverPort:         ptr.Deref(etcd.Spec.Etcd.ServerPort, 2380),
 		backupPort:         ptr.Deref(etcd.Spec.Backup.Port, 8080),
+		wrapperPort:        ptr.Deref(etcd.Spec.Etcd.WrapperPort, 9095),
 	}
 }
 
@@ -292,6 +294,7 @@ func (s StatefulSetMatcher) matchEtcdContainerCmdArgs() gomegatypes.GomegaMatche
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--backup-restore-ca-cert-bundle-path=/var/etcdbr/ssl/ca/%s", dataKey))
 	}
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--etcd-client-port=%d", s.clientPort))
+	cmdArgs = append(cmdArgs, fmt.Sprintf("--etcd-wrapper-port=%d", s.wrapperPort))
 	return HaveExactElements(cmdArgs)
 }
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -106,6 +106,7 @@ var (
 	}
 	etcdClientPort    = int32(2379)
 	etcdServerPort    = int32(2380)
+	etcdWrapperPort   = int32(9095)
 	etcdSnapshotCount = int64(75000)
 
 	backupPort                 = int32(8080)
@@ -175,6 +176,7 @@ func getDefaultEtcd(name, namespace, container, prefix string, provider TestProv
 		Resources:               &etcdResources,
 		ClientPort:              &etcdClientPort,
 		ServerPort:              &etcdServerPort,
+		WrapperPort:             &etcdWrapperPort,
 		SnapshotCount:           &etcdSnapshotCount,
 		ClientUrlTLS:            &etcdTLS,
 	}

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -287,6 +287,14 @@ func (eb *EtcdBuilder) WithEtcdClientPort(clientPort *int32) *EtcdBuilder {
 	return eb
 }
 
+func (eb *EtcdBuilder) WithEtcdWrapperPort(wrapperPort *int32) *EtcdBuilder {
+	if eb == nil || eb.etcd == nil {
+		return nil
+	}
+	eb.etcd.Spec.Etcd.WrapperPort = wrapperPort
+	return eb
+}
+
 func (eb *EtcdBuilder) WithEtcdClientServiceLabels(labels map[string]string) *EtcdBuilder {
 	if eb == nil || eb.etcd == nil {
 		return nil
@@ -434,8 +442,9 @@ func getDefaultEtcd(name, namespace string) *druidv1alpha1.Etcd {
 						"memory": ParseQuantity("1000Mi"),
 					},
 				},
-				ClientPort: ptr.To(common.DefaultPortEtcdClient),
-				ServerPort: ptr.To(common.DefaultPortEtcdPeer),
+				ClientPort:  ptr.To(common.DefaultPortEtcdClient),
+				ServerPort:  ptr.To(common.DefaultPortEtcdPeer),
+				WrapperPort: ptr.To(common.DefaultPortEtcdWrapper),
 			},
 			Common: druidv1alpha1.SharedConfig{
 				AutoCompactionMode:      &autoCompactionMode,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR
- fixes an issue which was not properly passing the etcd client port to `etcd-wrapper` (it was not configurable there before https://github.com/gardener/etcd-wrapper/pull/52)
- adds a new `WrapperPort` field to the `Etcd` API which allows to configure the server port of `etcd-wrapper`
- fixes an issue which was not properly passing the backup port to `etcd-wrapper`
- fixes an issue which was not properly configuring the readiness probes with the correct ports
- fixes an issue which was not properly passing the backup port to `etcd-backup-restore`

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/etcd-druid/issues/1071

**Special notes for your reviewer**:
Requires https://github.com/gardener/etcd-wrapper/pull/52
/cc @shreyas-s-rao @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The new `.spec.etcd.wrapperPort` field allows to change the server port of `etcd-wrapper`.
```
```bugfix developer
An issue has been fixed which caused `etcd` pods not to start when port different from the default values were used.
```
