### PR TITLE
Add missing backup-restore TLS secrets to secret controller

### DIFF
--- a/api/core/v1alpha1/etcd_test.go
+++ b/api/core/v1alpha1/etcd_test.go
@@ -170,6 +170,20 @@ func createEtcd(name, namespace string) *Etcd {
 		},
 	}
 
+	etcdbrTLSConfig := &TLSConfig{
+		TLSCASecretRef: SecretReference{
+			SecretReference: corev1.SecretReference{
+				Name: "ca-etcdbr",
+			},
+		},
+		ServerTLSSecretRef: corev1.SecretReference{
+			Name: "etcdbr-server-tls",
+		},
+		ClientTLSSecretRef: corev1.SecretReference{
+			Name: "etcdbr-client-tls",
+		},
+	}
+
 	instance := &Etcd{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -199,7 +213,7 @@ func createEtcd(name, namespace string) *Etcd {
 			Backup: BackupSpec{
 				Image:                    &imageBR,
 				Port:                     &backupPort,
-				TLS:                      clientTlsConfig,
+				TLS:                      etcdbrTLSConfig,
 				FullSnapshotSchedule:     &snapshotSchedule,
 				GarbageCollectionPolicy:  &garbageCollectionPolicy,
 				GarbageCollectionPeriod:  &garbageCollectionPeriod,

--- a/internal/controller/secret/mapper.go
+++ b/internal/controller/secret/mapper.go
@@ -53,6 +53,23 @@ func mapEtcdToSecret(_ context.Context, obj client.Object) []reconcile.Request {
 		}})
 	}
 
