### PR TITLE
Upgrade to Go 1.25.5 in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# Build the manager binary
-FROM golang:1.25.3 AS builder
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM golang:1.25.5 AS builder
 WORKDIR /go/src/github.com/gardener/etcd-druid
 COPY . .
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades to Go `1.25.5` in Dockerfile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Fixes the vulnerability.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrade to Go 1.25.5 in Dockerfile.
```
