### PR TITLE
Support disabling creation of etcd runtime components

### DIFF
--- a/api/core/v1alpha1/constants.go
+++ b/api/core/v1alpha1/constants.go
@@ -36,7 +36,5 @@ const (
 	DruidOperationReconcile = "reconcile"
 	// DisableEtcdRuntimeComponentCreationAnnotation is an annotation set by an operator to disable the creation and management of
 	// runtime components of the etcd cluster such as pods, PVCs, leases, RBAC resources, etc.
-	// This is useful when the operator wants to manage the runtime resources manually or when the runtime resources are not needed,
-	// but still requires the correct etcd cluster configuration to be made available.
 	DisableEtcdRuntimeComponentCreationAnnotation = "druid.gardener.cloud/disable-etcd-runtime-component-creation"
 )

--- a/api/core/v1alpha1/constants.go
+++ b/api/core/v1alpha1/constants.go
@@ -35,6 +35,6 @@ const (
 	// --enable-etcd-spec-auto-reconcile CLI flag.
 	DruidOperationReconcile = "reconcile"
 	// DisableEtcdRuntimeComponentCreationAnnotation is an annotation set by an operator to disable the creation and management of
-	// runtime components of the etcd cluster such as pods, PVCs, leases, RBAC resources, etc.
+	// runtime components of the etcd cluster such as pods, PVCs, leases, RBAC resources, PDBs, services, etc.
 	DisableEtcdRuntimeComponentCreationAnnotation = "druid.gardener.cloud/disable-etcd-runtime-component-creation"
 )

--- a/api/core/v1alpha1/constants.go
+++ b/api/core/v1alpha1/constants.go
@@ -34,4 +34,9 @@ const (
 	// This value will only be effective if etcd-druid is not configured with auto-reconciliation of Etcd resource specification via
 	// --enable-etcd-spec-auto-reconcile CLI flag.
 	DruidOperationReconcile = "reconcile"
+	// DisableEtcdRuntimeComponentCreationAnnotation is an annotation set by an operator to disable the creation and management of
+	// runtime components of the etcd cluster such as pods, PVCs, leases, RBAC resources, etc.
+	// This is useful when the operator wants to manage the runtime resources manually or when the runtime resources are not needed,
+	// but still requires the correct etcd cluster configuration to be made available.
+	DisableEtcdRuntimeComponentCreationAnnotation = "druid.gardener.cloud/disable-etcd-runtime-component-creation"
 )

--- a/api/core/v1alpha1/helper.go
+++ b/api/core/v1alpha1/helper.go
@@ -165,3 +165,8 @@ func RemoveOperationAnnotation(etcdObjMeta metav1.ObjectMeta) {
 	delete(etcdObjMeta.Annotations, DruidOperationAnnotation)
 	delete(etcdObjMeta.Annotations, GardenerOperationAnnotation)
 }
+
+// IsEtcdRuntimeComponentCreationEnabled checks if the creation of runtime components is not disabled for the Etcd resource.
+func IsEtcdRuntimeComponentCreationEnabled(etcdObjMeta metav1.ObjectMeta) bool {
+	return !metav1.HasAnnotation(etcdObjMeta, DisableEtcdRuntimeComponentCreationAnnotation)
+}

--- a/api/core/v1alpha1/helper.go
+++ b/api/core/v1alpha1/helper.go
@@ -166,7 +166,7 @@ func RemoveOperationAnnotation(etcdObjMeta metav1.ObjectMeta) {
 	delete(etcdObjMeta.Annotations, GardenerOperationAnnotation)
 }
 
-// IsEtcdRuntimeComponentCreationEnabled checks if the creation of runtime components is not disabled for the Etcd resource.
+// IsEtcdRuntimeComponentCreationEnabled checks if the creation of runtime components is enabled for an Etcd resource.
 func IsEtcdRuntimeComponentCreationEnabled(etcdObjMeta metav1.ObjectMeta) bool {
 	return !metav1.HasAnnotation(etcdObjMeta, DisableEtcdRuntimeComponentCreationAnnotation)
 }

--- a/api/core/v1alpha1/helper_test.go
+++ b/api/core/v1alpha1/helper_test.go
@@ -422,6 +422,37 @@ func TestGetReconcileOperationAnnotationKey(t *testing.T) {
 	}
 }
 