+	if etcd.Spec.Backup.TLS != nil {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: etcd.Namespace,
+			Name:      etcd.Spec.Backup.TLS.TLSCASecretRef.Name,
+		}})
+
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: etcd.Namespace,
+			Name:      etcd.Spec.Backup.TLS.ServerTLSSecretRef.Name,
+		}})
+
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: etcd.Namespace,
+			Name:      etcd.Spec.Backup.TLS.ClientTLSSecretRef.Name,
+		}})
+	}
+
 	if etcd.Spec.Backup.Store != nil && etcd.Spec.Backup.Store.SecretRef != nil {
 		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
 			Namespace: etcd.Namespace,

--- a/internal/controller/secret/mapper_test.go
+++ b/internal/controller/secret/mapper_test.go
@@ -21,6 +21,7 @@ func TestMapEtcdToSecret(t *testing.T) {
 		name             string
 		withClientTLS    bool
 		withPeerTLS      bool
+		withBackupTLS    bool
 		withBackup       bool
 		expectedRequests []reconcile.Request
 	}{
@@ -36,7 +37,7 @@ func TestMapEtcdToSecret(t *testing.T) {
 			},
 		},
 		{
-			name:          "etcd configured with only client TLS and with no store",
+			name:          "etcd configured with only client TLS and with no backup store",
 			withClientTLS: true,
 			expectedRequests: []reconcile.Request{
 				{NamespacedName: types.NamespacedName{Name: testutils.ClientTLSCASecretName, Namespace: testutils.TestNamespace}},
@@ -45,7 +46,7 @@ func TestMapEtcdToSecret(t *testing.T) {
 			},
 		},
 		{
-			name:          "etcd configured with both client and peer TLS but with no store configured",
+			name:          "etcd configured with both client and peer TLS but with no backup store",
 			withClientTLS: true,
 			withPeerTLS:   true,
 			expectedRequests: []reconcile.Request{
@@ -54,6 +55,15 @@ func TestMapEtcdToSecret(t *testing.T) {
 				{NamespacedName: types.NamespacedName{Name: testutils.ClientTLSClientCertSecretName, Namespace: testutils.TestNamespace}},
 				{NamespacedName: types.NamespacedName{Name: testutils.PeerTLSCASecretName, Namespace: testutils.TestNamespace}},
 				{NamespacedName: types.NamespacedName{Name: testutils.PeerTLSServerCertSecretName, Namespace: testutils.TestNamespace}},
+			},
+		},
+		{
+			name:          "etcd configured with only backup-restore TLS",
+			withBackupTLS: true,
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: testutils.BackupRestoreTLSCASecretName, Namespace: testutils.TestNamespace}},
+				{NamespacedName: types.NamespacedName{Name: testutils.BackupRestoreTLSServerCertSecretName, Namespace: testutils.TestNamespace}},
+				{NamespacedName: types.NamespacedName{Name: testutils.BackupRestoreTLSClientCertSecretName, Namespace: testutils.TestNamespace}},
 			},
 		},
 		{
@@ -67,6 +77,24 @@ func TestMapEtcdToSecret(t *testing.T) {
 				{NamespacedName: types.NamespacedName{Name: testutils.ClientTLSClientCertSecretName, Namespace: testutils.TestNamespace}},
 				{NamespacedName: types.NamespacedName{Name: testutils.PeerTLSCASecretName, Namespace: testutils.TestNamespace}},
 				{NamespacedName: types.NamespacedName{Name: testutils.PeerTLSServerCertSecretName, Namespace: testutils.TestNamespace}},
+				{NamespacedName: types.NamespacedName{Name: testutils.BackupStoreSecretName, Namespace: testutils.TestNamespace}},
+			},
+		},
+		{
+			name:          "etcd configured with client TLS, peer TLS and backup-restore TLS and with backup store",
+			withClientTLS: true,
+			withPeerTLS:   true,
+			withBackup:    true,
+			withBackupTLS: true,
+			expectedRequests: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: testutils.ClientTLSCASecretName, Namespace: testutils.TestNamespace}},
+				{NamespacedName: types.NamespacedName{Name: testutils.ClientTLSServerCertSecretName, Namespace: testutils.TestNamespace}},
+				{NamespacedName: types.NamespacedName{Name: testutils.ClientTLSClientCertSecretName, Namespace: testutils.TestNamespace}},
+				{NamespacedName: types.NamespacedName{Name: testutils.PeerTLSCASecretName, Namespace: testutils.TestNamespace}},
+				{NamespacedName: types.NamespacedName{Name: testutils.PeerTLSServerCertSecretName, Namespace: testutils.TestNamespace}},
+				{NamespacedName: types.NamespacedName{Name: testutils.BackupRestoreTLSCASecretName, Namespace: testutils.TestNamespace}},
+				{NamespacedName: types.NamespacedName{Name: testutils.BackupRestoreTLSServerCertSecretName, Namespace: testutils.TestNamespace}},
+				{NamespacedName: types.NamespacedName{Name: testutils.BackupRestoreTLSClientCertSecretName, Namespace: testutils.TestNamespace}},
 				{NamespacedName: types.NamespacedName{Name: testutils.BackupStoreSecretName, Namespace: testutils.TestNamespace}},
 			},
 		},
@@ -86,6 +114,9 @@ func TestMapEtcdToSecret(t *testing.T) {
 			}
 			if tc.withBackup {
 				etcdBuilder.WithDefaultBackup()
+			}
+			if tc.withBackupTLS {
+				etcdBuilder.WithBackupRestoreTLS()
 			}
 			etcd := etcdBuilder.Build()
 			actualRequests := mapEtcdToSecret(context.Background(), etcd)

--- a/internal/controller/secret/reconciler.go
+++ b/internal/controller/secret/reconciler.go
@@ -83,6 +83,13 @@ func isFinalizerNeeded(secretName string, etcdList *druidv1alpha1.EtcdList) (boo
 			return true, &etcd
 		}
 
