### PR TITLE
Use `/root` as home dir instead of `/home/nonroot` when running as `root`

### DIFF
--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -246,29 +246,29 @@ func (b *stsBuilder) getVolumeClaimTemplates() []corev1.PersistentVolumeClaim {
 }
 
 func (b *stsBuilder) getPodInitContainers() []corev1.Container {
-	initContainers := make([]corev1.Container, 0, 1)
-	if b.etcd.IsBackupStoreEnabled() {
-		if b.provider != nil && *b.provider == druidstore.Local {
-			etcdBackupVolumeMount := b.getEtcdBackupVolumeMount()
-			if etcdBackupVolumeMount != nil {
-				initContainers = append(initContainers, corev1.Container{
-					Name:            common.InitContainerNameChangeBackupBucketPermissions,
-					Image:           b.initContainerImage,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"sh", "-c", "--"},
-					Args:            []string{fmt.Sprintf("chown -R %d:%d /home/nonroot/%s", nonRootUser, nonRootUser, *b.etcd.Spec.Backup.Store.Container)},
-					VolumeMounts:    []corev1.VolumeMount{*etcdBackupVolumeMount},
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
-						RunAsGroup:               ptr.To[int64](0),
-						RunAsNonRoot:             ptr.To(false),
-						RunAsUser:                ptr.To[int64](0),
-					},
-				})
-			}
-		}
+	if !b.etcd.IsBackupStoreEnabled() || b.provider == nil || *b.provider != druidstore.Local || ptr.Deref(b.etcd.Spec.RunAsRoot, false) || b.getEtcdBackupVolumeMount() == nil {
+		return nil
 	}
