### PR TITLE
Add shell specification for check-git-status step

### DIFF
--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -116,6 +116,7 @@ jobs:
           K8S_VERSION: 1.34
       - name: check-git-status
         run: make check-git-status
+        shell: bash
   tests:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area open-source
/area testing
/kind bug


**What this PR does / why we need it**:

Currently the `make check-git-status` fails silently with:
```txt
 /bin/sh: 1: [[: not found
```
This is due to the `[[` syntax not being supported by the `sh` shell. By changing the shell to `bash`, we should be able to report issues caught as part of `make check` or `make generate`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