+		if etcd.Spec.Backup.TLS != nil &&
+			(etcd.Spec.Backup.TLS.TLSCASecretRef.Name == secretName ||
+				etcd.Spec.Backup.TLS.ServerTLSSecretRef.Name == secretName ||
+				etcd.Spec.Backup.TLS.ClientTLSSecretRef.Name == secretName) {
+			return true, &etcd
+		}
+
 		if etcd.Spec.Backup.Store != nil &&
 			etcd.Spec.Backup.Store.SecretRef != nil &&
 			etcd.Spec.Backup.Store.SecretRef.Name == secretName {

--- a/test/integration/controllers/secret/reconciler_test.go
+++ b/test/integration/controllers/secret/reconciler_test.go
@@ -32,7 +32,11 @@ var _ = Describe("Secret Controller", func() {
 	)
 
 	BeforeEach(func() {
-		etcd = testutils.EtcdBuilderWithDefaults("etcd", namespace).WithClientTLS().WithPeerTLS().Build()
+		etcd = testutils.EtcdBuilderWithDefaults("etcd", namespace).
+			WithClientTLS().
+			WithPeerTLS().
+			WithBackupRestoreTLS().
+			Build()
 	})
 
 	It("should reconcile the finalizers for the referenced secrets", func() {
@@ -51,6 +55,9 @@ var _ = Describe("Secret Controller", func() {
 			"client-url-etcd-server-tls",
 			"peer-url-ca-etcd",
 			"peer-url-etcd-server-tls",
+			"ca-etcdbr",
+			"etcdbr-server-tls",
+			"etcdbr-client-tls",
 			"etcd-backup",
 		}
 		err := testutils.CreateSecrets(ctx, k8sClient, namespace, secretNames...)
@@ -70,6 +77,9 @@ var _ = Describe("Secret Controller", func() {
 			"client-url-etcd-server-tls2",
 			"peer-url-ca-etcd2",
 			"peer-url-etcd-server-tls2",
+			"ca-etcdbr2",
+			"etcdbr-server-tls2",
+			"etcdbr-client-tls2",
 			"etcd-backup2",
 		}
 		err = testutils.CreateSecrets(ctx, k8sClient, namespace, newSecretNames...)
@@ -81,6 +91,9 @@ var _ = Describe("Secret Controller", func() {
 		etcd.Spec.Etcd.ClientUrlTLS.ClientTLSSecretRef.Name += "2"
 		etcd.Spec.Etcd.PeerUrlTLS.TLSCASecretRef.Name += "2"
 		etcd.Spec.Etcd.PeerUrlTLS.ServerTLSSecretRef.Name += "2"
+		etcd.Spec.Backup.TLS.TLSCASecretRef.Name += "2"
+		etcd.Spec.Backup.TLS.ServerTLSSecretRef.Name += "2"
+		etcd.Spec.Backup.TLS.ClientTLSSecretRef.Name += "2"
 		etcd.Spec.Backup.Store.SecretRef.Name += "2"
 		Expect(k8sClient.Patch(ctx, etcd, patch)).To(Succeed())
 

--- a/test/utils/constants.go
+++ b/test/utils/constants.go
@@ -30,6 +30,12 @@ const (
 	PeerTLSCASecretName = "peer-url-ca-etcd" // #nosec G101 - this is not a credential itself but the name of the kubernetes secret resource.
 	// PeerTLSServerCertSecretName is the name of the kubernetes Secret containing the peer's server certificate.
 	PeerTLSServerCertSecretName = "peer-url-etcd-server-tls" // #nosec G101 - this is not a credential itself but the name of the kubernetes secret resource.
+	// BackupRestoreTLSCASecretName is the name of the kubernetes Secret containing the etcd-backup-restore CA.
+	BackupRestoreTLSCASecretName = "ca-etcdbr" // #nosec G101 - this is not a credential itself but the name of the kubernetes secret resource.
+	// BackupRestoreTLSServerCertSecretName is the name of the kubernetes Secret containing the etcd-backup-restore server certificate.
+	BackupRestoreTLSServerCertSecretName = "etcdbr-server-tls" // #nosec G101 - this is not a credential itself but the name of the kubernetes secret resource.
+	// BackupRestoreTLSClientCertSecretName is the name of the kubernetes Secret containing the etcd-backup-restore client certificate.
+	BackupRestoreTLSClientCertSecretName = "etcdbr-client-tls" // #nosec G101 - this is not a credential itself but the name of the kubernetes secret resource.
 	// BackupStoreSecretName is the name of the kubernetes Secret containing the backup store credentials.
 	BackupStoreSecretName = "etcd-backup"
 )

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -79,11 +79,8 @@ func (eb *EtcdBuilder) WithReplicas(replicas int32) *EtcdBuilder {
 	return eb
 }
 
-func (eb *EtcdBuilder) WithClientTLS() *EtcdBuilder {
-	if eb == nil || eb.etcd == nil {
-		return nil
-	}
-	clientTLSConfig := &druidv1alpha1.TLSConfig{
+func GetClientTLSConfig() *druidv1alpha1.TLSConfig {
+	return &druidv1alpha1.TLSConfig{
 		TLSCASecretRef: druidv1alpha1.SecretReference{
 			SecretReference: corev1.SecretReference{
 				Name: ClientTLSCASecretName,
@@ -97,16 +94,18 @@ func (eb *EtcdBuilder) WithClientTLS() *EtcdBuilder {
 			Name: ClientTLSServerCertSecretName,
 		},
 	}
-	eb.etcd.Spec.Etcd.ClientUrlTLS = clientTLSConfig
-	eb.etcd.Spec.Backup.TLS = clientTLSConfig
-	return eb
 }
 
-func (eb *EtcdBuilder) WithPeerTLS() *EtcdBuilder {
+func (eb *EtcdBuilder) WithClientTLS() *EtcdBuilder {
 	if eb == nil || eb.etcd == nil {
 		return nil
 	}
-	peerTLSConfig := &druidv1alpha1.TLSConfig{
+	eb.etcd.Spec.Etcd.ClientUrlTLS = GetClientTLSConfig()
+	return eb
+}
+
+func GetPeerTLSConfig() *druidv1alpha1.TLSConfig {
+	return &druidv1alpha1.TLSConfig{
 		TLSCASecretRef: druidv1alpha1.SecretReference{
 			SecretReference: corev1.SecretReference{
 				Name: PeerTLSCASecretName,
@@ -117,7 +116,38 @@ func (eb *EtcdBuilder) WithPeerTLS() *EtcdBuilder {
 			Name: PeerTLSServerCertSecretName,
 		},
 	}
-	eb.etcd.Spec.Etcd.PeerUrlTLS = peerTLSConfig
+}
+
+func (eb *EtcdBuilder) WithPeerTLS() *EtcdBuilder {
+	if eb == nil || eb.etcd == nil {
+		return nil
+	}
+	eb.etcd.Spec.Etcd.PeerUrlTLS = GetPeerTLSConfig()
+	return eb
+}
+
+func GetBackupRestoreTLSConfig() *druidv1alpha1.TLSConfig {
+	return &druidv1alpha1.TLSConfig{
+		TLSCASecretRef: druidv1alpha1.SecretReference{
+			SecretReference: corev1.SecretReference{
+				Name: BackupRestoreTLSCASecretName,
+			},
+			DataKey: ptr.To("ca.crt"),
+		},
+		ServerTLSSecretRef: corev1.SecretReference{
+			Name: BackupRestoreTLSServerCertSecretName,
+		},
+		ClientTLSSecretRef: corev1.SecretReference{
+			Name: BackupRestoreTLSClientCertSecretName,
+		},
+	}
+}
+
+func (eb *EtcdBuilder) WithBackupRestoreTLS() *EtcdBuilder {
+	if eb == nil || eb.etcd == nil {
+		return nil
+	}
+	eb.etcd.Spec.Backup.TLS = GetBackupRestoreTLSConfig()
 	return eb
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Secret controller was not adding finalizer to backup-restore TLS secrets. This PR fixes that.

**Special notes for your reviewer**:
Caught this one while working on #782 
/cc @Shreyas-s14 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Secret controller now manages finalizer on referenced backup-restore TLS secrets.
```