+func TestIsEtcdRuntimeComponentCreationEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:     "Runtime component creation is enabled",
+			expected: true,
+		},
+		{
+			name: "Runtime component creation is disabled",
+			annotations: map[string]string{
+				DisableEtcdRuntimeComponentCreationAnnotation: "",
+			},
+			expected: false,
+		},
+	}
+
+	g := NewWithT(t)
+	t.Parallel()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), test.annotations, nil, false)
+			actual := IsEtcdRuntimeComponentCreationEnabled(etcdObjMeta)
+			g.Expect(actual).To(Equal(test.expected))
+		})
+	}
+}
+
 func createEtcdObjectMetadata(uid types.UID, annotations, labels map[string]string, markedForDeletion bool) metav1.ObjectMeta {
 	etcdObjMeta := metav1.ObjectMeta{
 		Name:        etcdName,

--- a/docs/usage/managing-etcd-clusters.md
+++ b/docs/usage/managing-etcd-clusters.md
@@ -32,23 +32,6 @@ kubectl get all,cm,role,rolebinding,lease,sa -n <namespace> --selector=instance=
 kubectl get all,cm,role,rolebinding,lease,sa -n <namespace> --selector=app.kubernetes.io/managed-by=etcd-druid,app.kubernetes.io/part-of=<etcd-name>
 ```
 
-### Disable creation of runtime components
-
-If you do not want to create runtime components in order to manage them externally, you can set the annotation `druid.gardener.cloud/disable-etcd-runtime-component-creation` on the Etcd custom resource. This is useful in scenarios where the etcd pods need to be run as static pods on a Kubernetes node, where druid provides the configuration for the etcd cluster, and an external actor creates the corresponding static pod manifests and related resources on the node.
-
-Setting this annotation will disable the creation of the following resources/components:
-- `pods` - while the Etcd `spec.replicas` still decides the number of etcd members in the etcd cluster configuration, no pods will be created for these.
-- `volumes` - no persistent volumes will be created for the etcd cluster, since no pods are created.
-- `member leases`
-- `snapshot leases`
-- `serviceaccount`
-- `role`
-- `rolebinding`
-
-The statefulset will still be created, with `spec.replicas` set to 0, but the lease renewal flags `--enable-member-lease-renewal` and `--enable-snapshot-lease-renewal` on the `etcd-backup-restore` config will be disabled.
-
-Additionally, certain checks on the `Etcd` resource status will be disabled, since according to etcd-druid, the etcd cluster is not running.
-
 ## Update & Reconcile an Etcd Cluster
 
 ### Edit the Etcd custom resource

--- a/docs/usage/managing-etcd-clusters.md
+++ b/docs/usage/managing-etcd-clusters.md
@@ -32,7 +32,22 @@ kubectl get all,cm,role,rolebinding,lease,sa -n <namespace> --selector=instance=
 kubectl get all,cm,role,rolebinding,lease,sa -n <namespace> --selector=app.kubernetes.io/managed-by=etcd-druid,app.kubernetes.io/part-of=<etcd-name>
 ```
 
-  
+### Disable creation of runtime components
+
+If you do not want to create runtime components in order to manage them externally, you can set the annotation `druid.gardener.cloud/disable-etcd-runtime-component-creation` on the Etcd custom resource. This is useful in scenarios where the etcd pods need to be run as static pods on a Kubernetes node, where druid provides the configuration for the etcd cluster, and an external actor creates the corresponding static pod manifests and related resources on the node.
+
+Setting this annotation will disable the creation of the following resources/components:
+- `pods` - while the Etcd `spec.replicas` still decides the number of etcd members in the etcd cluster configuration, no pods will be created for these.
+- `volumes` - no persistent volumes will be created for the etcd cluster, since no pods are created.
+- `member leases`
+- `snapshot leases`
+- `serviceaccount`
+- `role`
+- `rolebinding`
+
+The statefulset will still be created, with `spec.replicas` set to 0, but the lease renewal flags on the `etcd-backup-restore` sidecar container will remain disabled.
+
+Additionally, certain checks on the `Etcd` resource status will be disabled, since according to etcd-druid, the etcd cluster is not running.
 
 ## Update & Reconcile an Etcd Cluster
 

--- a/docs/usage/managing-etcd-clusters.md
+++ b/docs/usage/managing-etcd-clusters.md
@@ -45,7 +45,7 @@ Setting this annotation will disable the creation of the following resources/com
 - `role`
 - `rolebinding`
 
-The statefulset will still be created, with `spec.replicas` set to 0, but the lease renewal flags on the `etcd-backup-restore` sidecar container will remain disabled.
+The statefulset will still be created, with `spec.replicas` set to 0, but the lease renewal flags `--enable-member-lease-renewal` and `--enable-snapshot-lease-renewal` on the `etcd-backup-restore` config will be disabled.
 
 Additionally, certain checks on the `Etcd` resource status will be disabled, since according to etcd-druid, the etcd cluster is not running.
 

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -9,7 +9,6 @@ set -o pipefail
 
 make kind-up
 
-
 trap '{
   kind export logs "${ARTIFACTS:-/tmp}/etcd-druid-e2e" --name etcd-druid-e2e || true
   echo "cleaning copied and generated helm chart resources"

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -136,10 +136,7 @@ func (b *stsBuilder) getStatefulSetLabels() map[string]string {
 
 func (b *stsBuilder) createStatefulSetSpec(ctx component.OperatorContext) error {
 	err := b.createPodTemplateSpec(ctx)
-	b.sts.Spec.Replicas = ptr.To[int32](0)
-	if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta) {
-		b.sts.Spec.Replicas = ptr.To(b.replicas)
-	}
+	b.sts.Spec.Replicas = ptr.To(utils.IfConditionOr[int32](druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta), b.replicas, 0))
 	b.logger.Info("Creating StatefulSet spec", "replicas", b.sts.Spec.Replicas, "name", b.sts.Name, "namespace", b.sts.Namespace)
 	b.sts.Spec.UpdateStrategy = defaultUpdateStrategy
 	if err != nil {
@@ -150,7 +147,9 @@ func (b *stsBuilder) createStatefulSetSpec(ctx component.OperatorContext) error 
 			MatchLabels: druidv1alpha1.GetDefaultLabels(b.etcd.ObjectMeta),
 		}
 		b.sts.Spec.PodManagementPolicy = defaultPodManagementPolicy
-		b.sts.Spec.ServiceName = druidv1alpha1.GetPeerServiceName(b.etcd.ObjectMeta)
+		if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta) {
+			b.sts.Spec.ServiceName = druidv1alpha1.GetPeerServiceName(b.etcd.ObjectMeta)
+		}
 		b.sts.Spec.VolumeClaimTemplates = b.getVolumeClaimTemplates()
 	}
 	return nil
