### PR TITLE
Add privacy notice to pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -4,6 +4,8 @@ about: Report a bug encountered while working with etcd-druid
 
 ---
 
+<!-- Please ensure that you do not include company internal information. -->
+
 **How to categorize this issue?**
 <!--
 Please select area, kind, and priority for this issue. This helps the community categorizing it.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -4,6 +4,8 @@ about: Suggest an enhancement for etcd-druid
 
 ---
 
+<!-- Please ensure that you do not include company internal information. -->
+
 **How to categorize this issue?**
 <!--
 Please select area, kind, and priority for this issue. This helps the community categorizing it.

--- a/.github/ISSUE_TEMPLATE/flaking-test.md
+++ b/.github/ISSUE_TEMPLATE/flaking-test.md
@@ -5,6 +5,8 @@ title: "[Flaky Test] FLAKING TEST/SUITE"
 
 ---
 
+<!-- Please ensure that you do not include company internal information. -->
+
 <!-- Please only use this template for submitting reports about flaky tests or jobs (pass or fail with no underlying change in code) in Gardener CI -->
 
 **How to categorize this issue?**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Please ensure that you do not include company internal information. -->
+
 **How to categorize this PR?**
 <!--
 Please select area, kind, and priority for this pull request. This helps the community categorizing it.


### PR DESCRIPTION
This PR adds a privacy notice to pr and issue template files to remind users not to include company internal information.

Files modified:
- .github/ISSUE_TEMPLATE/bug.md
- .github/ISSUE_TEMPLATE/feature.md
- .github/ISSUE_TEMPLATE/flaking-test.md
- .github/pull_request_template.md