### PR TITLE
Release tags for api and client modules

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,10 @@ jobs:
       packages: write
     with:
       release-commit-target: branch
+      github-tag-template: '${version}'
+      github-additional-tag-templates: |
+        api/${version}
+        client/${version}
       next-version: ${{ inputs.next-version }}
       next-version-callback-action-path:
       slack-channel-id: C0177NLL8V9 # #gardener-etcd


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area open-source
/kind task

**What this PR does / why we need it**:
Release git tags for `api` and `client` modules, using the `github-additional-tag-templates` field added in https://github.com/gardener/cc-utils/pull/1382. These were previously present ([ref](https://github.com/gardener/etcd-druid/blob/c7d1e687148ec2bdfcab54cd2e35e6dd6deb271a/.ci/pipeline_definitions#L115-L118)) but were temporarily removed when migrating to GHA since GHA didn't support this at the time of migration.

**Special notes for your reviewer**:
/cc @ccwienk 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
