### PR TITLE
[hotfix-v0.30.0] Upgrade etcd-wrapper from v0.5.0 to v0.5.1 (#1104)

### DIFF
--- a/internal/images/images.yaml
+++ b/internal/images/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: etcd-wrapper
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
-  tag: "v0.5.0"
+  tag: "v0.5.1"
 - name: etcd-backup-restore
   resourceId:
     name: 'etcdbrctl'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area control-plane security compliance
/kind enhancement task

**What this PR does / why we need it**:
Cherry-pick of #1104 

**Special notes for your reviewer**:

**Release Notes**:
```other user github.com/gardener/etcd-wrapper #56 @shreyas-s-rao
Change permissions of files in etcd data directory to `0600`.
```

## BoM Diff
Added components: 0
Changed components: 1
Removed components: 0

### Changed Components:
⚙ github.com/gardener/etcd-wrapper: v0.5.0 → v0.5.1

## Component Details:
<details><summary>⚙ github.com/gardener/etcd-wrapper:v0.5.0 → v0.5.1</summary>
<table>
<thead>
<tr><th>Resource              </th><th>Version Change  </th></tr>
</thead>
<tbody>
<tr><td>🔄 etcd-wrapper        </td><td>v0.5.0 → v0.5.1 </td></tr>
<tr><td>🔄 check-build-step-log</td><td>v0.5.0 → v0.5.1 </td></tr>
<tr><td>🔄 release-notes       </td><td>v0.5.0 → v0.5.1 </td></tr>
</tbody>
</table>
</details>
