### PR TITLE
Add `fsGroupChangePolicy` to PodSecurityContext.

### DIFF
--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -640,18 +640,19 @@ func (b *stsBuilder) getEtcdContainerEnvVars() []corev1.EnvVar {
 func (b *stsBuilder) getPodSecurityContext() *corev1.PodSecurityContext {
 	if ptr.Deref(b.etcd.Spec.RunAsRoot, false) {
 		return &corev1.PodSecurityContext{
-			RunAsGroup:   ptr.To[int64](rootUser),
+			RunAsGroup:   ptr.To(rootUser),
 			RunAsNonRoot: ptr.To(false),
-			RunAsUser:    ptr.To[int64](rootUser),
-			FSGroup:      ptr.To[int64](rootUser),
+			RunAsUser:    ptr.To(rootUser),
+			FSGroup:      ptr.To(rootUser),
 		}
 	}
 
 	return &corev1.PodSecurityContext{
-		RunAsGroup:   ptr.To[int64](nonRootUser),
-		RunAsNonRoot: ptr.To(true),
-		RunAsUser:    ptr.To[int64](nonRootUser),
-		FSGroup:      ptr.To[int64](nonRootUser),
+		RunAsGroup:          ptr.To(nonRootUser),
+		RunAsNonRoot:        ptr.To(true),
+		RunAsUser:           ptr.To(nonRootUser),
+		FSGroup:             ptr.To(nonRootUser),
+		FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 	}
 }
 

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -371,10 +371,11 @@ func (s StatefulSetMatcher) matchEtcdPodSecurityContext() gomegatypes.GomegaMatc
 	}
 
 	return PointTo(MatchFields(IgnoreExtras|IgnoreMissing, Fields{
-		"RunAsGroup":   PointTo(Equal(int64(65532))),
-		"RunAsNonRoot": PointTo(Equal(true)),
-		"RunAsUser":    PointTo(Equal(int64(65532))),
-		"FSGroup":      PointTo(Equal(int64(65532))),
+		"RunAsGroup":          PointTo(Equal(int64(65532))),
+		"RunAsNonRoot":        PointTo(Equal(true)),
+		"RunAsUser":           PointTo(Equal(int64(65532))),
+		"FSGroup":             PointTo(Equal(int64(65532))),
+		"FSGroupChangePolicy": PointTo(Equal(corev1.FSGroupChangeOnRootMismatch)),
 	}))
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
/area compliance
/kind enhancement

**What this PR does / why we need it**:
This PR adds [FSGroupChangePolicy](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods) to PodSecurityContext and set the value to `OnRootMismatch`.

Note: If `FSGroupChangePolicy` policy is not set/added to PodSecurityContext then default value i.e `Always` is used which means, it always change the permission/ownership of the volume when volume is mounted, on the other hand if `FSGroupChangePolicy` set to `OnRootMismatch`, it only try to change the permission/ownership if root directory does not match with expected permissions of the volume.


**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/etcd-backup-restore/issues/932

**Special notes for your reviewer**:
/cc @shreyas-s-rao 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set the PodSecurityContext's `fsGroupChangePolicy` to `OnRootMismatch`.
```
