### PR TITLE
Fix local provider setup for running Etcd clusters

### DIFF
--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -833,7 +833,7 @@ func (b *stsBuilder) getBackupVolume(ctx component.OperatorContext) (*corev1.Vol
 			return nil, fmt.Errorf("error getting host mount path for etcd: %v Err: %w", druidv1alpha1.GetNamespaceName(b.etcd.ObjectMeta), err)
 		}
 
-		hpt := corev1.HostPathDirectory
+		hpt := corev1.HostPathDirectoryOrCreate
 		return &corev1.Volume{
 			Name: common.VolumeNameLocalBackup,
 			VolumeSource: corev1.VolumeSource{

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -507,7 +507,7 @@ func (s StatefulSetMatcher) getBackupVolumeMatcher() gomegatypes.GomegaMatcher {
 			"VolumeSource": MatchFields(IgnoreExtras, Fields{
 				"HostPath": PointTo(MatchFields(IgnoreExtras, Fields{
 					"Path": Equal(fmt.Sprintf("%s/%s", hostPath, ptr.Deref(s.etcd.Spec.Backup.Store.Container, ""))),
-					"Type": PointTo(Equal(corev1.HostPathDirectory)),
+					"Type": PointTo(Equal(corev1.HostPathDirectoryOrCreate)),
 				})),
 			}),
 		})

--- a/internal/controller/compaction/reconciler.go
+++ b/internal/controller/compaction/reconciler.go
@@ -590,7 +590,7 @@ func getCompactionJobVolumes(ctx context.Context, cl client.Client, logger logr.
 			return vs, fmt.Errorf("could not determine host mount path for local provider")
 		}
 
-		hpt := v1.HostPathDirectory
+		hpt := v1.HostPathDirectoryOrCreate
 		vs = append(vs, v1.Volume{
 			Name: "host-storage",
 			VolumeSource: v1.VolumeSource{

--- a/internal/controller/etcdcopybackupstask/reconciler.go
+++ b/internal/controller/etcdcopybackupstask/reconciler.go
@@ -441,7 +441,7 @@ func getVolumeNamePrefix(prefix string) string {
 func (r *Reconciler) createVolumesFromStore(ctx context.Context, store *druidv1alpha1.StoreSpec, namespace, provider, prefix string) (volumes []corev1.Volume, err error) {
 	switch provider {
 	case druidstore.Local:
-		hostPathDirectory := corev1.HostPathDirectory
+		hostPathDirectory := corev1.HostPathDirectoryOrCreate
 		hostPathPrefix, err := druidstore.GetHostMountPathFromSecretRef(ctx, r.Client, r.logger, store, namespace)
 		if err != nil {
 			return nil, err

--- a/internal/controller/etcdcopybackupstask/reconciler_test.go
+++ b/internal/controller/etcdcopybackupstask/reconciler_test.go
@@ -534,7 +534,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 				hostPathVolumeSource := volumes[0].VolumeSource.HostPath
 				Expect(hostPathVolumeSource).NotTo(BeNil())
 				Expect(hostPathVolumeSource.Path).To(Equal("/test/hostPath/" + *store.Container))
-				Expect(*hostPathVolumeSource.Type).To(Equal(corev1.HostPathDirectory))
+				Expect(*hostPathVolumeSource.Type).To(Equal(corev1.HostPathDirectoryOrCreate))
 			})
 
 			It("should create the correct volumes when secret data hostPath is not set", func() {
@@ -549,7 +549,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 				hostPathVolumeSource := volumes[0].VolumeSource.HostPath
 				Expect(hostPathVolumeSource).NotTo(BeNil())
 				Expect(hostPathVolumeSource.Path).To(Equal(druidstore.LocalProviderDefaultMountPath + "/" + *store.Container))
-				Expect(*hostPathVolumeSource.Type).To(Equal(corev1.HostPathDirectory))
+				Expect(*hostPathVolumeSource.Type).To(Equal(corev1.HostPathDirectoryOrCreate))
 			})
 
 			It("should create the correct volumes when store.SecretRef is not referred", func() {
@@ -564,7 +564,7 @@ var _ = Describe("EtcdCopyBackupsTaskController", func() {
 				hostPathVolumeSource := volumes[0].VolumeSource.HostPath
 				Expect(hostPathVolumeSource).NotTo(BeNil())
 				Expect(hostPathVolumeSource.Path).To(Equal(druidstore.LocalProviderDefaultMountPath + "/" + *store.Container))
-				Expect(*hostPathVolumeSource.Type).To(Equal(corev1.HostPathDirectory))
+				Expect(*hostPathVolumeSource.Type).To(Equal(corev1.HostPathDirectoryOrCreate))
 			})
 		})
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -635,7 +635,7 @@ func purgeSnapstore(store brtypes.SnapStore) error {
 }
 
 func getPurgeLocalSnapstoreJob(storeContainer, storePrefix string) *batchv1.Job {
-	directory := corev1.HostPathDirectory
+	directory := corev1.HostPathDirectoryOrCreate
 
 	return newTestHelperJob(
 		"purge-local-snapstore",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:

When etcd-druid is run with `local` provider with the `spec.backup.store.container` set, the functionality is broken with the following volume mount error: 

```
MountVolume.SetUp failed for volume "local-backup" : hostPath type check failed: /etc/gardener/local-backupbuckets/etcd-bucket is not a directory
```

This is due to the `HostPath` type being set to `Directory` instead of `DirectoryOrCreate` at multiple places, because of which the directory has to exist first before being used as a volume type for storing backups. But when started fresh, the node need not have the directory created beforehand, hence the volume error we see above. 

To fix this, the change is to basically convert all instances of hostPath type from `Directory` to `DirectoryOrCreate`, this configuration will ensure the directory is created if it doesn't exist, so that the CSI can create it into a volume to be mounted onto the `backup-restore` container. 

**Which issue(s) this PR fixes**:
Fixes part of #1010

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
fix a volume creation issue with using `local` provider for etcd backups
```
