### PR TITLE
Re-add `.ci/set_dependency_version` script to re-enable component version upgrades

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# WARNING: do not delete or rename this file; it is used by the
+# `Create Upgrade-Pull-Requests` workflow in the GHA CI pipeline to
+# update component versions in the internal/images/images.yaml file.
+
+import json
+import pathlib
+import sys
+
+import ci.util
+
+dependency_type = ci.util.check_env('DEPENDENCY_TYPE')
+if not dependency_type == 'component':
+    ci.util.fail(
+        "don't know how to upgrade dependency type: "
+        f'{dependency_type}'
+    )
+
+dependency_name = ci.util.check_env('DEPENDENCY_NAME')
+name = dependency_name.split('/')[-1]
+dependency_version = ci.util.check_env('DEPENDENCY_VERSION')
+
+images_file = pathlib.Path(
+        ci.util.check_env('REPO_DIR'),
+        'internal',
+        'images',
+        'images.yaml',
+)
+
+class ImagesParser(object):
+    '''
+    a naive YAML-parser crafted for the special case of processing
+    gardener's images.yaml file; crafted that way to preserve
+    comments/empty lines
+    '''
+    def __init__(
+        self,
+        images_file,
+        names,
+        target_version,
+    ):
+        self.images_file = images_file
+        self.lines = images_file.read_text().split('\n')
+        self.names = names
+        self.target_version = target_version
+        self._line_idx = 0
+
+    def _line(self):
+        return self.lines[self._line_idx]
+
+    def _next_line(self):
+        self._line_idx += 1
+        return self._line()
+
+    def _skip_to_next_entry(self, names):
+        while not self._line().startswith('-'):
+            self._next_line()
+        name = self._line().strip().split(':')[-1].strip()
+
+        if name not in names:
+            self._next_line()
+            return self._skip_to_next_entry(names)
+
+        # found one of the entries:
+        return name
+
+    def _skip_to_next_tag(self):
+        self._next_line()
+        while not self._line().startswith('-'):
+            if self._line().strip().startswith('tag:'):
+                return
+            self._next_line()
+        raise RuntimeError('did not find tag attribute')
+
+    def set_versions(self):
+        while self.names:
+            try:
+                name = self._skip_to_next_entry(self.names)
+            except IndexError:
+                print(str(self.names))
+                ci.util.fail('don\'t know how to update ' + str(self.names))
+            self.names.remove(name)
+            self._skip_to_next_tag()
+            tag_line = self._line()
+            indent = len(tag_line) - len(tag_line.lstrip())
+            patched_line = ' ' * indent + 'tag: "{version}"'.format(
+                version=self.target_version,
+            )
+            self.lines[self._line_idx] = patched_line
+
+    def write_updated_file(self):
+        self.images_file.write_text(
+            '\n'.join(self.lines)
+        )
+
+parser = ImagesParser(
+    images_file=images_file,
+    names=[name],
+    target_version=dependency_version,
+)
+
+parser.set_versions()
+parser.write_updated_file()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area open-source
/kind regression

**What this PR does / why we need it**:
Re-add `.ci/set_dependency_version` script, which was previously removed in https://github.com/gardener/etcd-druid/pull/1172, in order to re-enable component version upgrades for version upgrade PRs such as https://github.com/gardener/etcd-druid/pull/1196.

**Special notes for your reviewer**:
/invite @8R0WNI3 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
