### PR TITLE
Fix the `release` workflow by granting sufficient permissions to the `build` job.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
   build:
     uses: ./.github/workflows/base.yaml
     permissions:
+      pull-requests: write
       contents: read
       id-token: write
       packages: write


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area open-source
/kind bug

**What this PR does / why we need it**:

This PR unblocks the upcoming release `v0.35.0`.

The release workflow https://github.com/gardener/etcd-druid/actions/runs/21655993526 fails due to a:

```
Invalid workflow file: .github/workflows/release.yaml#L13
The workflow is not valid. .github/workflows/release.yaml (Line: 13, Col: 3): Error calling workflow 'gardener/etcd-druid/.github/workflows/base.yaml@0743dc7fda1d57245a0a0e2f65a6891277418942'. The nested job 'prepare' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.
```

This was missed in #1240.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fixed the release workflow.
```
