### PR TITLE
Reduce the default value of snapshot-count from 75k to 10k.

### DIFF
--- a/api/core/v1alpha1/etcd_test.go
+++ b/api/core/v1alpha1/etcd_test.go
@@ -123,7 +123,7 @@ func createEtcd(name, namespace string) *Etcd {
 		backupPort    int32 = 8080
 		wrapperPort   int32 = 9095
 		metricLevel         = Basic
-		snapshotCount int64 = 75000
+		snapshotCount int64 = 10000
 	)
 
 	garbageCollectionPeriod := metav1.Duration{

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -57,7 +57,7 @@ func main() {
 			},
 			Etcd: druidv1alpha1.EtcdConfig{
 				Quota:                   ptr.To(resource.MustParse("8Gi")),
-				SnapshotCount:           ptr.To(int64(75000)),
+				SnapshotCount:           ptr.To(int64(10000)),
 				DefragmentationSchedule: ptr.To("0 */24 * * *"),
 				ServerPort:              ptr.To[int32](2380),
 				ClientPort:              ptr.To[int32](2379),

--- a/internal/component/configmap/etcdconfig.go
+++ b/internal/component/configmap/etcdconfig.go
@@ -22,7 +22,7 @@ const (
 	defaultInitialClusterToken     = "etcd-cluster"
 	defaultInitialClusterState     = "new"
 	// For more information refer to https://etcd.io/docs/v3.4/op-guide/maintenance/#raft-log-retention
-	defaultSnapshotCount   = int64(75000)
+	defaultSnapshotCount   = int64(10000)
 	advertiseURLTypePeer   = "peer"
 	advertiseURLTypeClient = "client"
 )

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -107,7 +107,7 @@ var (
 	etcdClientPort    = int32(2379)
 	etcdServerPort    = int32(2380)
 	etcdWrapperPort   = int32(9095)
-	etcdSnapshotCount = int64(75000)
+	etcdSnapshotCount = int64(10000)
 
 	backupPort                 = int32(8080)
 	backupFullSnapshotSchedule = "0 */1 * * *"

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -40,7 +40,7 @@ var (
 	deltaSnapShotMemLimit   = resource.MustParse("100Mi")
 	autoCompactionMode      = druidv1alpha1.Periodic
 	autoCompactionRetention = "2m"
-	snapshotCount           = int64(75000)
+	snapshotCount           = int64(10000)
 	quota                   = resource.MustParse("8Gi")
 	localProvider           = druidv1alpha1.StorageProvider("Local")
 	prefix                  = "/tmp"


### PR DESCRIPTION
**How to categorize this PR?**
/area high-availability
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR reduces the default value of `--snapshot-count` from 75k to 10k.
- `--snapshot-count` is a tradeoff between higher memory usage and better availabilities of slow followers but in production usually clusters don't have slow followers, hence it better to reduce the snapshot-count to reduce the memory and disk usuage of etcd.
Please check doc: https://etcd.io/docs/v3.4/op-guide/maintenance/#raft-log-retention

**Which issue(s) this PR fixes**:
Fixes #1161 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reduces the default value of etcd's `--snapshot-count` from 75,000 to 10,000 set by `spec.etcd.snapshotCount`. This will reduce memory and disk usage of etcd. 
If you rely on the previous default, then set `spec.etcd.snapshotCount: 75000` to keep the old behavior.
```
