### PR TITLE
Add ability to detect split-brain/split-quorum scenarios

### DIFF
--- a/internal/health/condition/check_ready_test.go
+++ b/internal/health/condition/check_ready_test.go
@@ -6,8 +6,15 @@ package condition_test
 
 import (
 	"context"
+	"fmt"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	testutils "github.com/gardener/etcd-druid/test/utils"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/gardener/etcd-druid/internal/health/condition"
 	. "github.com/onsi/ginkgo/v2"
@@ -16,7 +23,21 @@ import (
 
 var _ = Describe("ReadyCheck", func() {
 	Describe("#Check", func() {
-		var readyMember, notReadyMember, unknownMember druidv1alpha1.EtcdMemberStatus
+		const (
+			etcdName      = "etcd"
+			etcdNamespace = "etcd-test"
+			clusterID     = "0"
+			newClusterID  = "1"
+			member1ID     = "1"
+			member2ID     = "2"
+			member3ID     = "3"
+		)
+		var (
+			member1Name                                = fmt.Sprintf("%s-%d", etcdName, 0)
+			member2Name                                = fmt.Sprintf("%s-%d", etcdName, 1)
+			member3Name                                = fmt.Sprintf("%s-%d", etcdName, 2)
+			readyMember, notReadyMember, unknownMember druidv1alpha1.EtcdMemberStatus
+		)
 
 		BeforeEach(func() {
 			readyMember = druidv1alpha1.EtcdMemberStatus{
@@ -33,6 +54,10 @@ var _ = Describe("ReadyCheck", func() {
 		Context("when members in status", func() {
 			It("should return that the cluster has a quorum (all members ready)", func() {
 				etcd := druidv1alpha1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      etcdName,
+						Namespace: etcdNamespace,
+					},
 					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
@@ -42,7 +67,12 @@ var _ = Describe("ReadyCheck", func() {
 						},
 					},
 				}
-				check := ReadyCheck(nil)
+				member1Lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member1ID, clusterID, druidv1alpha1.EtcdRoleLeader)))
+				member2Lease := createMemberLease(member2Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member2ID, clusterID, druidv1alpha1.EtcdRoleMember)))
+				member3Lease := createMemberLease(member3Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member3ID, clusterID, druidv1alpha1.EtcdRoleMember)))
+				existingObjects := mapToClientObjects([]*coordinationv1.Lease{member1Lease, member2Lease, member3Lease})
+				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
+				check := ReadyCheck(cl)
 
 				result := check.Check(context.TODO(), etcd)
 
@@ -52,6 +82,10 @@ var _ = Describe("ReadyCheck", func() {
 
 			It("should return that the cluster has a quorum (members are partly unknown)", func() {
 				etcd := druidv1alpha1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      etcdName,
+						Namespace: etcdNamespace,
+					},
 					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
@@ -61,7 +95,12 @@ var _ = Describe("ReadyCheck", func() {
 						},
 					},
 				}
-				check := ReadyCheck(nil)
+				member1Lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member1ID, clusterID, druidv1alpha1.EtcdRoleLeader)))
+				member2Lease := createMemberLease(member2Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member2ID, clusterID, druidv1alpha1.EtcdRoleMember)))
+				member3Lease := createMemberLease(member3Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member3ID, clusterID, druidv1alpha1.EtcdRoleMember)))
+				existingObjects := mapToClientObjects([]*coordinationv1.Lease{member1Lease, member2Lease, member3Lease})
+				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
+				check := ReadyCheck(cl)
 
 				result := check.Check(context.TODO(), etcd)
 
@@ -69,8 +108,99 @@ var _ = Describe("ReadyCheck", func() {
 				Expect(result.Status()).To(Equal(druidv1alpha1.ConditionTrue))
 			})
 
+			It("should return that the cluster has a quorum (all members ready, with old lease format from backup-restore)", func() {
+				etcd := druidv1alpha1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      etcdName,
+						Namespace: etcdNamespace,
+					},
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
+					Status: druidv1alpha1.EtcdStatus{
+						Members: []druidv1alpha1.EtcdMemberStatus{
+							readyMember,
+							readyMember,
+							readyMember,
+						},
+					},
+				}
+				// Note that the cluster ID is not part of the HolderIdentity here, which is the old format used by backup-restore
+				member1Lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member1ID, druidv1alpha1.EtcdRoleLeader)))
+				member2Lease := createMemberLease(member2Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member2ID, druidv1alpha1.EtcdRoleMember)))
+				member3Lease := createMemberLease(member3Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s", member3ID, druidv1alpha1.EtcdRoleMember)))
+				existingObjects := mapToClientObjects([]*coordinationv1.Lease{member1Lease, member2Lease, member3Lease})
+				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
+				check := ReadyCheck(cl)
+
+				result := check.Check(context.TODO(), etcd)
+
+				Expect(result.ConditionType()).To(Equal(druidv1alpha1.ConditionTypeReady))
+				Expect(result.Status()).To(Equal(druidv1alpha1.ConditionTrue))
+			})
+
+			It("should return that the cluster has a split-brain (there are 2 leaders simultaneously)", func() {
+				etcd := druidv1alpha1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      etcdName,
+						Namespace: etcdNamespace,
+					},
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
+					Status: druidv1alpha1.EtcdStatus{
+						Members: []druidv1alpha1.EtcdMemberStatus{
+							readyMember,
+							readyMember,
+							readyMember,
+						},
+					},
+				}
+				member1Lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member1ID, clusterID, druidv1alpha1.EtcdRoleLeader)))
+				member2Lease := createMemberLease(member2Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member2ID, clusterID, druidv1alpha1.EtcdRoleMember)))
+				member3Lease := createMemberLease(member3Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member3ID, clusterID, druidv1alpha1.EtcdRoleLeader)))
+				existingObjects := mapToClientObjects([]*coordinationv1.Lease{member1Lease, member2Lease, member3Lease})
+				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
+				check := ReadyCheck(cl)
+
+				result := check.Check(context.TODO(), etcd)
+
+				Expect(result.ConditionType()).To(Equal(druidv1alpha1.ConditionTypeReady))
+				Expect(result.Status()).To(Equal(druidv1alpha1.ConditionFalse))
+				Expect(result.Reason()).To(Equal("SplitBrainDetected"))
+			})
+
+			It("should return that the cluster has a split-quorum (members are part of different clusters)", func() {
+				etcd := druidv1alpha1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      etcdName,
+						Namespace: etcdNamespace,
+					},
+					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
+					Status: druidv1alpha1.EtcdStatus{
+						Members: []druidv1alpha1.EtcdMemberStatus{
+							readyMember,
+							unknownMember,
+							unknownMember,
+						},
+					},
+				}
+				member1Lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member1ID, clusterID, druidv1alpha1.EtcdRoleLeader)))
+				member2Lease := createMemberLease(member2Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member2ID, clusterID, druidv1alpha1.EtcdRoleMember)))
+				member3Lease := createMemberLease(member3Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member3ID, newClusterID, druidv1alpha1.EtcdRoleMember)))
+				existingObjects := mapToClientObjects([]*coordinationv1.Lease{member1Lease, member2Lease, member3Lease})
+				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
+				check := ReadyCheck(cl)
+
+				result := check.Check(context.TODO(), etcd)
+
+				Expect(result.ConditionType()).To(Equal(druidv1alpha1.ConditionTypeReady))
+				Expect(result.Status()).To(Equal(druidv1alpha1.ConditionFalse))
+				Expect(result.Reason()).To(Equal("SplitQuorumDetected"))
+			})
+
 			It("should return that the cluster has a quorum (one member not ready)", func() {
 				etcd := druidv1alpha1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      etcdName,
+						Namespace: etcdNamespace,
+					},
 					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
@@ -80,7 +210,11 @@ var _ = Describe("ReadyCheck", func() {
 						},
 					},
 				}
