### PR TITLE
Change GHA to label-triggered

### DIFF
--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -19,6 +19,7 @@ jobs:
       version-commit-callback-action-path:
     permissions:
       contents: read
+      pull-requests: write # Required for trusted-checkout to remove trusted label
 
   oci-images:
     name: Build OCI-Images
@@ -90,8 +91,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - prepare
     steps:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+        with:
+          remove-trusted-label: false # Already removed by the prepare step
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'
@@ -121,6 +126,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - prepare
     strategy:
       matrix:
         args:
@@ -132,6 +139,8 @@ jobs:
             run: make test-integration
     steps:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
+        with:
+          remove-trusted-label: false # Already removed by the prepare step
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -6,6 +6,8 @@ on:
       - 'hotfix-**'
       - 'release-**'
   pull_request_target:
+    types:
+      - labeled
 
 jobs:
   build:
@@ -13,7 +15,9 @@ jobs:
     with:
       mode: snapshot
     secrets: inherit
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'reviewed/ok-to-test' }}
     permissions:
+      pull-requests: write
       contents: read
       packages: write
       id-token: write
@@ -23,6 +27,7 @@ jobs:
     needs:
       - build
     secrets: inherit
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'reviewed/ok-to-test' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/pullrequest-trust-helper.yaml
+++ b/.github/workflows/pullrequest-trust-helper.yaml
@@ -1,0 +1,17 @@
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  pullrequest-trusted-helper:
+    permissions:
+      pull-requests: write
+    secrets: inherit # access to `GitHub-Actions`-App is needed to read teams
+    uses: gardener/cc-utils/.github/workflows/pullrequest-trust-helper.yaml@master
+    with:
+      # members will be trusted (-> get okay-to-test-label automatically)
+      trusted-teams: "core,etcd-druid-maintainers"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area open-source quality testing
/kind bug

**What this PR does / why we need it**:

#1229 was intended to enable publishing of docker images to the registry as part of the CI workflow for PRs, but due to permissions required by [gardener/cc-utils](https://github.com/gardener/cc-utils), this wouldn't work on PRs from untrusted forks when the workflow is triggered using the `pull_request_target` trigger. This PR changes the trigger to label-based to resolve the issue.

**Special notes for your reviewer**:

Guidance from [gardener/cc-utils](https://github.com/gardener/cc-utils) regarding this: https://gardener.github.io/cc-utils/github_actions.html#pull-requests-from-forked-repositories

/cc @ccwienk

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