@@ -466,12 +465,16 @@ func (b *stsBuilder) getBackupRestoreContainerCommandArgs() []string {
 		commandArgs = append(commandArgs, "--insecure-transport=false")
 		commandArgs = append(commandArgs, "--insecure-skip-tls-verify=false")
 		commandArgs = append(commandArgs, fmt.Sprintf("--endpoints=https://%s-local:%d", b.etcd.Name, b.clientPort))
-		commandArgs = append(commandArgs, fmt.Sprintf("--service-endpoints=https://%s:%d", druidv1alpha1.GetClientServiceName(b.etcd.ObjectMeta), b.clientPort))
+		if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta) {
+			commandArgs = append(commandArgs, fmt.Sprintf("--service-endpoints=https://%s:%d", druidv1alpha1.GetClientServiceName(b.etcd.ObjectMeta), b.clientPort))
+		}
 	} else {
 		commandArgs = append(commandArgs, "--insecure-transport=true")
 		commandArgs = append(commandArgs, "--insecure-skip-tls-verify=true")
 		commandArgs = append(commandArgs, fmt.Sprintf("--endpoints=http://%s-local:%d", b.etcd.Name, b.clientPort))
-		commandArgs = append(commandArgs, fmt.Sprintf("--service-endpoints=http://%s:%d", druidv1alpha1.GetClientServiceName(b.etcd.ObjectMeta), b.clientPort))
+		if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta) {
+			commandArgs = append(commandArgs, fmt.Sprintf("--service-endpoints=http://%s:%d", druidv1alpha1.GetClientServiceName(b.etcd.ObjectMeta), b.clientPort))
+		}
 	}
 	if b.etcd.Spec.Backup.TLS != nil {
 		commandArgs = append(commandArgs, fmt.Sprintf("--server-cert=%s/tls.crt", common.VolumeMountPathBackupRestoreServerTLS))

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -86,28 +86,43 @@ func TestGetExistingResourceNames(t *testing.T) {
 // ----------------------------------- Sync -----------------------------------
 func TestSyncWhenNoSTSExists(t *testing.T) {
 	testCases := []struct {
-		name        string
-		replicas    int32
-		createErr   *apierrors.StatusError
-		expectedErr *druiderr.DruidError
+		name                   string
+		replicas               int32
+		annotations            map[string]string
+		createErr              *apierrors.StatusError
+		expectedErr            *druiderr.DruidError
+		expectedReplicas       *int32
+		expectNoServiceAccount bool
 	}{
 		{
-			name:     "creates a single replica sts for a single node etcd cluster",
-			replicas: 1,
+			name:             "creates a single replica sts for a single node etcd cluster",
+			replicas:         1,
+			expectedReplicas: ptr.To[int32](1),
 		},
 		{
-			name:     "creates multiple replica sts for a multi-node etcd cluster",
-			replicas: 3,
+			name:             "creates multiple replica sts for a multi-node etcd cluster",
+			replicas:         3,
+			expectedReplicas: ptr.To[int32](3),
 		},
 		{
-			name:      "returns error when client create fails",
-			replicas:  3,
-			createErr: testutils.TestAPIInternalErr,
+			name:             "returns error when client create fails",
+			replicas:         3,
+			expectedReplicas: ptr.To[int32](3),
+			createErr:        testutils.TestAPIInternalErr,
 			expectedErr: &druiderr.DruidError{
 				Code:      ErrSyncStatefulSet,
 				Cause:     testutils.TestAPIInternalErr,
 				Operation: "Sync",
 			},
+		},
+		{
+			name:     "creates sts with 0 replicas, with lease renewal and serviceAccount disabled on backup-restore container when runtime component creation is disabled",
+			replicas: 3,
+			annotations: map[string]string{
+				druidv1alpha1.DisableEtcdRuntimeComponentCreationAnnotation: "",
+			},
+			expectedReplicas:       ptr.To[int32](0),
+			expectNoServiceAccount: true,
 		},
 	}
 
@@ -118,11 +133,16 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			// *************** Build test environment ***************
-			etcd := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).WithReplicas(tc.replicas).Build()
+			etcd := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).
+				WithReplicas(tc.replicas).
+				WithAnnotations(tc.annotations).
+				Build()
+
 			cl := testutils.CreateTestFakeClientForObjects(nil, tc.createErr, nil, nil, []client.Object{buildBackupSecret()}, getObjectKey(etcd.ObjectMeta))
 			etcdImage, etcdBRImage, initContainerImage, err := utils.GetEtcdImages(etcd, iv)
 			g.Expect(err).ToNot(HaveOccurred())
-			stsMatcher := NewStatefulSetMatcher(g, cl, etcd, tc.replicas, initContainerImage, etcdImage, etcdBRImage, ptr.To(druidstore.Local))
+			g.Expect(tc.expectedReplicas).ToNot(BeNil())
+			stsMatcher := NewStatefulSetMatcher(g, cl, etcd, *tc.expectedReplicas, initContainerImage, etcdImage, etcdBRImage, ptr.To(druidstore.Local), tc.expectNoServiceAccount)
 			operator := New(cl, iv)
 			// *************** Test and assert ***************
 			opCtx := component.NewOperatorContext(context.Background(), logr.Discard(), uuid.NewString())

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -93,6 +93,7 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 		expectedErr            *druiderr.DruidError
 		expectedReplicas       *int32
 		expectNoServiceAccount bool
+		expectNoService        bool
 	}{
 		{
 			name:             "creates a single replica sts for a single node etcd cluster",
@@ -116,13 +117,14 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 			},
 		},
 		{
-			name:     "creates sts with 0 replicas, with lease renewal and serviceAccount disabled on backup-restore container when runtime component creation is disabled",
+			name:     "creates sts with 0 replicas, with no serviceAccount and service defined, with lease renewal and client-service-endpoint CLI flags disabled on backup-restore container when runtime component creation is disabled",
 			replicas: 3,
 			annotations: map[string]string{
 				druidv1alpha1.DisableEtcdRuntimeComponentCreationAnnotation: "",
 			},
 			expectedReplicas:       ptr.To[int32](0),
 			expectNoServiceAccount: true,
+			expectNoService:        true,
 		},
 	}
 
