### PR TITLE
Fix inline test results

### DIFF
--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -139,9 +139,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir tmp/blobs.d
-          ${{ matrix.args.run }} |& tee tmp/blobs.d/test-log.txt
-          tar czf tmp/blobs.d/test-log.tar.gz -C tmp/blobs.d test-log.txt
+          mkdir -p /tmp/blobs.d
+          ${{ matrix.args.run }} |& tee /tmp/blobs.d/test-log.txt
+          tar czf /tmp/blobs.d/test-log.tar.gz -C /tmp/blobs.d test-log.txt
       - name: add-test-results-to-component-descriptor
         uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
FIxes the `test` step in GHA workflows (see [example workflow failure](https://github.com/gardener/etcd-druid/actions/runs/18594494881)).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
