### PR TITLE
Remove functionality that deletes old ConfigMaps

### DIFF
--- a/api/core/v1alpha1/helper.go
+++ b/api/core/v1alpha1/helper.go
@@ -29,12 +29,6 @@ func GetServiceAccountName(etcdObjMeta metav1.ObjectMeta) string {
 	return etcdObjMeta.Name
 }
 
-// GetOldConfigMapName returns the name of the old configmap for the Etcd.
-// TODO: @anveshreddy18: Remove this function after 3 releases, i.e in v0.31.0
-func GetOldConfigMapName(etcdObjMeta metav1.ObjectMeta) string {
-	return fmt.Sprintf("etcd-bootstrap-%s", string(etcdObjMeta.UID[:6]))
-}
-
 // GetConfigMapName returns the name of the configmap for the Etcd.
 func GetConfigMapName(etcdObjMeta metav1.ObjectMeta) string {
 	return fmt.Sprintf("%s-config", etcdObjMeta.Name)

--- a/internal/component/configmap/configmap.go
+++ b/internal/component/configmap/configmap.go
@@ -64,24 +64,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 }
 
 // PreSync is a no-op for the configmap component.
-// TODO: @anveshreddy18: Remove the functionality in the below PreSync method after 3 releases i.e in v0.31.0
-// This is a temporary functionality to remove the old configmaps from the cluster that are created by the etcd-druid.
-func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
-	oldConfigMap := emptyConfigMap(getOldObjectKey(etcd.ObjectMeta))
-	ctx.Logger.Info("PreSync: Deleting old configmap", "name", oldConfigMap.Name)
-	if err := r.client.Delete(ctx, oldConfigMap); err != nil {
-		if errors.IsNotFound(err) {
-			ctx.Logger.Info("No old configmap found, ConfigMap PreSync is a no-op", "name", oldConfigMap.Name)
-			return nil
-		}
-		return druiderr.WrapError(
-			err,
-			ErrDeleteConfigMap,
-			component.OperationPreSync,
-			fmt.Sprintf("Failed to delete old configmap %s", oldConfigMap.Name),
-		)
-	}
-	ctx.Logger.Info("deleted", "component", "configmap", "name", oldConfigMap.Name)
+func (r _resource) PreSync(_ component.OperatorContext, _ *druidv1alpha1.Etcd) error {
 	return nil
 }
 
@@ -155,13 +138,6 @@ func getLabels(etcd *druidv1alpha1.Etcd) map[string]string {
 func getObjectKey(obj metav1.ObjectMeta) client.ObjectKey {
 	return client.ObjectKey{
 		Name:      druidv1alpha1.GetConfigMapName(obj),
-		Namespace: obj.Namespace,
-	}
-}
-
-func getOldObjectKey(obj metav1.ObjectMeta) client.ObjectKey {
-	return client.ObjectKey{
-		Name:      druidv1alpha1.GetOldConfigMapName(obj),
 		Namespace: obj.Namespace,
 	}
 }

--- a/internal/component/types.go
+++ b/internal/component/types.go
@@ -17,8 +17,6 @@ import (
 // However, it can also be used where ever operation context is required to be specified.
 // Each component can in turn define their own fine-grained operation labels as well.
 const (
-	// OperationPreSync is the PreSync operation of the Operator.
-	OperationPreSync = "PreSync"
 	// OperationSync is the Sync operation of the Operator.
 	OperationSync = "Sync"
 	// OperationTriggerDelete is the TriggerDelete operation of the Operator.

--- a/internal/component/types.go
+++ b/internal/component/types.go
@@ -17,6 +17,8 @@ import (
 // However, it can also be used where ever operation context is required to be specified.
 // Each component can in turn define their own fine-grained operation labels as well.
 const (
+	// OperationPreSync is the PreSync operation of the Operator.
+	OperationPreSync = "PreSync"
 	// OperationSync is the Sync operation of the Operator.
 	OperationSync = "Sync"
 	// OperationTriggerDelete is the TriggerDelete operation of the Operator.

--- a/internal/controller/etcd/reconcile_spec.go
+++ b/internal/controller/etcd/reconcile_spec.go
@@ -169,9 +169,7 @@ func (r *Reconciler) recordEtcdSpecReconcileSuspension(etcd *druidv1alpha1.Etcd,
 }
 
 func (r *Reconciler) getOrderedOperatorsForPreSync() []component.Kind {
-	return []component.Kind{
-		component.ConfigMapKind,
-	}
+	return []component.Kind{}
 }
 
 func (r *Reconciler) getOrderedOperatorsForSync() []component.Kind {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:

This PR removes the code functionality that was introduced in #1014 to remove older ConfigMaps with the naming format `etcd-bootstrap-UID[:6]`. The functionality was only intended to be there for 3 releases starting from `v0.28.0` till `v0.30.0`. Now it's no longer needed to be present, hence removing the functionality.

**Which issue(s) this PR fixes**:
Fixes #1015 

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Remove the functionality that deletes old ConfigMaps from the cluster
```
