### PR TITLE
Correct the group name for `OperatorConfiguration` everywhere.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ api/hack/tools/bin/*
 # generated/copied chart resources
 charts/pki-resources/*
 charts/crds/*
+
+# go workspace files
+go.work
+go.work.sum

--- a/api/config/v1alpha1/doc.go
+++ b/api/config/v1alpha1/doc.go
@@ -4,6 +4,6 @@
 
 // +k8s:deepcopy-gen=package
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=operator.config.druid.gardener.cloud
+// +groupName=config.druid.gardener.cloud
 
 package v1alpha1

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "operator.config.data" -}}
 config.yaml: |
   ---
-  apiVersion: operator.config.druid.gardener.cloud/v1alpha1
+  apiVersion: config.druid.gardener.cloud/v1alpha1
   kind: OperatorConfiguration
   clientConnection:
     qps: {{ .Values.operatorConfig.clientConnection.qps }}

--- a/cmd/opts/testdata/operatorconfig.yaml
+++ b/cmd/opts/testdata/operatorconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.config.druid.gardener.cloud/v1alpha1
+apiVersion: config.druid.gardener.cloud/v1alpha1
 kind: OperatorConfiguration
 clientConnection:
   qps: 150

--- a/docs/api-reference/etcd-druid-api.md
+++ b/docs/api-reference/etcd-druid-api.md
@@ -1,8 +1,327 @@
 # API Reference
 
 ## Packages
+- [config.druid.gardener.cloud/v1alpha1](#configdruidgardenercloudv1alpha1)
 - [druid.gardener.cloud/v1alpha1](#druidgardenercloudv1alpha1)
-- [operator.config.druid.gardener.cloud/v1alpha1](#operatorconfigdruidgardenercloudv1alpha1)
+
+
+## config.druid.gardener.cloud/v1alpha1
+
+
+
+
+#### ClientConnectionConfiguration
+
+
+
+ClientConnectionConfiguration defines the configuration for constructing a client.Client to connect to k8s kube-apiserver.
+
+
+
+_Appears in:_
+- [OperatorConfiguration](#operatorconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `qps` _float_ | QPS controls the number of queries per second allowed for a connection.<br />Setting this to a negative value will disable client-side rate limiting. |  |  |
+| `burst` _integer_ | Burst allows extra queries to accumulate when a client is exceeding its rate. |  |  |
+| `contentType` _string_ | ContentType is the content type used when sending data to the server from this client. |  |  |
+| `acceptContentTypes` _string_ | AcceptContentTypes defines the Accept header sent by clients when connecting to the server,<br />overriding the default value of 'application/json'. This field will control all connections<br />to the server used by a particular client. |  |  |
+
+
+#### CompactionControllerConfiguration
+
+
+
+CompactionControllerConfiguration defines the configuration for the compaction controller.
+
+
+
+_Appears in:_
+- [ControllerConfiguration](#controllerconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Enabled specifies whether backup compaction should be enabled. |  |  |
+| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
+| `eventsThreshold` _integer_ | EventsThreshold denotes total number of etcd events to be reached upon which a backup compaction job is triggered. |  |  |
+| `activeDeadlineDuration` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | ActiveDeadlineDuration is the duration after which a running compaction job will be killed. |  |  |
+| `metricsScrapeWaitDuration` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | MetricsScrapeWaitDuration is the duration to wait for after compaction job is completed, to allow Prometheus metrics to be scraped |  |  |
+
+
+#### ControllerConfiguration
+
+
+
+ControllerConfiguration defines the configuration for the controllers.
+
+
+
+_Appears in:_
+- [OperatorConfiguration](#operatorconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `disableLeaseCache` _boolean_ | DisableLeaseCache disables the cache for lease.coordination.k8s.io resources.<br />Deprecated: This field will be eventually removed. It is recommended to not use this.<br />It has only been introduced to allow for backward compatibility with the old CLI flags. |  |  |
+| `etcd` _[EtcdControllerConfiguration](#etcdcontrollerconfiguration)_ | Etcd is the configuration for the Etcd controller. |  |  |
+| `compaction` _[CompactionControllerConfiguration](#compactioncontrollerconfiguration)_ | Compaction is the configuration for the compaction controller. |  |  |
+| `etcdCopyBackupsTask` _[EtcdCopyBackupsTaskControllerConfiguration](#etcdcopybackupstaskcontrollerconfiguration)_ | EtcdCopyBackupsTask is the configuration for the EtcdCopyBackupsTask controller. |  |  |
+| `secret` _[SecretControllerConfiguration](#secretcontrollerconfiguration)_ | Secret is the configuration for the Secret controller. |  |  |
+
+
+#### EtcdComponentProtectionWebhookConfiguration
+
+
+
+EtcdComponentProtectionWebhookConfiguration defines the configuration for EtcdComponentProtection webhook.
+NOTE: At least one of ReconcilerServiceAccountFQDN or ServiceAccountInfo must be set. It is recommended to switch to ServiceAccountInfo.
+
+
+
+_Appears in:_
+- [WebhookConfiguration](#webhookconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Enabled indicates whether the EtcdComponentProtection webhook is enabled. |  |  |
+| `reconcilerServiceAccountFQDN` _string_ | ReconcilerServiceAccountFQDN is the FQDN of the reconciler service account used by the etcd-druid operator.<br />Deprecated: Please use ServiceAccountInfo instead and ensure that both Name and Namespace are set via projected volumes and downward API in the etcd-druid deployment spec. |  |  |
+| `serviceAccountInfo` _[ServiceAccountInfo](#serviceaccountinfo)_ | ServiceAccountInfo contains paths to gather etcd-druid service account information. |  |  |
+| `exemptServiceAccounts` _string array_ | ExemptServiceAccounts is a list of service accounts that are exempt from Etcd Components Webhook checks. |  |  |
+
+
+#### EtcdControllerConfiguration
+
+
+
+EtcdControllerConfiguration defines the configuration for the Etcd controller.
+
+
+
+_Appears in:_
+- [ControllerConfiguration](#controllerconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
+| `enableEtcdSpecAutoReconcile` _boolean_ | EnableEtcdSpecAutoReconcile controls how the Etcd Spec is reconciled. If set to true, then any change in Etcd spec<br />will automatically trigger a reconciliation of the Etcd resource. If set to false, then an operator needs to<br />explicitly set gardener.cloud/operation=reconcile annotation on the Etcd resource to trigger reconciliation<br />of the Etcd spec.<br />NOTE: Decision to enable it should be carefully taken as spec updates could potentially result in rolling update<br />of the StatefulSet which will cause a minor downtime for a single node etcd cluster and can potentially cause a<br />downtime for a multi-node etcd cluster. |  |  |
+| `disableEtcdServiceAccountAutomount` _boolean_ | DisableEtcdServiceAccountAutomount controls the auto-mounting of service account token for etcd StatefulSets. |  |  |
+| `etcdStatusSyncPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | EtcdStatusSyncPeriod is the duration after which an event will be re-queued ensuring etcd status synchronization. |  |  |
+| `etcdMember` _[EtcdMemberConfiguration](#etcdmemberconfiguration)_ | EtcdMember holds configuration related to etcd members. |  |  |
+
+
+#### EtcdCopyBackupsTaskControllerConfiguration
+
+
+
+EtcdCopyBackupsTaskControllerConfiguration defines the configuration for the EtcdCopyBackupsTask controller.
+
+
+
+_Appears in:_
+- [ControllerConfiguration](#controllerconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Enabled specifies whether EtcdCopyBackupsTaskController should be enabled. |  |  |
+| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
+
+
+#### EtcdMemberConfiguration
+
+
+
+EtcdMemberConfiguration holds configuration related to etcd members.
+
+
+
+_Appears in:_
+- [EtcdControllerConfiguration](#etcdcontrollerconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `notReadyThreshold` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | NotReadyThreshold is the duration after which an etcd member's state is considered `NotReady`. |  |  |
+| `unknownThreshold` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | UnknownThreshold is the duration after which an etcd member's state is considered `Unknown`. |  |  |
+
+
+#### LeaderElectionConfiguration
+
+
+
+LeaderElectionConfiguration defines the configuration for the leader election.
+It should be enabled when you deploy etcd-druid in HA mode. For single replica etcd-druid deployments
+it will not really serve any purpose.
+
+
+
+_Appears in:_
+- [OperatorConfiguration](#operatorconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Enabled specifies whether leader election is enabled. Set this<br />to true when running replicated instances of the operator for high availability. |  |  |
+| `leaseDuration` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | LeaseDuration is the duration that non-leader candidates will wait<br />after observing a leadership renewal until attempting to acquire<br />leadership of the occupied but un-renewed leader slot. This is effectively the<br />maximum duration that a leader can be stopped before it is replaced<br />by another candidate. This is only applicable if leader election is<br />enabled. |  |  |
+| `renewDeadline` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | RenewDeadline is the interval between attempts by the acting leader to<br />renew its leadership before it stops leading. This must be less than or<br />equal to the lease duration.<br />This is only applicable if leader election is enabled. |  |  |
+| `retryPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | RetryPeriod is the duration leader elector clients should wait<br />between attempting acquisition and renewal of leadership.<br />This is only applicable if leader election is enabled. |  |  |
+| `resourceLock` _string_ | ResourceLock determines which resource lock to use for leader election.<br />This is only applicable if leader election is enabled. |  |  |
+| `resourceName` _string_ | ResourceName determines the name of the resource that leader election<br />will use for holding the leader lock.<br />This is only applicable if leader election is enabled. |  |  |
+
+
+#### LogConfiguration
+
+
+
+LogConfiguration contains the configuration for logging.
+
+
+
+_Appears in:_
+- [OperatorConfiguration](#operatorconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `logLevel` _[LogLevel](#loglevel)_ | LogLevel is the level/severity for the logs. Must be one of [info,debug,error]. |  |  |
+| `logFormat` _[LogFormat](#logformat)_ | LogFormat is the output format for the logs. Must be one of [text,json]. |  |  |
+
+
+#### LogFormat
+
+_Underlying type:_ _string_
+
+LogFormat is the format of the log.
+
+
+
+_Appears in:_
+- [LogConfiguration](#logconfiguration)
+
+| Field | Description |
+| --- | --- |
+| `json` | LogFormatJSON is the JSON log format.<br /> |
+| `text` | LogFormatText is the text log format.<br /> |
+
+
+#### LogLevel
+
+_Underlying type:_ _string_
+
+LogLevel represents the level for logging.
+
+
+
+_Appears in:_
+- [LogConfiguration](#logconfiguration)
+
+| Field | Description |
+| --- | --- |
+| `debug` | LogLevelDebug is the debug log level, i.e. the most verbose.<br /> |
+| `info` | LogLevelInfo is the default log level.<br /> |
+| `error` | LogLevelError is a log level where only errors are logged.<br /> |
+
+
+
+
+#### SecretControllerConfiguration
+
+
+
+SecretControllerConfiguration defines the configuration for the Secret controller.
+
+
+
+_Appears in:_
+- [ControllerConfiguration](#controllerconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
+
+
+#### Server
+
+
+
+Server contains information for HTTP(S) server configuration.
+
+
+
+_Appears in:_
+- [ServerConfiguration](#serverconfiguration)
+- [TLSServer](#tlsserver)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `bindAddress` _string_ | BindAddress is the IP address on which to listen for the specified port. |  |  |
+| `port` _integer_ | Port is the port on which to serve unsecured, unauthenticated access. |  |  |
+
+
+#### ServerConfiguration
+
+
+
+ServerConfiguration contains the server configurations.
+
+
+
+_Appears in:_
+- [OperatorConfiguration](#operatorconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `webhooks` _[TLSServer](#tlsserver)_ | Webhooks is the configuration for the TLS webhook server. |  |  |
+| `metrics` _[Server](#server)_ | Metrics is the configuration for serving the metrics endpoint. |  |  |
+
+
+#### ServiceAccountInfo
+
+
+
+ServiceAccountInfo contains paths to gather etcd-druid service account information.
+Usually downward API and projected volumes are used in the deployment specification of etcd-druid to provide this information as mounted volume files.
+
+
+
+_Appears in:_
+- [EtcdComponentProtectionWebhookConfiguration](#etcdcomponentprotectionwebhookconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the service account associated with etcd-druid deployment. |  |  |
+| `namespace` _string_ | Namespace is the namespace in which the service account has been deployed.<br />Usually this information is usually available at /var/run/secrets/kubernetes.io/serviceaccount/namespace.<br />However, if automountServiceAccountToken is set to false then this file will not be available. |  |  |
+
+
+#### TLSServer
+
+
+
+TLSServer is the configuration for a TLS enabled server.
+
+
+
+_Appears in:_
+- [ServerConfiguration](#serverconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `bindAddress` _string_ | BindAddress is the IP address on which to listen for the specified port. |  |  |
+| `port` _integer_ | Port is the port on which to serve unsecured, unauthenticated access. |  |  |
+| `serverCertDir` _string_ | ServerCertDir is the path to a directory containing the server's TLS certificate and key (the files must be<br />named tls.crt and tls.key respectively). |  |  |
+
+
+#### WebhookConfiguration
+
+
+
+WebhookConfiguration defines the configuration for admission webhooks.
+
+
+
+_Appears in:_
+- [OperatorConfiguration](#operatorconfiguration)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `etcdComponentProtection` _[EtcdComponentProtectionWebhookConfiguration](#etcdcomponentprotectionwebhookconfiguration)_ | EtcdComponentProtection is the configuration for EtcdComponentProtection webhook. |  |  |
+
 
 
 ## druid.gardener.cloud/v1alpha1
@@ -677,324 +996,5 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Enabled specifies whether to wait for a final full snapshot before copying backups. |  |  |
 | `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | Timeout is the timeout for waiting for a final full snapshot. When this timeout expires, the copying of backups<br />will be performed anyway. No timeout or 0 means wait forever. |  |  |
-
-
-
-## operator.config.druid.gardener.cloud/v1alpha1
-
-
-
-
-#### ClientConnectionConfiguration
-
-
-
-ClientConnectionConfiguration defines the configuration for constructing a client.Client to connect to k8s kube-apiserver.
-
-
-
-_Appears in:_
-- [OperatorConfiguration](#operatorconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `qps` _float_ | QPS controls the number of queries per second allowed for a connection.<br />Setting this to a negative value will disable client-side rate limiting. |  |  |
-| `burst` _integer_ | Burst allows extra queries to accumulate when a client is exceeding its rate. |  |  |
-| `contentType` _string_ | ContentType is the content type used when sending data to the server from this client. |  |  |
-| `acceptContentTypes` _string_ | AcceptContentTypes defines the Accept header sent by clients when connecting to the server,<br />overriding the default value of 'application/json'. This field will control all connections<br />to the server used by a particular client. |  |  |
-
-
-#### CompactionControllerConfiguration
-
-
-
-CompactionControllerConfiguration defines the configuration for the compaction controller.
-
-
-
-_Appears in:_
-- [ControllerConfiguration](#controllerconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled specifies whether backup compaction should be enabled. |  |  |
-| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
-| `eventsThreshold` _integer_ | EventsThreshold denotes total number of etcd events to be reached upon which a backup compaction job is triggered. |  |  |
-| `activeDeadlineDuration` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | ActiveDeadlineDuration is the duration after which a running compaction job will be killed. |  |  |
-| `metricsScrapeWaitDuration` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | MetricsScrapeWaitDuration is the duration to wait for after compaction job is completed, to allow Prometheus metrics to be scraped |  |  |
-
-
-#### ControllerConfiguration
-
-
-
-ControllerConfiguration defines the configuration for the controllers.
-
-
-
-_Appears in:_
-- [OperatorConfiguration](#operatorconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `disableLeaseCache` _boolean_ | DisableLeaseCache disables the cache for lease.coordination.k8s.io resources.<br />Deprecated: This field will be eventually removed. It is recommended to not use this.<br />It has only been introduced to allow for backward compatibility with the old CLI flags. |  |  |
-| `etcd` _[EtcdControllerConfiguration](#etcdcontrollerconfiguration)_ | Etcd is the configuration for the Etcd controller. |  |  |
-| `compaction` _[CompactionControllerConfiguration](#compactioncontrollerconfiguration)_ | Compaction is the configuration for the compaction controller. |  |  |
-| `etcdCopyBackupsTask` _[EtcdCopyBackupsTaskControllerConfiguration](#etcdcopybackupstaskcontrollerconfiguration)_ | EtcdCopyBackupsTask is the configuration for the EtcdCopyBackupsTask controller. |  |  |
-| `secret` _[SecretControllerConfiguration](#secretcontrollerconfiguration)_ | Secret is the configuration for the Secret controller. |  |  |
-
-
-#### EtcdComponentProtectionWebhookConfiguration
-
-
-
-EtcdComponentProtectionWebhookConfiguration defines the configuration for EtcdComponentProtection webhook.
-NOTE: At least one of ReconcilerServiceAccountFQDN or ServiceAccountInfo must be set. It is recommended to switch to ServiceAccountInfo.
-
-
-
-_Appears in:_
-- [WebhookConfiguration](#webhookconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled indicates whether the EtcdComponentProtection webhook is enabled. |  |  |
-| `reconcilerServiceAccountFQDN` _string_ | ReconcilerServiceAccountFQDN is the FQDN of the reconciler service account used by the etcd-druid operator.<br />Deprecated: Please use ServiceAccountInfo instead and ensure that both Name and Namespace are set via projected volumes and downward API in the etcd-druid deployment spec. |  |  |
-| `serviceAccountInfo` _[ServiceAccountInfo](#serviceaccountinfo)_ | ServiceAccountInfo contains paths to gather etcd-druid service account information. |  |  |
-| `exemptServiceAccounts` _string array_ | ExemptServiceAccounts is a list of service accounts that are exempt from Etcd Components Webhook checks. |  |  |
-
-
-#### EtcdControllerConfiguration
-
-
-
-EtcdControllerConfiguration defines the configuration for the Etcd controller.
-
-
-
-_Appears in:_
-- [ControllerConfiguration](#controllerconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
-| `enableEtcdSpecAutoReconcile` _boolean_ | EnableEtcdSpecAutoReconcile controls how the Etcd Spec is reconciled. If set to true, then any change in Etcd spec<br />will automatically trigger a reconciliation of the Etcd resource. If set to false, then an operator needs to<br />explicitly set gardener.cloud/operation=reconcile annotation on the Etcd resource to trigger reconciliation<br />of the Etcd spec.<br />NOTE: Decision to enable it should be carefully taken as spec updates could potentially result in rolling update<br />of the StatefulSet which will cause a minor downtime for a single node etcd cluster and can potentially cause a<br />downtime for a multi-node etcd cluster. |  |  |
-| `disableEtcdServiceAccountAutomount` _boolean_ | DisableEtcdServiceAccountAutomount controls the auto-mounting of service account token for etcd StatefulSets. |  |  |
-| `etcdStatusSyncPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | EtcdStatusSyncPeriod is the duration after which an event will be re-queued ensuring etcd status synchronization. |  |  |
-| `etcdMember` _[EtcdMemberConfiguration](#etcdmemberconfiguration)_ | EtcdMember holds configuration related to etcd members. |  |  |
-
-
-#### EtcdCopyBackupsTaskControllerConfiguration
-
-
-
-EtcdCopyBackupsTaskControllerConfiguration defines the configuration for the EtcdCopyBackupsTask controller.
-
-
-
-_Appears in:_
-- [ControllerConfiguration](#controllerconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled specifies whether EtcdCopyBackupsTaskController should be enabled. |  |  |
-| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
-
-
-#### EtcdMemberConfiguration
-
-
-
-EtcdMemberConfiguration holds configuration related to etcd members.
-
-
-
-_Appears in:_
-- [EtcdControllerConfiguration](#etcdcontrollerconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `notReadyThreshold` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | NotReadyThreshold is the duration after which an etcd member's state is considered `NotReady`. |  |  |
-| `unknownThreshold` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | UnknownThreshold is the duration after which an etcd member's state is considered `Unknown`. |  |  |
-
-
-#### LeaderElectionConfiguration
-
-
-
-LeaderElectionConfiguration defines the configuration for the leader election.
-It should be enabled when you deploy etcd-druid in HA mode. For single replica etcd-druid deployments
-it will not really serve any purpose.
-
-
-
-_Appears in:_
-- [OperatorConfiguration](#operatorconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled specifies whether leader election is enabled. Set this<br />to true when running replicated instances of the operator for high availability. |  |  |
-| `leaseDuration` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | LeaseDuration is the duration that non-leader candidates will wait<br />after observing a leadership renewal until attempting to acquire<br />leadership of the occupied but un-renewed leader slot. This is effectively the<br />maximum duration that a leader can be stopped before it is replaced<br />by another candidate. This is only applicable if leader election is<br />enabled. |  |  |
-| `renewDeadline` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | RenewDeadline is the interval between attempts by the acting leader to<br />renew its leadership before it stops leading. This must be less than or<br />equal to the lease duration.<br />This is only applicable if leader election is enabled. |  |  |
-| `retryPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | RetryPeriod is the duration leader elector clients should wait<br />between attempting acquisition and renewal of leadership.<br />This is only applicable if leader election is enabled. |  |  |
-| `resourceLock` _string_ | ResourceLock determines which resource lock to use for leader election.<br />This is only applicable if leader election is enabled. |  |  |
-| `resourceName` _string_ | ResourceName determines the name of the resource that leader election<br />will use for holding the leader lock.<br />This is only applicable if leader election is enabled. |  |  |
-
-
-#### LogConfiguration
-
-
-
-LogConfiguration contains the configuration for logging.
-
-
-
-_Appears in:_
-- [OperatorConfiguration](#operatorconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `logLevel` _[LogLevel](#loglevel)_ | LogLevel is the level/severity for the logs. Must be one of [info,debug,error]. |  |  |
-| `logFormat` _[LogFormat](#logformat)_ | LogFormat is the output format for the logs. Must be one of [text,json]. |  |  |
-
-
-#### LogFormat
-
-_Underlying type:_ _string_
-
-LogFormat is the format of the log.
-
-
-
-_Appears in:_
-- [LogConfiguration](#logconfiguration)
-
-| Field | Description |
-| --- | --- |
-| `json` | LogFormatJSON is the JSON log format.<br /> |
-| `text` | LogFormatText is the text log format.<br /> |
-
-
-#### LogLevel
-
-_Underlying type:_ _string_
-
-LogLevel represents the level for logging.
-
-
-
-_Appears in:_
-- [LogConfiguration](#logconfiguration)
-
-| Field | Description |
-| --- | --- |
-| `debug` | LogLevelDebug is the debug log level, i.e. the most verbose.<br /> |
-| `info` | LogLevelInfo is the default log level.<br /> |
-| `error` | LogLevelError is a log level where only errors are logged.<br /> |
-
-
-
-
-#### SecretControllerConfiguration
-
-
-
-SecretControllerConfiguration defines the configuration for the Secret controller.
-
-
-
-_Appears in:_
-- [ControllerConfiguration](#controllerconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
-
-
-#### Server
-
-
-
-Server contains information for HTTP(S) server configuration.
-
-
-
-_Appears in:_
-- [ServerConfiguration](#serverconfiguration)
-- [TLSServer](#tlsserver)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `bindAddress` _string_ | BindAddress is the IP address on which to listen for the specified port. |  |  |
-| `port` _integer_ | Port is the port on which to serve unsecured, unauthenticated access. |  |  |
-
-
-#### ServerConfiguration
-
-
-
-ServerConfiguration contains the server configurations.
-
-
-
-_Appears in:_
-- [OperatorConfiguration](#operatorconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `webhooks` _[TLSServer](#tlsserver)_ | Webhooks is the configuration for the TLS webhook server. |  |  |
-| `metrics` _[Server](#server)_ | Metrics is the configuration for serving the metrics endpoint. |  |  |
-
-
-#### ServiceAccountInfo
-
-
-
-ServiceAccountInfo contains paths to gather etcd-druid service account information.
-Usually downward API and projected volumes are used in the deployment specification of etcd-druid to provide this information as mounted volume files.
-
-
-
-_Appears in:_
-- [EtcdComponentProtectionWebhookConfiguration](#etcdcomponentprotectionwebhookconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the service account associated with etcd-druid deployment. |  |  |
-| `namespace` _string_ | Namespace is the namespace in which the service account has been deployed.<br />Usually this information is usually available at /var/run/secrets/kubernetes.io/serviceaccount/namespace.<br />However, if automountServiceAccountToken is set to false then this file will not be available. |  |  |
-
-
-#### TLSServer
-
-
-
-TLSServer is the configuration for a TLS enabled server.
-
-
-
-_Appears in:_
-- [ServerConfiguration](#serverconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `bindAddress` _string_ | BindAddress is the IP address on which to listen for the specified port. |  |  |
-| `port` _integer_ | Port is the port on which to serve unsecured, unauthenticated access. |  |  |
-| `serverCertDir` _string_ | ServerCertDir is the path to a directory containing the server's TLS certificate and key (the files must be<br />named tls.crt and tls.key respectively). |  |  |
-
-
-#### WebhookConfiguration
-
-
-
-WebhookConfiguration defines the configuration for admission webhooks.
-
-
-
-_Appears in:_
-- [OperatorConfiguration](#operatorconfiguration)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `etcdComponentProtection` _[EtcdComponentProtectionWebhookConfiguration](#etcdcomponentprotectionwebhookconfiguration)_ | EtcdComponentProtection is the configuration for EtcdComponentProtection webhook. |  |  |
 
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:

* etcd-druid failed to start-up when `enabledOperatorConfig` is set to `true` in `values.yaml`. This was because of the mismatch in the group specified in the template for the `ConfigMap` generated for `OperatorConfiguration`. This was missed in 443bb9c39f1172204026b4e8ec08d4e3229c2e6f in #1090.

* The group specified in `api/config/v1alpha1/doc.go` also was incorrect, and is now corrected to the correct group.

* Generate the docs with the changes above.

* Include `go.work` and `go.work.sum` is included in `.gitignore` for a better local development experience.


**Which issue(s) this PR fixes**:
Fixes a bug in #1090.

**Special notes for your reviewer**:

@Shreyas-s14 @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a bug which caused etcd-druid to fail at start up, due to a group mismatch for `OperatorConfiguration` in its group registration and templates.
```
