### PR TITLE
Fixes helm chart service template to correctly use .Values.enabledOperatorConfig

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -87,3 +87,33 @@ etcd-druid-operator-configmap-{{ include "operator.config.data" . | sha256sum | 
 {{- define "webhook.etcdcomponentprotection.reconcilerServiceAccountFQDN" -}}
 {{- printf "system:serviceaccount:%s:%s" .Release.Namespace .Values.serviceAccount.name }}
 {{- end -}}
+
+{{ define "operator.service.ports" -}}
+{{- if .Values.enabledOperatorConfig }}
+{{- if .Values.operatorConfig.server.metrics.port }}
+- name: metrics
+  port: {{ .Values.operatorConfig.server.metrics.port }}
+  protocol: TCP
+  targetPort: {{ .Values.operatorConfig.server.metrics.port }}
+{{- end }}
+{{- if .Values.operatorConfig.server.webhooks.port }}
+- name: webhooks
+  port: {{ .Values.operatorConfig.server.webhooks.port }}
+  protocol: TCP
+  targetPort: {{ .Values.operatorConfig.server.webhooks.port }}
+{{ end -}}
+{{- else }}
+{{- if .Values.controllerManager.server.metrics.port }}
+- name: metrics
+  port: {{ .Values.controllerManager.server.metrics.port }}
+  protocol: TCP
+  targetPort: {{ .Values.controllerManager.server.metrics.port }}
+{{- end }}
+{{- if .Values.controllerManager.server.webhook.port }}
+- name: webhooks
+  port: {{ .Values.controllerManager.server.webhook.port }}
+  protocol: TCP
+  targetPort: {{ .Values.controllerManager.server.webhook.port }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -106,8 +106,8 @@ etcd-druid-operator-configmap-{{ include "operator.config.data" . | sha256sum | 
 {{- end }}
 {{- if $webhooksPort }}
 - name: webhooks
-  port: {{ .Values.operatorConfig.server.webhooks.port }}
+  port: {{ $webhooksPort }}
   protocol: TCP
-  targetPort: {{ .Values.operatorConfig.server.webhooks.port }}
+  targetPort: {{ $webhooksPort }}
 {{- end }}
 {{- end -}}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -89,31 +89,25 @@ etcd-druid-operator-configmap-{{ include "operator.config.data" . | sha256sum | 
 {{- end -}}
 
 {{ define "operator.service.ports" -}}
+{{- $metricsPort := "" }}
+{{- $webhooksPort := "" }}
 {{- if .Values.enabledOperatorConfig }}
-{{- if .Values.operatorConfig.server.metrics.port }}
-- name: metrics
-  port: {{ .Values.operatorConfig.server.metrics.port }}
-  protocol: TCP
-  targetPort: {{ .Values.operatorConfig.server.metrics.port }}
+{{- $metricsPort = .Values.operatorConfig.server.metrics.port }}
+{{- $webhooksPort = .Values.operatorConfig.server.webhooks.port }}
+{{- else }}
+{{- $metricsPort = .Values.controllerManager.server.metrics.port }}
+{{- $webhooksPort = .Values.controllerManager.server.webhook.port }}
 {{- end }}
-{{- if .Values.operatorConfig.server.webhooks.port }}
+{{- if $metricsPort }}
+- name: metrics
+  port: {{ $metricsPort }}
+  protocol: TCP
+  targetPort: {{ $metricsPort }}
+{{- end }}
+{{- if $webhooksPort }}
 - name: webhooks
   port: {{ .Values.operatorConfig.server.webhooks.port }}
   protocol: TCP
   targetPort: {{ .Values.operatorConfig.server.webhooks.port }}
-{{ end -}}
-{{- else }}
-{{- if .Values.controllerManager.server.metrics.port }}
-- name: metrics
-  port: {{ .Values.controllerManager.server.metrics.port }}
-  protocol: TCP
-  targetPort: {{ .Values.controllerManager.server.metrics.port }}
-{{- end }}
-{{- if .Values.controllerManager.server.webhook.port }}
-- name: webhooks
-  port: {{ .Values.controllerManager.server.webhook.port }}
-  protocol: TCP
-  targetPort: {{ .Values.controllerManager.server.webhook.port }}
-{{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -21,88 +21,88 @@ spec:
       shareProcessNamespace: true
       serviceAccountName: etcd-druid
       containers:
-      - name: etcd-druid
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        imagePullPolicy: {{ .Values.image.imagePullPolicy }}
-        args:
+        - name: etcd-druid
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          args:
         {{- if .Values.enabledOperatorConfig }}
-        - --config=/etc/etcd-druid/config/config.yaml
+            - --config=/etc/etcd-druid/config/config.yaml
         {{- else }}
         {{- if .Values.featureGates }}
         {{- $featuregates := "" }}
         {{- range $feature, $value := $.Values.featureGates }}
         {{- $featuregates = printf "%s%s=%t," $featuregates $feature $value }}
         {{- end }}
-        - --feature-gates={{ $featuregates | trimSuffix "," }}
+            - --feature-gates={{ $featuregates | trimSuffix "," }}
         {{- end }}
         {{- if ((((.Values.controllerManager).server).metrics).bindAddress) }}
-        - --metrics-bind-address={{ .Values.controllerManager.server.metrics.bindAddress }}
+            - --metrics-bind-address={{ .Values.controllerManager.server.metrics.bindAddress }}
         {{- end }}
         {{- if ((((.Values.controllerManager).server).metrics).port) }}
-        - --metrics-port={{ .Values.controllerManager.server.metrics.port }}
+            - --metrics-port={{ .Values.controllerManager.server.metrics.port }}
         {{- end }}
         {{- if ((((.Values.controllerManager).server).webhook).bindAddress) }}
-        - --webhook-server-bind-address={{ .Values.controllerManager.server.webhook.bindAddress }}
+            - --webhook-server-bind-address={{ .Values.controllerManager.server.webhook.bindAddress }}
         {{- end }}
         {{- if ((((.Values.controllerManager).server).webhook).port) }}
-        - --webhook-server-port={{ .Values.controllerManager.server.webhook.port }}
+            - --webhook-server-port={{ .Values.controllerManager.server.webhook.port }}
         {{- end }}
         {{- if (((((.Values.controllerManager).server).webhook).tls).serverCertDir) }}
-        - --webhook-server-tls-server-cert-dir={{ .Values.controllerManager.server.webhook.tls.serverCertDir }}
+            - --webhook-server-tls-server-cert-dir={{ .Values.controllerManager.server.webhook.tls.serverCertDir }}
         {{- end }}
         {{- if (((.Values.controllerManager).leaderElection).enabled) }}
-        - --enable-leader-election={{ .Values.controllerManager.leaderElection.enabled }}
-        - --leader-election-id={{ .Values.controllerManager.leaderElection.id }}
+            - --enable-leader-election={{ .Values.controllerManager.leaderElection.enabled }}
+            - --leader-election-id={{ .Values.controllerManager.leaderElection.id }}
         {{- end }}
         {{- if ((.Values.controllerManager).disableLeaseCache) }}
-        - --disable-lease-cache={{ .Values.controllerManager.disableLeaseCache }}
+            - --disable-lease-cache={{ .Values.controllerManager.disableLeaseCache }}
         {{- end }}
         {{- if ((.Values.controllers).etcd) }}
-        - --etcd-workers={{ .Values.controllers.etcd.workers }}
-        - --enable-etcd-spec-auto-reconcile={{ .Values.controllers.etcd.enableEtcdSpecAutoReconcile }}
-        - --disable-etcd-serviceaccount-automount={{ .Values.controllers.etcd.disableEtcdServiceAccountAutomount }}
-        - --etcd-status-sync-period={{ .Values.controllers.etcd.etcdStatusSyncPeriod }}
-        - --etcd-member-notready-threshold={{ .Values.controllers.etcd.etcdMemberNotReadyThreshold }}
-        - --etcd-member-unknown-threshold={{ .Values.controllers.etcd.etcdMemberUnknownThreshold }}
+            - --etcd-workers={{ .Values.controllers.etcd.workers }}
+            - --enable-etcd-spec-auto-reconcile={{ .Values.controllers.etcd.enableEtcdSpecAutoReconcile }}
+            - --disable-etcd-serviceaccount-automount={{ .Values.controllers.etcd.disableEtcdServiceAccountAutomount }}
+            - --etcd-status-sync-period={{ .Values.controllers.etcd.etcdStatusSyncPeriod }}
+            - --etcd-member-notready-threshold={{ .Values.controllers.etcd.etcdMemberNotReadyThreshold }}
+            - --etcd-member-unknown-threshold={{ .Values.controllers.etcd.etcdMemberUnknownThreshold }}
         {{- end }}
         {{- if and ((.Values.controllers).compaction) (eq .Values.controllers.compaction.enabled true) }}
-        - --enable-backup-compaction=true
-        - --compaction-workers={{ .Values.controllers.compaction.workers }}
-        - --etcd-events-threshold={{ int $.Values.controllers.compaction.etcdEventsThreshold }}
-        - --active-deadline-duration={{ .Values.controllers.compaction.activeDeadlineDuration }}
-        - --metrics-scrape-wait-duration={{ .Values.controllers.compaction.metricsScrapeWaitDuration }}
+            - --enable-backup-compaction=true
+            - --compaction-workers={{ .Values.controllers.compaction.workers }}
+            - --etcd-events-threshold={{ int $.Values.controllers.compaction.etcdEventsThreshold }}
+            - --active-deadline-duration={{ .Values.controllers.compaction.activeDeadlineDuration }}
+            - --metrics-scrape-wait-duration={{ .Values.controllers.compaction.metricsScrapeWaitDuration }}
         {{- end }}
         {{- if and ((.Values.controllers).etcdCopyBackupsTask) (eq .Values.controllers.etcdCopyBackupsTask.enabled true) }}
         {{- if (((.Values.controllers).etcdCopyBackupsTask).workers) }}
-        - --etcd-copy-backups-task-workers={{ .Values.controllers.etcdCopyBackupsTask.workers }}
+            - --etcd-copy-backups-task-workers={{ .Values.controllers.etcdCopyBackupsTask.workers }}
         {{- end }}
         {{- end }}
         {{- if (((.Values.controllers).secret).workers) }}
-        - --secret-workers={{ .Values.controllers.secret.workers }}
+            - --secret-workers={{ .Values.controllers.secret.workers }}
         {{- end }}
         {{- if eq $etcdComponentProtectionWebhookEnabled "true" }}
-        - --enable-etcd-components-webhook=true
-        - --reconciler-service-account={{ include "webhook.etcdcomponentprotection.reconcilerServiceAccountFQDN" . }}
+            - --enable-etcd-components-webhook=true
+            - --reconciler-service-account={{ include "webhook.etcdcomponentprotection.reconcilerServiceAccountFQDN" . }}
         {{- if .Values.webhooks.etcdComponentProtection.exemptServiceAccounts }}
-        - --etcd-components-webhook-exempt-service-accounts={{ join "," .Values.webhooks.etcdComponentProtection.exemptServiceAccounts }}
+            - --etcd-components-webhook-exempt-service-accounts={{ join "," .Values.webhooks.etcdComponentProtection.exemptServiceAccounts }}
         {{- end }}
         {{- end }}
         {{- end }}
-        volumeMounts:
+          volumeMounts:
         {{- if eq $etcdComponentProtectionWebhookEnabled "true" }}
-          - mountPath: /etc/webhook-server-tls
-            name: tls
-            readOnly: true
+            - mountPath: /etc/webhook-server-tls
+              name: tls
+              readOnly: true
         {{- end }}
         {{- if .Values.enabledOperatorConfig }}
-          - mountPath: /etc/etcd-druid/config
-            name: operator-config
-            readOnly: true
+            - mountPath: /etc/etcd-druid/config
+              name: operator-config
+              readOnly: true
         {{- end }}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -129,5 +129,5 @@ spec:
       {{- if .Values.enabledOperatorConfig }}
         - name: operator-config
           configMap:
-            name: {{ include "operator.config.name" . }}
+            name: etcd-druid-operator-config
       {{- end }}

--- a/charts/templates/operatorconfigmap.yaml
+++ b/charts/templates/operatorconfigmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "operator.config.name" . }}
+  name: etcd-druid-operator-config
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: etcd-druid

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -11,15 +11,28 @@ spec:
   selector:
     app.kubernetes.io/name: etcd-druid
   ports:
-    {{- if (((.Values.controllerManager).server).metrics).port }}
-    - name: metrics
-      port: {{ .Values.controllerManager.server.metrics.port }}
-      protocol: TCP
-      targetPort: {{ .Values.controllerManager.server.metrics.port }}
-    {{- end }}
-    {{- if (((.Values.controllerManager).server).webhook).port }}
-    - name: webhooks
-      port: {{ .Values.controllerManager.server.webhook.port }}
-      protocol: TCP
-      targetPort: {{ .Values.controllerManager.server.webhook.port }}
-    {{- end }}
+{{- include "operator.service.ports" . | trim | nindent 4 }}
+{{/*    {{- if (((.Values.controllerManager).server).port) }}*/}}
+{{/*    - name: server*/}}
+{{/*      port: {{ .Values.controllerManager.server.port }}*/}}
+{{/*      protocol: TCP*/}}
+{{/*      targetPort: {{ .Values.controllerManager.server.port }}*/}}
+{{/*    {{- end }}*/}}
+{{/*    {{- if (((.Values.controllerManager).server).healthz).port }}*/}}
+{{/*    - name: healthz*/}}
+{{/*      port: {{ .Values.controllerManager.server.healthz.port }}*/}}
+{{/*      protocol: TCP*/}}
+{{/*      targetPort: {{ .Values.controllerManager.server.healthz.port }}*/}}
+{{/*    {{- end }}*/}}
+{{/*    {{- if (((.Values.controllerManager).server).metrics).port }}*/}}
+{{/*    - name: metrics*/}}
+{{/*      port: {{ .Values.controllerManager.server.metrics.port }}*/}}
+{{/*      protocol: TCP*/}}
+{{/*      targetPort: {{ .Values.controllerManager.server.metrics.port }}*/}}
+{{/*    {{- end }}*/}}
+{{/*    {{- if (((.Values.controllerManager).server).webhook).port }}*/}}
+{{/*    - name: webhooks*/}}
+{{/*      port: {{ .Values.controllerManager.server.webhook.port }}*/}}
+{{/*      protocol: TCP*/}}
+{{/*      targetPort: {{ .Values.controllerManager.server.webhook.port }}*/}}
+{{/*    {{- end }}*/}}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -12,27 +12,3 @@ spec:
     app.kubernetes.io/name: etcd-druid
   ports:
 {{- include "operator.service.ports" . | trim | nindent 4 }}
-{{/*    {{- if (((.Values.controllerManager).server).port) }}*/}}
-{{/*    - name: server*/}}
-{{/*      port: {{ .Values.controllerManager.server.port }}*/}}
-{{/*      protocol: TCP*/}}
-{{/*      targetPort: {{ .Values.controllerManager.server.port }}*/}}
-{{/*    {{- end }}*/}}
-{{/*    {{- if (((.Values.controllerManager).server).healthz).port }}*/}}
-{{/*    - name: healthz*/}}
-{{/*      port: {{ .Values.controllerManager.server.healthz.port }}*/}}
-{{/*      protocol: TCP*/}}
-{{/*      targetPort: {{ .Values.controllerManager.server.healthz.port }}*/}}
-{{/*    {{- end }}*/}}
-{{/*    {{- if (((.Values.controllerManager).server).metrics).port }}*/}}
-{{/*    - name: metrics*/}}
-{{/*      port: {{ .Values.controllerManager.server.metrics.port }}*/}}
-{{/*      protocol: TCP*/}}
-{{/*      targetPort: {{ .Values.controllerManager.server.metrics.port }}*/}}
-{{/*    {{- end }}*/}}
-{{/*    {{- if (((.Values.controllerManager).server).webhook).port }}*/}}
-{{/*    - name: webhooks*/}}
-{{/*      port: {{ .Values.controllerManager.server.webhook.port }}*/}}
-{{/*      protocol: TCP*/}}
-{{/*      targetPort: {{ .Values.controllerManager.server.webhook.port }}*/}}
-{{/*    {{- end }}*/}}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -29,7 +29,7 @@ webhookPKI:
 # This configuration property is a short-lived property. It will be used to toggle between the now deprecated
 # CLI flags and the new OperatorConfiguration (which is the recommended way to configure etcd-druid operator).
 # To preserve backward compatibility the default value for this property is set to false.
-enabledOperatorConfig: false
+enabledOperatorConfig: true
 
 # Operator configuration
 # All configurable fields have been specified. Many of which are commented out with their default values.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Fixes the etcd-druid operator service template yaml to first check `.Values.enabledOperatorConfig` and based on the value pick the ports configuration from the relevant section in `values.yaml`.

**Which issue(s) this PR fixes**:
Fixes #1131 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixes etcd-druid service template yaml to properly support operator configuration values defined in values.yaml
```