@@ -142,7 +144,7 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 			etcdImage, etcdBRImage, initContainerImage, err := utils.GetEtcdImages(etcd, iv)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(tc.expectedReplicas).ToNot(BeNil())
-			stsMatcher := NewStatefulSetMatcher(g, cl, etcd, *tc.expectedReplicas, initContainerImage, etcdImage, etcdBRImage, ptr.To(druidstore.Local), tc.expectNoServiceAccount)
+			stsMatcher := NewStatefulSetMatcher(g, cl, etcd, *tc.expectedReplicas, initContainerImage, etcdImage, etcdBRImage, ptr.To(druidstore.Local), tc.expectNoServiceAccount, tc.expectNoService)
 			operator := New(cl, iv)
 			// *************** Test and assert ***************
 			opCtx := component.NewOperatorContext(context.Background(), logr.Discard(), uuid.NewString())

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -38,18 +38,19 @@ var (
 
 // StatefulSetMatcher is the type used for matching StatefulSets. It holds relevant information required for matching.
 type StatefulSetMatcher struct {
-	g                  *WithT
-	cl                 client.Client
-	replicas           int32
-	etcd               *druidv1alpha1.Etcd
-	initContainerImage string
-	etcdImage          string
-	etcdBRImage        string
-	provider           *string
-	clientPort         int32
-	serverPort         int32
-	backupPort         int32
-	wrapperPort        int32
+	g                      *WithT
+	cl                     client.Client
+	etcd                   *druidv1alpha1.Etcd
+	initContainerImage     string
+	etcdImage              string
+	etcdBRImage            string
+	provider               *string
+	clientPort             int32
+	serverPort             int32
+	backupPort             int32
+	wrapperPort            int32
+	expectedReplicas       int32
+	expectNoServiceAccount bool
 }
 
 // NewStatefulSetMatcher constructs a new instance of StatefulSetMatcher.
@@ -58,20 +59,22 @@ func NewStatefulSetMatcher(g *WithT,
 	etcd *druidv1alpha1.Etcd,
 	replicas int32,
 	initContainerImage, etcdImage, etcdBRImage string,
-	provider *string) StatefulSetMatcher {
+	provider *string,
+	expectNoServiceAccount bool) StatefulSetMatcher {
 	return StatefulSetMatcher{
-		g:                  g,
-		cl:                 cl,
-		replicas:           replicas,
-		etcd:               etcd,
-		initContainerImage: initContainerImage,
-		etcdImage:          etcdImage,
-		etcdBRImage:        etcdBRImage,
-		provider:           provider,
-		clientPort:         ptr.Deref(etcd.Spec.Etcd.ClientPort, 2379),
-		serverPort:         ptr.Deref(etcd.Spec.Etcd.ServerPort, 2380),
-		backupPort:         ptr.Deref(etcd.Spec.Backup.Port, 8080),
-		wrapperPort:        ptr.Deref(etcd.Spec.Etcd.WrapperPort, 9095),
+		g:                      g,
+		cl:                     cl,
+		etcd:                   etcd,
+		initContainerImage:     initContainerImage,
+		etcdImage:              etcdImage,
+		etcdBRImage:            etcdBRImage,
+		provider:               provider,
+		clientPort:             ptr.Deref(etcd.Spec.Etcd.ClientPort, 2379),
+		serverPort:             ptr.Deref(etcd.Spec.Etcd.ServerPort, 2380),
+		backupPort:             ptr.Deref(etcd.Spec.Backup.Port, 8080),
+		wrapperPort:            ptr.Deref(etcd.Spec.Etcd.WrapperPort, 9095),
+		expectedReplicas:       replicas,
+		expectNoServiceAccount: expectNoServiceAccount,
 	}
 }
 
@@ -94,7 +97,7 @@ func (s StatefulSetMatcher) matchSTSObjectMeta() gomegatypes.GomegaMatcher {
 
 func (s StatefulSetMatcher) matchSpec() gomegatypes.GomegaMatcher {
 	return MatchFields(IgnoreExtras, Fields{
-		"Replicas":            PointTo(Equal(s.replicas)),
+		"Replicas":            PointTo(Equal(s.expectedReplicas)),
 		"Selector":            testutils.MatchSpecLabelSelector(druidv1alpha1.GetDefaultLabels(s.etcd.ObjectMeta)),
 		"PodManagementPolicy": Equal(appsv1.ParallelPodManagement),
 		"UpdateStrategy": MatchFields(IgnoreExtras, Fields{
@@ -142,16 +145,19 @@ func (s StatefulSetMatcher) matchPodObjectMeta() gomegatypes.GomegaMatcher {
 
 func (s StatefulSetMatcher) matchPodSpec() gomegatypes.GomegaMatcher {
 	// NOTE: currently this matcher does not check affinity and TSC since these are seldom used. If these are used in future then this matcher should be enhanced.
-	return MatchFields(IgnoreExtras, Fields{
+	fields := map[string]gomegatypes.GomegaMatcher{
 		"HostAliases":           s.matchPodHostAliases(),
-		"ServiceAccountName":    Equal(druidv1alpha1.GetServiceAccountName(s.etcd.ObjectMeta)),
 		"ShareProcessNamespace": PointTo(Equal(true)),
 		"InitContainers":        s.matchPodInitContainers(),
 		"Containers":            s.matchContainers(),
 		"SecurityContext":       s.matchEtcdPodSecurityContext(),
 		"Volumes":               s.matchPodVolumes(),
 		"PriorityClassName":     Equal(ptr.Deref(s.etcd.Spec.PriorityClassName, "")),
-	})
+	}
+	if !s.expectNoServiceAccount {
+		fields["ServiceAccountName"] = Equal(druidv1alpha1.GetServiceAccountName(s.etcd.ObjectMeta))
+	}
+	return MatchFields(IgnoreExtras, fields)
 }
 
 func (s StatefulSetMatcher) matchPodHostAliases() gomegatypes.GomegaMatcher {

--- a/internal/controller/etcd/reconcile_spec.go
+++ b/internal/controller/etcd/reconcile_spec.go
@@ -103,6 +103,8 @@ func (r *Reconciler) syncEtcdResources(ctx component.OperatorContext, etcdObjKey
 }
 
 // cleanupEtcdResources cleans up the resources that are no longer required for the Etcd cluster.
+// This is required when runtime components are disabled for an Etcd cluster after it was created with runtime components enabled,
+// so druid needs to ensure that the previously created runtime components are now cleaned up to avoid leaked resources in the cluster.
 func (r *Reconciler) cleanupEtcdResources(ctx component.OperatorContext, etcdObjKey client.ObjectKey) ctrlutils.ReconcileStepResult {
 	etcd := &druidv1alpha1.Etcd{}
 	if result := ctrlutils.GetLatestEtcd(ctx, r.client, etcdObjKey, etcd); ctrlutils.ShortCircuitReconcileFlow(result) {
@@ -210,14 +212,14 @@ func (r *Reconciler) getOrderedOperatorsForSync(etcdObjMeta metav1.ObjectMeta) [
 			component.RoleBindingKind,
 			component.MemberLeaseKind,
 			component.SnapshotLeaseKind,
+			component.PodDisruptionBudgetKind,
+			component.ClientServiceKind,
+			component.PeerServiceKind,
 		}
 	}
 
 	// add the rest of the operators that are always needed for the etcd cluster
 	operators = append(operators,
-		component.ClientServiceKind,
-		component.PeerServiceKind,
-		component.PodDisruptionBudgetKind,
 		component.ConfigMapKind,
 		component.StatefulSetKind,
 	)
@@ -235,5 +237,8 @@ func (r *Reconciler) getOperatorsForCleanup(etcdObjMeta metav1.ObjectMeta) []com
 		component.RoleBindingKind,
 		component.MemberLeaseKind,
 		component.SnapshotLeaseKind,
+		component.PodDisruptionBudgetKind,
+		component.ClientServiceKind,
+		component.PeerServiceKind,
 	}
 }

--- a/internal/controller/etcd/reconciler.go
+++ b/internal/controller/etcd/reconciler.go
@@ -155,9 +155,9 @@ func createAndInitializeOperatorRegistry(client client.Client, config druidconfi
 	reg.Register(component.RoleBindingKind, rolebinding.New(client))
 	reg.Register(component.MemberLeaseKind, memberlease.New(client))
 	reg.Register(component.SnapshotLeaseKind, snapshotlease.New(client))
+	reg.Register(component.PodDisruptionBudgetKind, poddistruptionbudget.New(client))
 	reg.Register(component.ClientServiceKind, clientservice.New(client))
 	reg.Register(component.PeerServiceKind, peerservice.New(client))
-	reg.Register(component.PodDisruptionBudgetKind, poddistruptionbudget.New(client))
 	reg.Register(component.ConfigMapKind, configmap.New(client))
 	reg.Register(component.StatefulSetKind, statefulset.New(client, imageVector))
 	return reg

--- a/internal/controller/etcd/reconciler.go
+++ b/internal/controller/etcd/reconciler.go
@@ -150,15 +150,15 @@ func (r *Reconciler) GetOperatorRegistry() component.Registry {
 
 func createAndInitializeOperatorRegistry(client client.Client, config druidconfigv1alpha1.EtcdControllerConfiguration, imageVector imagevector.ImageVector) component.Registry {
 	reg := component.NewRegistry()
-	reg.Register(component.ConfigMapKind, configmap.New(client))
 	reg.Register(component.ServiceAccountKind, serviceaccount.New(client, config.DisableEtcdServiceAccountAutomount))
+	reg.Register(component.RoleKind, role.New(client))
+	reg.Register(component.RoleBindingKind, rolebinding.New(client))
 	reg.Register(component.MemberLeaseKind, memberlease.New(client))
 	reg.Register(component.SnapshotLeaseKind, snapshotlease.New(client))
 	reg.Register(component.ClientServiceKind, clientservice.New(client))
 	reg.Register(component.PeerServiceKind, peerservice.New(client))
 	reg.Register(component.PodDisruptionBudgetKind, poddistruptionbudget.New(client))
-	reg.Register(component.RoleKind, role.New(client))
-	reg.Register(component.RoleBindingKind, rolebinding.New(client))
+	reg.Register(component.ConfigMapKind, configmap.New(client))
 	reg.Register(component.StatefulSetKind, statefulset.New(client, imageVector))
 	return reg
 }

--- a/internal/webhook/etcdcomponentprotection/handler.go
+++ b/internal/webhook/etcdcomponentprotection/handler.go
@@ -17,8 +17,11 @@ import (
 	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admission/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -55,8 +58,8 @@ func NewHandler(mgr manager.Manager, config druidconfigv1alpha1.EtcdComponentPro
 
 // Handle handles admission requests and prevents unintended changes to resources created by etcd-druid.
 func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.Response {
-	requestGKString := utils.GetGroupKindAsStringFromRequest(req)
-	log := h.logger.WithValues("name", req.Name, "namespace", req.Namespace, "resourceGroupKind", requestGKString, "operation", req.Operation, "user", req.UserInfo.Username)
+	requestGK := utils.GetGroupKindFromRequest(req)
+	log := h.logger.WithValues("name", req.Name, "namespace", req.Namespace, "resourceGroupKind", requestGK, "operation", req.Operation, "user", req.UserInfo.Username)
 	log.V(1).Info("EtcdComponents webhook invoked")
 
 	if ok, response := h.skipValidationForOperations(req.Operation); ok {
@@ -68,7 +71,7 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Errored(utils.DetermineStatusCode(err), err)
 	}
 	if partialObjMeta == nil {
-		return admission.Allowed(fmt.Sprintf("resource: %v is not supported by EtcdComponents webhook", requestGKString))
+		return admission.Allowed(fmt.Sprintf("resource: %v is not supported by EtcdComponents webhook", requestGK))
 	}
 
 	if !isObjManagedByDruid(partialObjMeta.ObjectMeta) {
@@ -86,6 +89,12 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 	// allow changes to resources if Etcd has annotation druid.gardener.cloud/disable-etcd-component-protection is set.
 	if !druidv1alpha1.AreManagedResourcesProtected(etcd.ObjectMeta) {
 		return admission.Allowed(fmt.Sprintf("changes allowed, since Etcd %s has annotation %s", etcd.Name, druidv1alpha1.DisableEtcdComponentProtectionAnnotation))
+	}
+
+	if isRuntimeComponent(requestGK) {
+		if !druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(etcd.ObjectMeta) {
+			return admission.Allowed(fmt.Sprintf("Etcd %s has runtime component creation disabled, skipping validations for resource %v", etcd.Name, utils.CreateObjectKey(partialObjMeta)))
+		}
 	}
 
 	// allow deletion operation on resources if the Etcd is currently being deleted, but only by etcd-druid and exempt service accounts.
@@ -162,6 +171,13 @@ func (h *Handler) getParentEtcdObj(ctx context.Context, partialObjMeta *metav1.P
 func isObjManagedByDruid(objMeta metav1.ObjectMeta) bool {
 	managedBy, hasLabel := objMeta.GetLabels()[druidv1alpha1.LabelManagedByKey]
 	return hasLabel && managedBy == druidv1alpha1.LabelManagedByValue
+}
+
+func isRuntimeComponent(requestGK schema.GroupKind) bool {
+	return requestGK == corev1.SchemeGroupVersion.WithKind("ServiceAccount").GroupKind() ||
+		requestGK == rbacv1.SchemeGroupVersion.WithKind("Role").GroupKind() ||
+		requestGK == rbacv1.SchemeGroupVersion.WithKind("RoleBinding").GroupKind() ||
+		requestGK == coordinationv1.SchemeGroupVersion.WithKind("Lease").GroupKind()
 }
 
 func isServiceAccountExempted(serviceAccount string, exemptedServiceAccounts []string) bool {

--- a/internal/webhook/etcdcomponentprotection/handler.go
+++ b/internal/webhook/etcdcomponentprotection/handler.go
@@ -18,6 +18,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -173,11 +174,14 @@ func isObjManagedByDruid(objMeta metav1.ObjectMeta) bool {
 	return hasLabel && managedBy == druidv1alpha1.LabelManagedByValue
 }
 
+// isRuntimeComponent checks if the request is for a runtime component for the etcd cluster, such as lease, RBAC, etc.
 func isRuntimeComponent(requestGK schema.GroupKind) bool {
 	return requestGK == corev1.SchemeGroupVersion.WithKind("ServiceAccount").GroupKind() ||
 		requestGK == rbacv1.SchemeGroupVersion.WithKind("Role").GroupKind() ||
 		requestGK == rbacv1.SchemeGroupVersion.WithKind("RoleBinding").GroupKind() ||
-		requestGK == coordinationv1.SchemeGroupVersion.WithKind("Lease").GroupKind()
+		requestGK == coordinationv1.SchemeGroupVersion.WithKind("Lease").GroupKind() ||
+		requestGK == policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget").GroupKind() ||
+		requestGK == corev1.SchemeGroupVersion.WithKind("Service").GroupKind()
 }
 
 func isServiceAccountExempted(serviceAccount string, exemptedServiceAccounts []string) bool {

--- a/internal/webhook/etcdcomponentprotection/handler_test.go
+++ b/internal/webhook/etcdcomponentprotection/handler_test.go
@@ -277,7 +277,7 @@ func TestUnexpectedResourceType(t *testing.T) {
 	})
 
 	g.Expect(resp.Allowed).To(BeTrue())
-	g.Expect(resp.Result.Message).To(Equal("resource: coordination.k8s.io/Unknown is not supported by EtcdComponents webhook"))
+	g.Expect(resp.Result.Message).To(Equal("resource: Unknown.coordination.k8s.io is not supported by EtcdComponents webhook"))
 }
 
 func TestMissingManagedByLabel(t *testing.T) {
@@ -342,6 +342,7 @@ func TestHandleUpdate(t *testing.T) {
 		objectLabels                 map[string]string
 		isObjectDeletionTimestampSet bool
 		objectRaw                    []byte
+		isRuntimeComponent           bool
 		// ----- etcd configuration -----
 		etcdAnnotations         map[string]string
 		etcdStatusLastOperation *druidv1alpha1.LastOperation
@@ -361,6 +362,15 @@ func TestHandleUpdate(t *testing.T) {
 			expectedAllowed: true,
 			expectedMessage: fmt.Sprintf("changes allowed, since Etcd %s has annotation %s", testEtcdName, druidv1alpha1.DisableEtcdComponentProtectionAnnotation),
 			expectedCode:    http.StatusOK,
+		},
+		{
+			name:               "disable runtime component creation annotation set",
+			objectLabels:       map[string]string{druidv1alpha1.LabelManagedByKey: druidv1alpha1.LabelManagedByValue, druidv1alpha1.LabelPartOfKey: testEtcdName},
+			isRuntimeComponent: true,
+			etcdAnnotations:    map[string]string{druidv1alpha1.DisableEtcdRuntimeComponentCreationAnnotation: ""},
+			expectedAllowed:    true,
+			expectedMessage:    fmt.Sprintf("Etcd %s has runtime component creation disabled, skipping validations for resource %v", testEtcdName, client.ObjectKey{Name: testObjectName, Namespace: testNamespace}),
+			expectedCode:       http.StatusOK,
 		},
 		{
 			name:                         "operator makes a request when Etcd is being reconciled by druid",
@@ -444,11 +454,17 @@ func TestHandleUpdate(t *testing.T) {
 			})
 
 			obj := buildObjRawExtension(g, &appsv1.StatefulSet{}, tc.objectRaw, testObjectName, testNamespace, tc.objectLabels, tc.isObjectDeletionTimestampSet)
+			kind := statefulSetGVK
+			if tc.isRuntimeComponent {
+				obj = buildObjRawExtension(g, &coordinationv1.Lease{}, tc.objectRaw, testObjectName, testNamespace, tc.objectLabels, tc.isObjectDeletionTimestampSet)
+				kind = leaseGVK
+			}
+
 			response := handler.Handle(context.Background(), admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Update,
 					UserInfo:  authenticationv1.UserInfo{Username: tc.userName},
-					Kind:      statefulSetGVK,
+					Kind:      kind,
 					Name:      testObjectName,
 					Namespace: testNamespace,
 					Object:    obj,

--- a/internal/webhook/utils/miscellaneous.go
+++ b/internal/webhook/utils/miscellaneous.go
@@ -6,7 +6,6 @@ package utils
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
@@ -16,11 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
-
-// GetGroupKindAsStringFromRequest returns the GroupKind as a string from the given admission request.
-func GetGroupKindAsStringFromRequest(req admission.Request) string {
-	return fmt.Sprintf("%s/%s", req.Kind.Group, req.Kind.Kind)
-}
 
 // GetGroupKindFromRequest returns the GroupKind from the given admission request.
 func GetGroupKindFromRequest(req admission.Request) schema.GroupKind {

--- a/test/it/controller/etcd/assertions.go
+++ b/test/it/controller/etcd/assertions.go
@@ -211,6 +211,25 @@ func assertStatefulSetGeneration(ctx context.Context, t *testing.T, cl client.Cl
 	g.Eventually(checkFn).Within(timeout).WithPolling(pollInterval).WithContext(ctx).Should(BeNil())
 }
 
+func assertStatefulSetReplicas(ctx context.Context, t *testing.T, cl client.Client, stsObjectKey client.ObjectKey, expectedReplicas int32, timeout, pollInterval time.Duration) {
+	g := NewWithT(t)
+	checkFn := func() error {
+		sts := &appsv1.StatefulSet{}
+
+		if err := cl.Get(ctx, stsObjectKey, sts); err != nil {
+			return err
+		}
+		if sts.Spec.Replicas == nil {
+			return fmt.Errorf("expected sts replicas to be set, got nil")
+		}
+		if *sts.Spec.Replicas != expectedReplicas {
+			return fmt.Errorf("expected sts replicas to be %d, got %v", expectedReplicas, *sts.Spec.Replicas)
+		}
+		return nil
+	}
+	g.Eventually(checkFn).Within(timeout).WithPolling(pollInterval).WithContext(ctx).Should(BeNil())
+}
+
 func assertETCDObservedGeneration(t *testing.T, cl client.Client, etcdObjectKey client.ObjectKey, expectedObservedGeneration *int64, timeout, pollInterval time.Duration) {
 	g := NewWithT(t)
 	checkFn := func() error {

--- a/test/it/controller/etcd/reconciler_test.go
+++ b/test/it/controller/etcd/reconciler_test.go
@@ -170,9 +170,6 @@ func testNecessaryManagedResourcesAreCorrectlyCreatedWhenDisableEtcdRuntimeCompo
 	g.Expect(cl.Create(ctx, etcdInstance)).To(Succeed())
 	// ***************** test etcd spec reconciliation  *****************
 	componentKindCreated := []component.Kind{
-		component.ClientServiceKind,
-		component.PeerServiceKind,
-		component.PodDisruptionBudgetKind,
 		component.ConfigMapKind,
 		component.StatefulSetKind,
 	}
@@ -184,6 +181,9 @@ func testNecessaryManagedResourcesAreCorrectlyCreatedWhenDisableEtcdRuntimeCompo
 		component.RoleBindingKind,
 		component.MemberLeaseKind,
 		component.SnapshotLeaseKind,
+		component.PodDisruptionBudgetKind,
+		component.ClientServiceKind,
+		component.PeerServiceKind,
 	}
 	assertComponentsDoNotExist(ctx, t, reconcilerTestEnv, etcdInstance, componentKindNotCreated, timeout, pollingInterval)
 	expectedLastOperation := &druidv1alpha1.LastOperation{
@@ -241,12 +241,12 @@ func testUnnecessaryManagedResourcesAreCleanedUpWhenDisableEtcdRuntimeComponentC
 		component.RoleBindingKind,
 		component.MemberLeaseKind,
 		component.SnapshotLeaseKind,
+		component.PodDisruptionBudgetKind,
+		component.ClientServiceKind,
+		component.PeerServiceKind,
 	}
 	assertComponentsDoNotExist(ctx, t, reconcilerTestEnv, etcdInstance, componentKindAbsent, timeout, pollingInterval)
 	componentKindPresent := []component.Kind{
-		component.ClientServiceKind,
-		component.PeerServiceKind,
-		component.PodDisruptionBudgetKind,
 		component.ConfigMapKind,
 		component.StatefulSetKind,
 	}
@@ -288,13 +288,13 @@ func testFailureToCreateAllResources(t *testing.T, testNs string, reconcilerTest
 		component.RoleKind,
 		component.RoleBindingKind,
 		component.MemberLeaseKind,
+		component.PodDisruptionBudgetKind,
 	}
 	assertSelectedComponentsExists(ctx, t, reconcilerTestEnv, etcdInstance, componentKindCreated, timeout, pollingInterval)
 	componentKindNotCreated := []component.Kind{
 		component.SnapshotLeaseKind, // no backup store has been set
 		component.ClientServiceKind,
 		component.PeerServiceKind,
-		component.PodDisruptionBudgetKind,
 		component.ConfigMapKind,
 		component.StatefulSetKind,
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement task

**What this PR does / why we need it**:
Introduce annotation `druid.gardener.cloud/disable-etcd-runtime-component-creation` for the Etcd resource to instruct druid to not create runtime components for the etcd cluster, such as pods, volumes, member leases and snapshot leases used by the pods to communicate status to druid, and RBAC resources (serviceaccount, role, rolebinding) needed by the etcd member pods to update said leases. This is useful when the operator wants to manage the runtime resources manually or when the runtime resources are not needed, but still requires the correct etcd cluster configuration to be made available.

This also disables status checks, since these rely on the existence of said leases and pods to derive etcd cluster status. In the future, we will work on ways for the running members to directly communicate status with druid without the need for a k8s cluster and leases to do so.

**Which issue(s) this PR fixes**:
Fixes #1106 

**Special notes for your reviewer**:
/cc @rfranzke 
/invite @ishan16696 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
NONE
```
