### PR TITLE
docs: fix order of steps

### DIFF
--- a/docs/usage/recovering-etcd-clusters.md
+++ b/docs/usage/recovering-etcd-clusters.md
@@ -171,13 +171,21 @@ NAME            READY   STATUS    RESTARTS   AGE
 
 If both containers report readiness (as seen above), then the etcd-cluster is considered ready.
 
-#### 08-Enable Etcd reconciliation and resource protection
+#### 08-Enable Etcd reconciliation
 
-All manual changes are now done. We must now re-enable etcd-cluster resource protection and also enable reconciliation by etcd-druid by doing the following:
+We must now re-enable reconciliation by etcd-druid by doing the following:
 
 ```bash
 kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/suspend-etcd-spec-reconcile-
-kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/disable-etcd-component-protection-
+```
+
+*Optional:*
+
+If etcd-druid has been set up without `--enable-etcd-spec-auto-reconcile` then to ensure reconciliation one must annotate `Etcd` resource with the following command:
+
+```bash
+# Annotate etcd CR to reconcile
+kubectl annotate etcd <etcd-name> -n <namespace> gardener.cloud/operation="reconcile"
 ```
 
 #### 09-Scale-up Etcd Cluster to 3 and trigger reconcile
@@ -186,13 +194,6 @@ Scale etcd-cluster to its original size (we assumed 3 below).
 
 ```bash
 kubectl scale sts <sts-name> -n namespace --replicas=3
-```
-
-If etcd-druid has been set up with `--enable-etcd-spec-auto-reconcile` switched-off then to ensure reconciliation one must annotate `Etcd` resource with the following command:
-
-```bash
-# Annotate etcd CR to reconcile
-kubectl annotate etcd <etcd-name> -n <namespace> gardener.cloud/operation="reconcile"
 ```
 
 #### 10-Verify Etcd cluster health
@@ -222,4 +223,11 @@ NAME          HOLDER                  AGE
 <etcd-name>-0 4c37667312a3912b:Member 1m
 <etcd-name>-1 75a9b74cfd3077cc:Member 1m
 <etcd-name>-2 c62ee6af755e890d:Leader 1m
+```
+
+#### 11-Enable resource protection
+
+Finally re-enable protection from manual edits by removing the corresponding annotation:
+```bash
+kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/disable-etcd-component-protection-
 ```


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area usability
/kind cleanup

**What this PR does / why we need it**:
The order of steps to perform a recovery is a bit off and didn't work for us. This fix is the way we got it eventually working.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix order of instructions in recovery docs
```
