### PR TITLE
To include release notes from sub-component i.e etcdbr.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,3 +34,4 @@ jobs:
       next-version: ${{ inputs.next-version }}
       next-version-callback-action-path:
       slack-channel-id: C0177NLL8V9 # #gardener-etcd
+      include-subcomponent-release-notes: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Etcd-druid release didn't include etcd-backup-restore's release notes: https://github.com/gardener/etcd-druid/releases/tag/v0.32.0. This PR is to make sure that release notes from sub-component i.e etcdbr should be included in etcd-druid release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
