### PR TITLE
Fix etcd-wrapper related tls config flags

### DIFF
--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -613,12 +613,14 @@ func (b *stsBuilder) getEtcdContainerCommandArgs() []string {
 	commandArgs = append(commandArgs, fmt.Sprintf("--backup-restore-host-port=%s-local:%d", b.etcd.Name, b.backupPort))
 	commandArgs = append(commandArgs, fmt.Sprintf("--etcd-server-name=%s-local", b.etcd.Name))
 
-	if b.etcd.Spec.Etcd.ClientUrlTLS == nil {
+	if b.etcd.Spec.Backup.TLS == nil {
 		commandArgs = append(commandArgs, "--backup-restore-tls-enabled=false")
 	} else {
 		commandArgs = append(commandArgs, "--backup-restore-tls-enabled=true")
-		dataKey := ptr.Deref(b.etcd.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.DataKey, "ca.crt")
+		dataKey := ptr.Deref(b.etcd.Spec.Backup.TLS.TLSCASecretRef.DataKey, "ca.crt")
 		commandArgs = append(commandArgs, fmt.Sprintf("--backup-restore-ca-cert-bundle-path=%s/%s", common.VolumeMountPathBackupRestoreCA, dataKey))
+	}
+	if b.etcd.Spec.Etcd.ClientUrlTLS != nil {
 		commandArgs = append(commandArgs, fmt.Sprintf("--etcd-client-cert-path=%s/tls.crt", common.VolumeMountPathEtcdClientTLS))
 		commandArgs = append(commandArgs, fmt.Sprintf("--etcd-client-key-path=%s/tls.key", common.VolumeMountPathEtcdClientTLS))
 	}

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -273,36 +273,23 @@ func (s StatefulSetMatcher) matchEtcdContainerReadinessHandler() gomegatypes.Gom
 	})
 }
 
-func (s StatefulSetMatcher) matchEtcdContainerReadinessProbeCmd() gomegatypes.GomegaMatcher {
-	if s.etcd.Spec.Etcd.ClientUrlTLS != nil {
-		dataKey := ptr.Deref(s.etcd.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.DataKey, "ca.crt")
-		return HaveExactElements(
-			"/bin/sh",
-			"-ec",
-			fmt.Sprintf("ETCDCTL_API=3 etcdctl --cacert=/var/etcd/ssl/ca/%s --cert=/var/etcd/ssl/client/tls.crt --key=/var/etcd/ssl/client/tls.key --endpoints=https://%s-local:%d get foo --consistency=l", dataKey, s.etcd.Name, s.clientPort),
-		)
-	} else {
-		return HaveExactElements(
-			"/bin/sh",
-			"-ec",
-			fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=http://%s-local:%d get foo --consistency=l", s.etcd.Name, s.clientPort),
-		)
-	}
-}
-
 func (s StatefulSetMatcher) matchEtcdContainerCmdArgs() gomegatypes.GomegaMatcher {
 	cmdArgs := make([]string, 0, 8)
 	cmdArgs = append(cmdArgs, "start-etcd")
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--backup-restore-host-port=%s-local:%d", s.etcd.Name, s.backupPort))
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--etcd-server-name=%s-local", s.etcd.Name))
-	if s.etcd.Spec.Etcd.ClientUrlTLS == nil {
+	// backup-restore tls specific configuration
+	if s.etcd.Spec.Backup.TLS == nil {
 		cmdArgs = append(cmdArgs, "--backup-restore-tls-enabled=false")
 	} else {
-		dataKey := ptr.Deref(s.etcd.Spec.Etcd.ClientUrlTLS.TLSCASecretRef.DataKey, "ca.crt")
+		dataKey := ptr.Deref(s.etcd.Spec.Backup.TLS.TLSCASecretRef.DataKey, "ca.crt")
 		cmdArgs = append(cmdArgs, "--backup-restore-tls-enabled=true")
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--backup-restore-ca-cert-bundle-path=/var/etcdbr/ssl/ca/%s", dataKey))
+	}
+	// etcd client url tls specific configuration
+	if s.etcd.Spec.Etcd.ClientUrlTLS != nil {
 		cmdArgs = append(cmdArgs, "--etcd-client-cert-path=/var/etcd/ssl/client/tls.crt")
 		cmdArgs = append(cmdArgs, "--etcd-client-key-path=/var/etcd/ssl/client/tls.key")
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--backup-restore-ca-cert-bundle-path=/var/etcdbr/ssl/ca/%s", dataKey))
 	}
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--etcd-client-port=%d", s.clientPort))
 	cmdArgs = append(cmdArgs, fmt.Sprintf("--etcd-wrapper-port=%d", s.wrapperPort))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area user-management
/kind bug

**What this PR does / why we need it**:

The tls configuration related flags in the etcd container args in statefulset builder are incorrectly populated, where the `backup-restore` tls specific flags were dependent on etcd clientURL tls, but it should not depend on that and should instead depend on whether `etcd-backup-restore` server is TLS enabled or not. Have made the required changes in this PR.


**Special notes for your reviewer**:

Try configuring druid setup by just enabling backup-restore server TLS, it throws error as the client in the etcd container makes `http` request instead of `https` as the container's cli flags are incorrectly populated in druid. With these changes, it should work fine.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix backup-restore TLS related CLI flags to etcd-wrapper.
```