-				check := ReadyCheck(nil)
+				member1Lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member1ID, clusterID, druidv1alpha1.EtcdRoleLeader)))
+				member3Lease := createMemberLease(member3Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member3ID, clusterID, druidv1alpha1.EtcdRoleMember)))
+				existingObjects := mapToClientObjects([]*coordinationv1.Lease{member1Lease, member3Lease})
+				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
+				check := ReadyCheck(cl)
 
 				result := check.Check(context.TODO(), etcd)
 
@@ -90,6 +224,10 @@ var _ = Describe("ReadyCheck", func() {
 
 			It("should return that the cluster has lost its quorum", func() {
 				etcd := druidv1alpha1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      etcdName,
+						Namespace: etcdNamespace,
+					},
 					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{
@@ -99,7 +237,10 @@ var _ = Describe("ReadyCheck", func() {
 						},
 					},
 				}
-				check := ReadyCheck(nil)
+				member1Lease := createMemberLease(member1Name, etcdNamespace, ptr.To(fmt.Sprintf("%s:%s:%s", member1ID, clusterID, druidv1alpha1.EtcdRoleLeader)))
+				existingObjects := mapToClientObjects([]*coordinationv1.Lease{member1Lease})
+				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, existingObjects)
+				check := ReadyCheck(cl)
 
 				result := check.Check(context.TODO(), etcd)
 
@@ -112,12 +253,17 @@ var _ = Describe("ReadyCheck", func() {
 		Context("when no members in status", func() {
 			It("should return that quorum is unknown", func() {
 				etcd := druidv1alpha1.Etcd{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      etcdName,
+						Namespace: etcdNamespace,
+					},
 					Spec: druidv1alpha1.EtcdSpec{Replicas: 3},
 					Status: druidv1alpha1.EtcdStatus{
 						Members: []druidv1alpha1.EtcdMemberStatus{},
 					},
 				}
-				check := ReadyCheck(nil)
+				cl := testutils.CreateTestFakeClientForObjects(nil, nil, nil, nil, nil)
+				check := ReadyCheck(cl)
 
 				result := check.Check(context.TODO(), etcd)
 
@@ -129,3 +275,24 @@ var _ = Describe("ReadyCheck", func() {
 	})
 
 })
+
+func mapToClientObjects(leases []*coordinationv1.Lease) []client.Object {
+	objects := make([]client.Object, 0, len(leases))
+	for _, lease := range leases {
+		objects = append(objects, lease)
+	}
+	return objects
+}
+
+func createMemberLease(name, namespace string, holderIdentity *string) *coordinationv1.Lease {
+	lease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: holderIdentity,
+		},
+	}
+	return lease
+}

--- a/internal/health/etcdmember/check_ready.go
+++ b/internal/health/etcdmember/check_ready.go
@@ -113,21 +113,28 @@ func separateIdFromRole(holderIdentity *string) (*string, *druidv1alpha1.EtcdRol
 	if holderIdentity == nil {
 		return nil, nil
 	}
-	parts := strings.SplitN(*holderIdentity, holderIdentitySeparator, 2)
-	id := &parts[0]
-	if len(parts) != 2 {
-		return id, nil
+	id, remainder, hasSeparator := strings.Cut(*holderIdentity, holderIdentitySeparator)
+	if !hasSeparator {
+		return &id, nil
 	}
 
-	switch druidv1alpha1.EtcdRole(parts[1]) {
+	before, after, hasSeparator := strings.Cut(remainder, holderIdentitySeparator)
+	var roleString string
+	if hasSeparator {
+		roleString = after
+	} else {
+		roleString = before
+	}
+
+	switch druidv1alpha1.EtcdRole(roleString) {
 	case druidv1alpha1.EtcdRoleLeader:
 		role := druidv1alpha1.EtcdRoleLeader
-		return id, &role
+		return &id, &role
 	case druidv1alpha1.EtcdRoleMember:
 		role := druidv1alpha1.EtcdRoleMember
-		return id, &role
+		return &id, &role
 	default:
-		return id, nil
+		return &id, nil
 	}
 }
 

--- a/test/it/controller/etcd/helper.go
+++ b/test/it/controller/etcd/helper.go
@@ -165,6 +165,7 @@ func createAndAssertEtcdReconciliation(ctx context.Context, t *testing.T, reconc
 type etcdMemberLeaseConfig struct {
 	name        string
 	memberID    string
+	clusterID   string
 	role        druidv1alpha1.EtcdRole
 	renewTime   *metav1.MicroTime
 	annotations map[string]string
@@ -179,8 +180,8 @@ func updateMemberLeases(ctx context.Context, t *testing.T, cl client.Client, nam
 		for key, value := range config.annotations {
 			metav1.SetMetaDataAnnotation(&updatedLease.ObjectMeta, key, value)
 		}
-		if config.memberID != "" && config.role != "" {
-			updatedLease.Spec.HolderIdentity = ptr.To(fmt.Sprintf("%s:%s", config.memberID, config.role))
+		if config.memberID != "" && config.role != "" && config.clusterID != "" {
+			updatedLease.Spec.HolderIdentity = ptr.To(fmt.Sprintf("%s:%s:%s", config.memberID, config.clusterID, config.role))
 		}
 		if config.renewTime != nil {
 			updatedLease.Spec.RenewTime = config.renewTime

--- a/test/it/controller/etcd/reconciler_test.go
+++ b/test/it/controller/etcd/reconciler_test.go
@@ -634,10 +634,11 @@ func testConditionsAndMembersWhenAllMemberLeasesAreActive(t *testing.T, etcd *dr
 	testNs := etcd.Namespace
 	clock := testclock.NewFakeClock(time.Now().Round(time.Second))
 	g := NewWithT(t)
+	clusterID := testutils.GenerateRandomAlphanumericString(g, 8)
 	mlcs := []etcdMemberLeaseConfig{
-		{name: memberLeaseNames[0], memberID: testutils.GenerateRandomAlphanumericString(g, 8), role: druidv1alpha1.EtcdRoleMember, renewTime: &metav1.MicroTime{Time: clock.Now().Add(-time.Second * 30)}},
-		{name: memberLeaseNames[1], memberID: testutils.GenerateRandomAlphanumericString(g, 8), role: druidv1alpha1.EtcdRoleLeader, renewTime: &metav1.MicroTime{Time: clock.Now()}},
-		{name: memberLeaseNames[2], memberID: testutils.GenerateRandomAlphanumericString(g, 8), role: druidv1alpha1.EtcdRoleMember, renewTime: &metav1.MicroTime{Time: clock.Now().Add(-time.Second * 30)}},
+		{name: memberLeaseNames[0], memberID: testutils.GenerateRandomAlphanumericString(g, 8), clusterID: clusterID, role: druidv1alpha1.EtcdRoleMember, renewTime: &metav1.MicroTime{Time: clock.Now().Add(-time.Second * 30)}},
+		{name: memberLeaseNames[1], memberID: testutils.GenerateRandomAlphanumericString(g, 8), clusterID: clusterID, role: druidv1alpha1.EtcdRoleLeader, renewTime: &metav1.MicroTime{Time: clock.Now()}},
+		{name: memberLeaseNames[2], memberID: testutils.GenerateRandomAlphanumericString(g, 8), clusterID: clusterID, role: druidv1alpha1.EtcdRoleMember, renewTime: &metav1.MicroTime{Time: clock.Now().Add(-time.Second * 30)}},
 	}
 	updateMemberLeases(context.Background(), t, reconcilerTestEnv.itTestEnv.GetClient(), testNs, mlcs)
 	// ******************************* test etcd status update flow *******************************


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/area robustness
/area monitoring

**What this PR does / why we need it**:
Adds the ability to detect split-brain/split-quorum scenarios. This allows for operators to look at the member leases of etcds deployed by druid and determine if it is stuck in a split-brain or split-quorum scenario.

**Which issue(s) this PR fixes**:
Related to #1022 

**Special notes for your reviewer**:
To ensure that this update doesn't break existing clusters, both an update and revert scenario was tested using https://gardener.github.io/etcd-druid/usage/managing-etcd-clusters.html#overwrite-container-oci-images. No issues were found in the test.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
