### PR TITLE
Fix compaction e2e test setup in skaffold profile

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -66,7 +66,7 @@ profiles:
         path: /deploy/helm/releases/0/setValues/operatorConfig
         value:
           controllers.etcd.etcdStatusSyncPeriod: 5s
-          controllers.compaction.etcdEventsThreshold: "15"
+          controllers.compaction.eventsThreshold: "15"
           controllers.compaction.metricsScrapeWaitDuration: 30s
       - op: add
         path: /deploy/helm/releases/0/setValues/controllers


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:

The PR #1090 had introduced OperatorConfiguration but the skaffold profiles for the e2e test setup had an issue with an incorrect config field name, which the e2e tests depend upon. The field name was supposed to be `eventsThreshold` but was incorrectly named `etcdEventsThreshold` due to which the compaction e2e tests were failing consistently in PR pipelines. 

Code ref: https://github.com/gardener/etcd-druid/blob/f2552bdd84afa7f9b3ec1ffbc70c451865fff66c/skaffold.yaml#L69

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix incorrectly named config field in skaffold profile for e2e tests
```
