### PR TITLE
Fix formatting in EtcdOpsTask proposal documentation

### DIFF
--- a/docs/proposals/05-etcdopstask.md
+++ b/docs/proposals/05-etcdopstask.md
@@ -231,7 +231,7 @@ Task(s) can be created by creating an instance of the `EtcdOpsTask` custom resou
 #### Execution
 
 * Authors propose to introduce a new controller which watches for `EtcdOpsTask` custom resource.
-* Each `out-of-band` task may have some task specific configuration defined in [.spec.config.<taskConfig>](#spec).
+* Each `out-of-band` task may have some task specific configuration defined in [.spec.config.`<taskConfig>`](#spec).
 * The controller needs to process this task specific config, which comes as a structured object of type `EtcdOpsTaskConfig`, according to the schema defined for each task.
 * For every `out-of-band` task, a set of `pre-conditions` can be defined. These pre-conditions are evaluated against the current state of the target etcd cluster. Based on the evaluation result (boolean), the task is permitted or denied execution.
 * If multiple tasks are invoked simultaneously or in `pending` state, then they will be executed in a First-In-First-Out (FIFO) manner.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
fix syntax, <> without a codeblock breaks markdown compiler. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
