### PR TITLE
Set the default snapshot compression to true.

### DIFF
--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -31,7 +31,7 @@ const (
 	// DefaultCompression is constant for default compression policy(only if compression is enabled).
 	DefaultCompression = GzipCompression
 	// DefaultCompressionEnabled is constant to define whether to compress the snapshots or not.
-	DefaultCompressionEnabled = false
+	DefaultCompressionEnabled bool = true
 
 	// Periodic is a constant to set auto-compaction-mode 'periodic' for duration based retention.
 	Periodic CompactionMode = "periodic"

--- a/examples/etcd/druid_v1alpha1_etcd.yaml
+++ b/examples/etcd/druid_v1alpha1_etcd.yaml
@@ -54,7 +54,7 @@ spec:
     #   provider: local # options: aws,azure,gcp,openstack,alicloud,dell,openshift,local
     #   prefix: etcd-test
     compression:
-      enabled: false
+      enabled: true # false (to disable compression)
       policy: "gzip"
     leaderElection:
       reelectionPeriod: 5s

--- a/examples/etcd/druid_v1alpha1_etcd_azurite.yaml
+++ b/examples/etcd/druid_v1alpha1_etcd_azurite.yaml
@@ -54,7 +54,7 @@ spec:
       secretRef:
         name: etcd-backup-azurite
     compression:
-      enabled: false
+      enabled: true
       policy: "gzip"
     leaderElection:
       reelectionPeriod: 5s

--- a/examples/etcd/druid_v1alpha1_etcd_fakegcs.yaml
+++ b/examples/etcd/druid_v1alpha1_etcd_fakegcs.yaml
@@ -54,7 +54,7 @@ spec:
       secretRef:
         name: etcd-backup-gcp
     compression:
-      enabled: false
+      enabled: true
       policy: "gzip"
     leaderElection:
       reelectionPeriod: 5s

--- a/examples/etcd/druid_v1alpha1_etcd_localstack.yaml
+++ b/examples/etcd/druid_v1alpha1_etcd_localstack.yaml
@@ -54,7 +54,7 @@ spec:
       secretRef:
         name: etcd-backup-aws
     compression:
-      enabled: false
+      enabled: true
       policy: "gzip"
     leaderElection:
       reelectionPeriod: 5s

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -565,14 +565,14 @@ func (b *stsBuilder) getBackupStoreCommandArgs() []string {
 
 	// Snapshot compression and timeout command line args
 	// -----------------------------------------------------------------------------------------------------------------
+	compressionEnabled, compressionPolicy := druidv1alpha1.DefaultCompressionEnabled, druidv1alpha1.DefaultCompression
 	if b.etcd.Spec.Backup.SnapshotCompression != nil {
-		if ptr.Deref(b.etcd.Spec.Backup.SnapshotCompression.Enabled, false) {
-			commandArgs = append(commandArgs, fmt.Sprintf("--compress-snapshots=%t", *b.etcd.Spec.Backup.SnapshotCompression.Enabled))
-		}
-		if b.etcd.Spec.Backup.SnapshotCompression.Policy != nil {
-			commandArgs = append(commandArgs, fmt.Sprintf("--compression-policy=%s", string(*b.etcd.Spec.Backup.SnapshotCompression.Policy)))
-		}
+		compressionEnabled = ptr.Deref(b.etcd.Spec.Backup.SnapshotCompression.Enabled, druidv1alpha1.DefaultCompressionEnabled)
+		compressionPolicy = ptr.Deref(b.etcd.Spec.Backup.SnapshotCompression.Policy, druidv1alpha1.DefaultCompression)
 	}
+
+	commandArgs = append(commandArgs, fmt.Sprintf("--compress-snapshots=%t", compressionEnabled))
+	commandArgs = append(commandArgs, fmt.Sprintf("--compression-policy=%s", compressionPolicy))
 
 	etcdSnapshotTimeout := defaultEtcdSnapshotTimeout
 	if b.etcd.Spec.Backup.EtcdSnapshotTimeout != nil {


### PR DESCRIPTION
/area backup
/kind technical-debt

**What this PR does / why we need it**:
Snapshot compression feature was introduced long back by this PR https://github.com/gardener/etcd-backup-restore/pull/293 but we decided not to enable it by default in etcd-druid. Now I think the feature has been matured enough and it can be enabled by default. Moreover, I have seen that while doing perf testing for snapshot timeout sometimes dev forgot to enable the snapshot compression which result in failure while uploading/downloading the big snapshots as those snapshots aren't compressed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Snapshot compression is now enabled by default.
If you wish to disable the snapshot compression then please set the etcd resource: `.spec.backup.compression.enabled` to false.
```

