### PR TITLE
ci: Adapt to new release-notes interface

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,4 +38,5 @@ jobs:
       next-version: ${{ inputs.next-version }}
       next-version-callback-action-path:
       slack-channel-id: C0177NLL8V9 # #gardener-etcd
-      include-subcomponent-release-notes: true
+      social-release-notes-recursion-depth: -1
+      github-release-notes-recursion-depth: -1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area open-source
/kind api-change

**What this PR does / why we need it**:
Release-notes logic will be more explicit and different variants (e.g. github and slack posting) are configured individually.
Also, rather than just toggling subcomponent release-notes, one can now specify the desired depth (whereas -1 ^= `all`, thus equivalent to previous flag).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
~⚠️ Only merge after https://github.com/gardener/cc-utils/pull/1358 is merged (I will ping you).~
merged

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
