### PR TITLE
Increase the default connection timeout for out-of-band full snapshot requests to 15mins

### DIFF
--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcdopstasks.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcdopstasks.yaml
@@ -85,10 +85,10 @@ spec:
                         minimum: 10
                         type: integer
                       timeoutSecondsFull:
-                        default: 480
+                        default: 900
                         description: |-
                           TimeoutSecondsFull is the timeout for full snapshot operations.
-                          Defaults to 480 seconds (8 minutes).
+                          Defaults to 900 seconds (15 minutes).
                         format: int32
                         minimum: 120
                         type: integer

--- a/api/core/v1alpha1/ondemandsnapshot.go
+++ b/api/core/v1alpha1/ondemandsnapshot.go
@@ -35,9 +35,9 @@ type OnDemandSnapshotConfig struct {
 	TimeoutSecondsDelta *int32 `json:"timeoutSecondsDelta,omitempty"`
 
 	// TimeoutSecondsFull is the timeout for full snapshot operations.
-	// Defaults to 480 seconds (8 minutes).
+	// Defaults to 900 seconds (15 minutes).
 	// +optional
-	// +kubebuilder:default=480
+	// +kubebuilder:default=900
 	// +kubebuilder:validation:Minimum=120
 	TimeoutSecondsFull *int32 `json:"timeoutSecondsFull,omitempty"`
 }

--- a/charts/crds/druid.gardener.cloud_etcdopstasks.yaml
+++ b/charts/crds/druid.gardener.cloud_etcdopstasks.yaml
@@ -85,10 +85,10 @@ spec:
                         minimum: 10
                         type: integer
                       timeoutSecondsFull:
-                        default: 480
+                        default: 900
                         description: |-
                           TimeoutSecondsFull is the timeout for full snapshot operations.
-                          Defaults to 480 seconds (8 minutes).
+                          Defaults to 900 seconds (15 minutes).
                         format: int32
                         minimum: 120
                         type: integer

--- a/docs/api-reference/etcd-druid-api.md
+++ b/docs/api-reference/etcd-druid-api.md
@@ -990,7 +990,7 @@ _Appears in:_
 | `type` _[OnDemandSnapshotType](#ondemandsnapshottype)_ | Type specifies whether the snapshot is a 'full' or 'delta' snapshot.<br />Use 'full' for a complete backup of the etcd database, or 'delta' for incremental changes since the last snapshot. |  | Enum: [full delta] <br />Required: \{\} <br /> |
 | `isFinal` _boolean_ | IsFinal indicates whether the snapshot of type: full is marked as final. This is subject to change. |  |  |
 | `timeoutSecondsDelta` _integer_ | TimeoutSeconds is the timeout for the delta snapshot operation.<br />Defaults to 60 seconds. | 60 | Minimum: 10 <br /> |
-| `timeoutSecondsFull` _integer_ | TimeoutSecondsFull is the timeout for full snapshot operations.<br />Defaults to 480 seconds (8 minutes). | 480 | Minimum: 120 <br /> |
+| `timeoutSecondsFull` _integer_ | TimeoutSecondsFull is the timeout for full snapshot operations.<br />Defaults to 900 seconds (15 minutes). | 900 | Minimum: 120 <br /> |
 
 
 #### OnDemandSnapshotType

--- a/docs/proposals/05-etcdopstask.md
+++ b/docs/proposals/05-etcdopstask.md
@@ -314,9 +314,9 @@ type OnDemandSnapshotConfig struct {
 	TimeoutSecondsDelta *int32 `json:"timeoutSecondsDelta,omitempty"`
 
 	// TimeoutSecondsFull is the timeout for full snapshot operations.
-	// Defaults to 480 seconds (8 minutes).
+	// Defaults to 900 seconds (15 minutes).
 	// +optional
-	// +kubebuilder:default=480
+	// +kubebuilder:default=900
 	TimeoutSecondsFull *int32 `json:"timeoutSecondsFull,omitempty"`
 }
 ```

--- a/docs/usage/using-etcdopstask.md
+++ b/docs/usage/using-etcdopstask.md
@@ -26,7 +26,7 @@ spec:
     onDemandSnapshot:
       type: full  # or delta
       #isFinal: false
-      timeoutSecondsFull: 480
+      timeoutSecondsFull: 900
       #timeoutSecondsDelta: 60
    ttlSecondsAfterFinished: 360   
   
@@ -125,7 +125,7 @@ Triggers an on-demand snapshot outside the regular snapshot schedule.
 **Configuration Options:**
 - `type`: Specifies the snapshot type (`full` or `delta`)
 - `isFinal`: Optional boolean flag to mark the snapshot as final (default: `false`). This field is applicable only for full snapshots.
-- `timeoutSecondsFull`: Timeout in seconds for full snapshot operations (default: 480)
+- `timeoutSecondsFull`: Timeout in seconds for full snapshot operations (default: 900)
 - `timeoutSecondsDelta`: Timeout in seconds for delta snapshot operations (default: 60)
 
 

--- a/examples/client/etcdopstask/main.go
+++ b/examples/client/etcdopstask/main.go
@@ -39,7 +39,7 @@ func main() {
 				OnDemandSnapshot: &druidv1alpha1.OnDemandSnapshotConfig{
 					Type:               druidv1alpha1.OnDemandSnapshotTypeFull,
 					IsFinal:            ptr.To(false),
-					TimeoutSecondsFull: ptr.To(int32(480)),
+					TimeoutSecondsFull: ptr.To(int32(900)),
 				},
 			},
 			EtcdName:                ptr.To("example-etcd"),

--- a/examples/etcdopstask/on-demand-snapshot.yaml
+++ b/examples/etcdopstask/on-demand-snapshot.yaml
@@ -8,7 +8,7 @@ spec:
     onDemandSnapshot:
       type: full #options: full, delta
       # isFinal: false
-      timeoutSecondsFull: 480
+      timeoutSecondsFull: 900
       # timeoutSecondsDelta: 60
   etcdName: etcd-test
   ttlSecondsAfterFinished: 3600

--- a/internal/controller/compaction/snapshot.go
+++ b/internal/controller/compaction/snapshot.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultEtcdFullSnapshotReqTimeout = 600 * time.Second
+	defaultEtcdFullSnapshotReqTimeout = 900 * time.Second
 )
 
 type httpClientInterface interface {

--- a/test/it/crdvalidation/etcdopstask/spec_test.go
+++ b/test/it/crdvalidation/etcdopstask/spec_test.go
@@ -264,7 +264,7 @@ func TestValidateEtcdOpsTaskSpecDefaults(t *testing.T) {
 			name:                        "Default values set for spec.TTLSecondsAfterFinished and spec.config.onDemandSnapshot.timeoutSeconds",
 			taskName:                    "task-defaults",
 			expectedTTL:                 3600,
-			expectedTimeoutSecondsFull:  480,
+			expectedTimeoutSecondsFull:  900,
 			expectedTimeoutSecondsDelta: 60,
 		},
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area networking
/area performance
/kind task

**What this PR does / why we need it**:

This PR increases the default connection timeout for out-of-band full snapshot requests made from druid to `backup-restore` server to 15mins due to the issues we've faced with low timeout seen on internal landscapes. Please check the referenced issue by @ishan16696 for more details.

**Which issue(s) this PR fixes**:
Fixes #1259 

**Checklist**:
- [x] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [x] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [x] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [x] Add tests that cover your changes (if applicable)
    - [x] Unit tests
    - [x] Integration tests
    - [x] E2E tests

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