-	return initContainers
+
+	etcdBackupVolumeMount := b.getEtcdBackupVolumeMount()
+	if etcdBackupVolumeMount == nil {
+		return nil
+	}
+
+	return []corev1.Container{{
+		Name:            common.InitContainerNameChangeBackupBucketPermissions,
+		Image:           b.initContainerImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command:         []string{"sh", "-c", "--"},
+		Args:            []string{fmt.Sprintf("chown -R %d:%d %s", nonRootUser, nonRootUser, kubernetes.MountPathLocalStore(b.etcd, b.provider))},
+		VolumeMounts:    []corev1.VolumeMount{*etcdBackupVolumeMount},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			RunAsGroup:               ptr.To[int64](0),
+			RunAsNonRoot:             ptr.To(false),
+			RunAsUser:                ptr.To[int64](0),
+		},
+	}}
 }
 
 func (b *stsBuilder) getEtcdContainerVolumeMounts() []corev1.VolumeMount {

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -86,7 +86,7 @@ func newStsBuilder(client client.Client,
 	if err != nil {
 		return nil, err
 	}
-	provider, err := getBackupStoreProvider(etcd)
+	provider, err := kubernetes.GetBackupStoreProvider(etcd)
 	if err != nil {
 		return nil, err
 	}
@@ -859,15 +859,4 @@ func (b *stsBuilder) getBackupVolume(ctx component.OperatorContext) (*corev1.Vol
 		}, nil
 	}
 	return nil, nil
-}
-
-func getBackupStoreProvider(etcd *druidv1alpha1.Etcd) (*string, error) {
-	if !etcd.IsBackupStoreEnabled() {
-		return nil, nil
-	}
-	provider, err := druidstore.StorageProviderFromInfraProvider(etcd.Spec.Backup.Store.Provider)
-	if err != nil {
-		return nil, err
-	}
-	return &provider, nil
 }

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -330,7 +330,7 @@ func (b *stsBuilder) getEtcdBackupVolumeMount() *corev1.VolumeMount {
 		if b.etcd.Spec.Backup.Store.Container != nil {
 			return &corev1.VolumeMount{
 				Name:      common.VolumeNameLocalBackup,
-				MountPath: fmt.Sprintf("/home/nonroot/%s", ptr.Deref(b.etcd.Spec.Backup.Store.Container, "")),
+				MountPath: kubernetes.MountPathLocalStore(b.etcd, b.provider),
 			}
 		}
 	case druidstore.GCS:

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -345,7 +345,10 @@ func (s StatefulSetMatcher) getEtcdBackupVolumeMountMatcher() gomegatypes.Gomega
 	switch *s.provider {
 	case druidstore.Local:
 		if s.etcd.Spec.Backup.Store.Container != nil {
-			return matchVolMount(common.VolumeNameLocalBackup, fmt.Sprintf("/home/nonroot/%s", ptr.Deref(s.etcd.Spec.Backup.Store.Container, "")))
+			if ptr.Deref(s.etcd.Spec.RunAsRoot, false) {
+				return matchVolMount(common.VolumeNameLocalBackup, fmt.Sprintf("/root/%s", *s.etcd.Spec.Backup.Store.Container))
+			}
+			return matchVolMount(common.VolumeNameLocalBackup, fmt.Sprintf("/home/nonroot/%s", *s.etcd.Spec.Backup.Store.Container))
 		}
 	case druidstore.GCS:
 		return matchVolMount(common.VolumeNameProviderBackupSecret, common.VolumeMountPathGCSBackupSecret)

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -163,7 +163,7 @@ func (s StatefulSetMatcher) matchPodHostAliases() gomegatypes.GomegaMatcher {
 
 func (s StatefulSetMatcher) matchPodInitContainers() gomegatypes.GomegaMatcher {
 	initContainerMatcherElements := make(map[string]gomegatypes.GomegaMatcher)
-	if s.etcd.IsBackupStoreEnabled() && s.provider != nil && *s.provider == druidstore.Local {
+	if s.etcd.IsBackupStoreEnabled() && s.provider != nil && *s.provider == druidstore.Local && !ptr.Deref(s.etcd.Spec.RunAsRoot, false) {
 		changeBackupBucketPermissionsMatcher := MatchFields(IgnoreExtras, Fields{
 			"Name":            Equal(common.InitContainerNameChangeBackupBucketPermissions),
 			"Image":           Equal(s.initContainerImage),

--- a/internal/controller/compaction/reconciler.go
+++ b/internal/controller/compaction/reconciler.go
@@ -17,6 +17,7 @@ import (
 	druidstore "github.com/gardener/etcd-druid/internal/store"
 	"github.com/gardener/etcd-druid/internal/utils"
 	"github.com/gardener/etcd-druid/internal/utils/imagevector"
+	"github.com/gardener/etcd-druid/internal/utils/kubernetes"
 
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
@@ -380,7 +381,7 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 		return nil, err
 	}
 
-	//TODO (abdasgupta): Evaluate necessity of claiming object here after creation
+	// TODO (abdasgupta): Evaluate necessity of claiming object here after creation
 	return job, nil
 }
 
@@ -551,7 +552,7 @@ func getCompactionJobVolumeMounts(etcd *druidv1alpha1.Etcd) ([]v1.VolumeMount, e
 	case druidstore.Local:
 		vms = append(vms, v1.VolumeMount{
 			Name:      "host-storage",
-			MountPath: "/home/nonroot/" + ptr.Deref(etcd.Spec.Backup.Store.Container, ""),
+			MountPath: kubernetes.MountPathLocalStore(etcd, &provider),
 		})
 	case druidstore.GCS:
 		vms = append(vms, v1.VolumeMount{

--- a/internal/utils/kubernetes/store.go
+++ b/internal/utils/kubernetes/store.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	druidstore "github.com/gardener/etcd-druid/internal/store"
+)
+
+// GetBackupStoreProvider returns the provider name for the backup store. If the provider is not known, an error is
+// returned.
+func GetBackupStoreProvider(etcd *druidv1alpha1.Etcd) (*string, error) {
+	if !etcd.IsBackupStoreEnabled() {
+		return nil, nil
+	}
+	provider, err := druidstore.StorageProviderFromInfraProvider(etcd.Spec.Backup.Store.Provider)
+	if err != nil {
+		return nil, err
+	}
+	return &provider, nil
+}

--- a/internal/utils/kubernetes/store_test.go
+++ b/internal/utils/kubernetes/store_test.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubernetes
+
+import (
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	testutils "github.com/gardener/etcd-druid/test/utils"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestMountPathLocalStore(t *testing.T) {
+	newEtcdBuilder := func() *testutils.EtcdBuilder {
+		return testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace)
+	}
+	testCases := []struct {
+		name           string
+		etcd           *druidv1alpha1.Etcd
+		provider       *string
+		expectedResult string
+	}{
+		{
+			name:           "should return empty string if backup store is not enabled",
+			etcd:           newEtcdBuilder().Build(),
+			expectedResult: "",
+		},
+		{
+			name:           "should return empty string if provider is nil",
+			etcd:           newEtcdBuilder().WithProviderLocal().Build(),
+			expectedResult: "",
+		},
+		{
+			name:           "should return empty string if provider is not 'Local'",
+			etcd:           newEtcdBuilder().WithProviderS3().Build(),
+			provider:       ptr.To("S3"),
+			expectedResult: "",
+		},
+		{
+			name:           "should return non-root homedir with path if container is set",
+			etcd:           newEtcdBuilder().WithProviderLocal().Build(),
+			provider:       ptr.To("Local"),
+			expectedResult: "/home/nonroot/default.bkp",
+		},
+		{
+			name:           "should return root homedir with path if container is set",
+			etcd:           newEtcdBuilder().WithProviderLocal().WithRunAsRoot(ptr.To(true)).Build(),
+			provider:       ptr.To("Local"),
+			expectedResult: "/root/default.bkp",
+		},
+		{
+			name: "should return non-root homedir without path if container is nil",
+			etcd: func() *druidv1alpha1.Etcd {
+				etcd := newEtcdBuilder().WithProviderLocal().Build()
+				etcd.Spec.Backup.Store.Container = nil
+				return etcd
+			}(),
+			provider:       ptr.To("Local"),
+			expectedResult: "/home/nonroot",
+		},
+		{
+			name: "should return root homedir without path if container is nil",
+			etcd: func() *druidv1alpha1.Etcd {
+				etcd := newEtcdBuilder().WithProviderLocal().WithRunAsRoot(ptr.To(true)).Build()
+				etcd.Spec.Backup.Store.Container = nil
+				return etcd
+			}(),
+			provider:       ptr.To("Local"),
+			expectedResult: "/root",
+		},
+	}
+
+	g := NewWithT(t)
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g.Expect(MountPathLocalStore(tc.etcd, tc.provider)).To(Equal(tc.expectedResult))
+		})
+	}
+}

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -121,6 +121,14 @@ func (eb *EtcdBuilder) WithPeerTLS() *EtcdBuilder {
 	return eb
 }
 
+func (eb *EtcdBuilder) WithRunAsRoot(runAsRoot *bool) *EtcdBuilder {
+	if eb == nil || eb.etcd == nil {
+		return nil
+	}
+	eb.etcd.Spec.RunAsRoot = runAsRoot
+	return eb
+}
+
 func (eb *EtcdBuilder) WithReadyStatus() *EtcdBuilder {
 	if eb == nil || eb.etcd == nil {
 		return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
In https://github.com/gardener/etcd-druid/pull/1088, we introduced `spec.runAsRoot` in the `Etcd` API. However, when set to `true` and when using the `local` provider for backups, the bucket path is mounted to `/home/nonroot`. This does not play well together with `etcd-backup-restore` which uses the home directory for looking up the bucket: https://github.com/gardener/etcd-backup-restore/blob/beafd20c79dd41e266c303590e3fe8cc316a46bb/pkg/snapstore/utils.go#L72-L76

This PR changes the mount path to `/root` when `.spec.runAsRoot` is set to `true`. The init container is not needed in this case.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/etcd-druid/pull/1088

**Special notes for your reviewer**:
/cc @unmarshall @anveshreddy18 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
