### PR TITLE
Github actions `non-release` workflow for `push` events does not run against PRs

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -1,6 +1,10 @@
 name: Build
 on:
   push:
+    branches:
+      - master
+      - 'hotfix-**'
+      - 'release-**'
   pull_request_target:
 
 jobs:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area open-source testing
/kind bug

**What this PR does / why we need it**:
Any commit or push to head for PR branches created within the repo trigger both `push` and `pull_request_target` events, causing every GHA step to run twice for PRs like dependabot PRs (example: https://github.com/gardener/etcd-druid/pull/1143, https://github.com/gardener/etcd-druid/pull/1142). This PR ensures that `push` events are only applicable to select branches on the repo, like `master` and release/hotfix branches, and no other branch, since we still need to run the `build` steps on every head update to master and release branches when PRs are merged onto them.

The `pull_request_target` event will still ensure that all the `build` steps are run for the PR upon every commit/change to the PR.

**Special notes for your reviewer**:
/invite @ccwienk 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
