### PR TITLE
Code improvements using modernize

### DIFF
--- a/internal/component/configmap/configmap_test.go
+++ b/internal/component/configmap/configmap_test.go
@@ -330,7 +330,7 @@ func matchConfigMap(g *WithT, etcd *druidv1alpha1.Etcd, actualConfigMap corev1.C
 	}))
 	// Validate the etcd config data
 	actualETCDConfigYAML := actualConfigMap.Data[common.EtcdConfigFileName]
-	actualETCDConfig := make(map[string]interface{})
+	actualETCDConfig := make(map[string]any)
 	err := yaml.Unmarshal([]byte(actualETCDConfigYAML), &actualETCDConfig)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actualETCDConfig).To(MatchKeys(IgnoreExtras|IgnoreMissing, Keys{
@@ -349,7 +349,7 @@ func matchConfigMap(g *WithT, etcd *druidv1alpha1.Etcd, actualConfigMap corev1.C
 	matchPeerTLSRelatedConfiguration(g, etcd, actualETCDConfig)
 }
 
-func matchClientTLSRelatedConfiguration(g *WithT, etcd *druidv1alpha1.Etcd, actualETCDConfig map[string]interface{}) {
+func matchClientTLSRelatedConfiguration(g *WithT, etcd *druidv1alpha1.Etcd, actualETCDConfig map[string]any) {
 	if etcd.Spec.Etcd.ClientUrlTLS != nil {
 		g.Expect(actualETCDConfig).To(MatchKeys(IgnoreExtras|IgnoreMissing, Keys{
 			"listen-client-urls":    Equal(fmt.Sprintf("https://0.0.0.0:%d", ptr.Deref(etcd.Spec.Etcd.ClientPort, common.DefaultPortEtcdClient))),
@@ -388,11 +388,11 @@ func expectedAdvertiseURLs(etcd *druidv1alpha1.Etcd, advertiseURLType, scheme st
 	return advUrlsMap
 }
 
-func expectedAdvertiseURLsAsInterface(etcd *druidv1alpha1.Etcd, advertiseURLType, scheme string) map[string]interface{} {
+func expectedAdvertiseURLsAsInterface(etcd *druidv1alpha1.Etcd, advertiseURLType, scheme string) map[string]any {
 	advertiseUrlsMap := expectedAdvertiseURLs(etcd, advertiseURLType, scheme)
-	advertiseUrlsInterface := make(map[string]interface{}, len(advertiseUrlsMap))
+	advertiseUrlsInterface := make(map[string]any, len(advertiseUrlsMap))
 	for podName, urlList := range advertiseUrlsMap {
-		urlsListInterface := make([]interface{}, len(urlList))
+		urlsListInterface := make([]any, len(urlList))
 		for i, url := range urlList {
 			urlsListInterface[i] = url
 		}
@@ -401,7 +401,7 @@ func expectedAdvertiseURLsAsInterface(etcd *druidv1alpha1.Etcd, advertiseURLType
 	return advertiseUrlsInterface
 }
 
-func matchPeerTLSRelatedConfiguration(g *WithT, etcd *druidv1alpha1.Etcd, actualETCDConfig map[string]interface{}) {
+func matchPeerTLSRelatedConfiguration(g *WithT, etcd *druidv1alpha1.Etcd, actualETCDConfig map[string]any) {
 	if etcd.Spec.Etcd.PeerUrlTLS != nil {
 		g.Expect(actualETCDConfig).To(MatchKeys(IgnoreExtras|IgnoreMissing, Keys{
 			"peer-transport-security": MatchKeys(IgnoreExtras, Keys{

--- a/internal/component/memberlease/memberlease_test.go
+++ b/internal/component/memberlease/memberlease_test.go
@@ -292,8 +292,8 @@ func doGetLatestLeases(g *WithT, cl client.Client, etcd *druidv1alpha1.Etcd, mat
 	return leases.Items
 }
 
-func memberLeases(etcdName string, etcdUID types.UID, numLeases int32) []interface{} {
-	var elements []interface{}
+func memberLeases(etcdName string, etcdUID types.UID, numLeases int32) []any {
+	var elements []any
 	for i := 0; i < int(numLeases); i++ {
 		leaseName := fmt.Sprintf("%s-%d", etcdName, i)
 		elements = append(elements, matchLeaseElement(leaseName, etcdName, etcdUID))
@@ -316,7 +316,7 @@ func newMemberLeases(etcd *druidv1alpha1.Etcd, numLeases int) ([]*coordinationv1
 	}
 	memberLeaseNames := druidv1alpha1.GetMemberLeaseNames(etcd.ObjectMeta, etcd.Spec.Replicas)
 	leases := make([]*coordinationv1.Lease, 0, numLeases)
-	for i := 0; i < numLeases; i++ {
+	for i := range numLeases {
 		lease := &coordinationv1.Lease{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            memberLeaseNames[i],

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -551,6 +551,6 @@ func getStatefulSetLabels(etcdName string) map[string]string {
 	}
 }
 
-func containerIdentifier(element interface{}) string {
+func containerIdentifier(element any) string {
 	return (element.(corev1.Container)).Name
 }

--- a/internal/controller/utils/validator.go
+++ b/internal/controller/utils/validator.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"fmt"
+	"slices"
 
 	"golang.org/x/exp/constraints"
 )
@@ -13,10 +14,8 @@ import (
 // ShouldBeOneOfAllowedValues checks if value is amongst the allowedValues. If it is not then an error is returned else nil is returned.
 // Type is constrained by comparable forcing the consumers to only use concrete types that can be compared using the == or != operators.
 func ShouldBeOneOfAllowedValues[E comparable](key string, allowedValues []E, value E) error {
-	for _, av := range allowedValues {
-		if av == value {
-			return nil
-		}
+	if slices.Contains(allowedValues, value) {
+		return nil
 	}
 	return fmt.Errorf("unsupported value %v provided for %s. allowed values are: %v", value, key, allowedValues)
 }

--- a/internal/utils/kubernetes/lease_test.go
+++ b/internal/utils/kubernetes/lease_test.go
@@ -154,7 +154,7 @@ func createLeases(etcd *druidv1alpha1.Etcd, withTLSEnabled int) []*coordinationv
 		druidv1alpha1.LabelManagedByKey: druidv1alpha1.LabelManagedByValue,
 	}
 	tlsEnabledCount := 0
-	for i := 0; i < numLeases; i++ {
+	for i := range numLeases {
 		var annotations map[string]string
 		if tlsEnabledCount < withTLSEnabled {
 			annotations = map[string]string{

--- a/test/e2e/etcd_multi_node_test.go
+++ b/test/e2e/etcd_multi_node_test.go
@@ -585,7 +585,7 @@ func checkDefragmentationFinished(ctx context.Context, cl client.Client, etcd *d
 			return fmt.Errorf("error occurred while getting [%s] pod logs, error: %v ", leaderPodKey, err)
 		}
 
-		for i := 0; i < int(multiNodeEtcdReplicas); i++ {
+		for i := range int(multiNodeEtcdReplicas) {
 			if !strings.Contains(logs,
 				fmt.Sprintf("Finished defragmenting etcd member[https://%s-%d.%s-peer.%s.svc:2379]",
 					etcd.Name, i, etcd.Name, namespace)) {

--- a/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
+++ b/test/integration/controllers/etcdcopybackupstask/reconciler_test.go
@@ -411,6 +411,6 @@ func addEqual(elements Elements, s string) {
 	elements[s] = Equal(s)
 }
 
-func conditionIdentifier(element interface{}) string {
+func conditionIdentifier(element any) string {
 	return string((element.(druidv1alpha1.Condition)).Type)
 }

--- a/test/it/controller/etcd/assertions.go
+++ b/test/it/controller/etcd/assertions.go
@@ -106,7 +106,6 @@ func doAssertComponentsExist(ctx context.Context, t *testing.T, rtEnv Reconciler
 	wg := sync.WaitGroup{}
 	wg.Add(len(assertionFns))
 	for _, assertFn := range assertionFns {
-		assertFn := assertFn
 		go func() {
 			defer wg.Done()
 			assertFn(opCtx, t, opRegistry, etcd, timeout, pollInterval)

--- a/test/it/crdvalidation/etcdcopybackupstask/helper.go
+++ b/test/it/crdvalidation/etcdcopybackupstask/helper.go
@@ -58,7 +58,7 @@ func validatePatchedObjectCreation[T client.Object](g *WithT, patchedObject *uns
 
 // patchObject is a helper that patches a key within the given Kubernetes object. This is needed to simulate invalid
 // values passed in through YAML to the api-server, bypassing the type-checks of the Go client.
-func patchObject[T client.Object](object T, fieldPath []string, value interface{}) (*unstructured.Unstructured, error) {
+func patchObject[T client.Object](object T, fieldPath []string, value any) (*unstructured.Unstructured, error) {
 	// Convert the object to a vanilla Go map
 	unstructuredObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
 	if err != nil {
@@ -70,9 +70,9 @@ func patchObject[T client.Object](object T, fieldPath []string, value interface{
 	for _, key := range fieldPath[:len(fieldPath)-1] {
 		// Initialize the map for the sub-path if it does not exist to avoid runtime error in the next iteration.
 		if _, exists := currentObject[key]; !exists {
-			currentObject[key] = make(map[string]interface{})
+			currentObject[key] = make(map[string]any)
 		}
-		currentObject = currentObject[key].(map[string]interface{})
+		currentObject = currentObject[key].(map[string]any)
 	}
 	currentObject[fieldPath[len(fieldPath)-1]] = value
 

--- a/test/utils/client.go
+++ b/test/utils/client.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"context"
+	"maps"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -349,8 +350,6 @@ func (c *testClient) getRecordedObjectCollectionError(method ClientMethod, names
 
 func createLabelSet(l map[string]string) labels.Set {
 	s := labels.Set{}
-	for k, v := range l {
-		s[k] = v
-	}
+	maps.Copy(s, l)
 	return s
 }

--- a/test/utils/iterator.go
+++ b/test/utils/iterator.go
@@ -9,26 +9,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func OwnerRefIterator(element interface{}) string {
+func OwnerRefIterator(element any) string {
 	return (element.(metav1.OwnerReference)).Name
 }
 
-func VolumeMountIterator(element interface{}) string {
+func VolumeMountIterator(element any) string {
 	return (element.(corev1.VolumeMount)).Name
 }
 
-func VolumeIterator(element interface{}) string {
+func VolumeIterator(element any) string {
 	return (element.(corev1.Volume)).Name
 }
 
-func EnvIterator(element interface{}) string {
+func EnvIterator(element any) string {
 	return (element.(corev1.EnvVar)).Name
 }
 
-func ContainerIterator(element interface{}) string {
+func ContainerIterator(element any) string {
 	return (element.(corev1.Container)).Name
 }
 
-func CmdIterator(element interface{}) string {
+func CmdIterator(element any) string {
 	return element.(string)
 }

--- a/test/utils/matcher.go
+++ b/test/utils/matcher.go
@@ -27,7 +27,7 @@ type mapMatcher[T comparable] struct {
 	diff      []string
 }
 
-func (m mapMatcher[T]) Match(actual interface{}) (bool, error) {
+func (m mapMatcher[T]) Match(actual any) (bool, error) {
 	if actual == nil {
 		return false, nil
 	}
@@ -47,15 +47,15 @@ func (m mapMatcher[T]) Match(actual interface{}) (bool, error) {
 	return len(m.diff) == 0, nil
 }
 
-func (m mapMatcher[T]) FailureMessage(actual interface{}) string {
+func (m mapMatcher[T]) FailureMessage(actual any) string {
 	return m.createMessage(actual, "to be")
 }
 
-func (m mapMatcher[T]) NegatedFailureMessage(actual interface{}) string {
+func (m mapMatcher[T]) NegatedFailureMessage(actual any) string {
 	return m.createMessage(actual, "to not be")
 }
 
-func (m mapMatcher[T]) createMessage(actual interface{}, message string) string {
+func (m mapMatcher[T]) createMessage(actual any, message string) string {
 	msgBuilder := strings.Builder{}
 	msgBuilder.WriteString(format.Message(actual, message, m.expected))
 	if len(m.diff) > 0 {

--- a/test/utils/misc.go
+++ b/test/utils/misc.go
@@ -26,7 +26,7 @@ func MatchFinalizer(finalizer string) gomegatypes.GomegaMatcher {
 	})
 }
 
-func stringIdentifier(element interface{}) string {
+func stringIdentifier(element any) string {
 	return element.(string)
 }
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
The fixes in this PR are applied using 
```
$ go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -omitzero=false -fix ./...
```
Refer https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize for details on each fix.

**Which issue(s) this PR fixes**:
Fixes #



**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
