### PR TITLE
Fix CI build status marker in website

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@
     <a href="https://api.reuse.software/info/github.com/gardener/etcd-druid">
       <img alt="REUSE Status" src="https://api.reuse.software/badge/github.com/gardener/etcd-druid">
     </a>
-    <a href="https://concourse.ci.gardener.cloud/teams/gardener/pipelines/etcd-druid-master/jobs/master-head-update-job">
-      <img alt="CI Build Status" src="https://concourse.ci.gardener.cloud/api/v1/teams/gardener/pipelines/etcd-druid-master/jobs/master-head-update-job/badge">
+    <a href="https://github.com/gardener/etcd-druid/actions/workflows/non-release.yaml">
+      <img alt="CI Build Status" src="https://github.com/gardener/etcd-druid/actions/workflows/non-release.yaml/badge.svg">
     </a>
     <a href="https://goreportcard.com/report/github.com/gardener/etcd-druid">
       <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/gardener/etcd-druid">


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area open-source usability
/kind bug

**What this PR does / why we need it**:
Fix CI build status marker in website

**Special notes for your reviewer**:
/invite @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
