### PR TITLE
Fixed broken links - 2026.03

### DIFF
--- a/docs/deployment/production-setup-recommendations.md
+++ b/docs/deployment/production-setup-recommendations.md
@@ -153,4 +153,4 @@ If you have a concept of `hibernating` kubernetes clusters, then following shoul
 
 ## Reference
 
-* A nicely written [blog post](https://github.com/gardener/documentation/blob/master/website/blog/2023/03-27-High-Availability-and-Zone-Outage-Toleration.md) on `High Availability and Zone Outage Toleration` has a lot of recommendations that one can borrow from.
+* A nicely written [blog post](https://github.com/gardener/documentation/blob/master/website/blog/2023/03/03-27-high-availability-and-zone-outage-toleration.md) on `High Availability and Zone Outage Toleration` has a lot of recommendations that one can borrow from.

--- a/docs/development/implementing-new-etcdopstask.md
+++ b/docs/development/implementing-new-etcdopstask.md
@@ -22,11 +22,11 @@
       - `Requeue` (bool): Indicates if the task should be requeued.
       - `Error` (error): Any error encountered during processing.
       - `Description` (string): A human-readable description of the current state or error.
-    >NOTE: 
+    >NOTE:
     > 1) The `Admit` method is run when the task is created to validate preconditions. If it fails, the task is marked as `Rejected`. If it succeeds, the task moves to `InProgress` state and this method is not called again.
     > 2) The `Execute` method is called repeatedly in case of timeouts/transient errors until the task execution is successful or a non-retryable error occurs. Once this is done the task moves to `Succeeded` or `Failed` state respectively.  
     > 3) The `Cleanup` method is called when the task reaches a terminal state (Succeeded/Failed/Rejected) to clean up any resources created during the task execution. This can be a no-op if there are no resources to clean up. (Refer the [on-demand-snapshot handler implementation](https://github.com/gardener/etcd-druid/tree/master/internal/controller/etcdopstask/handler/ondemandsnapshot/ondemandsnapshot.go) for reference).
-    > 4) Refer the etcdopstask [api](https://gitthub.com/gardener/etcd-druid/tree/master/api/core/v1alpha1/etcdopstask.go) for details regarding the etcdopstask state transitions and status fields.
+    > 4) Refer the etcdopstask [api](https://github.com/gardener/etcd-druid/tree/master/api/core/v1alpha1/etcdopstask.go) for details regarding the etcdopstask state transitions and status fields.
     - Transient error handling is to be done via setting the `requeue` field in the return type from the corresponsing methods with appropriate `Error` and `Description` field clearly indicating the reason. Common error codes are defined in [types.go](https://github.com/gardener/etcd-druid/tree/master/internal/controller/etcdopstask/handler/types.go). Introduce new error codes if necessary.
     This will then be reflected in the `LastOperation` and/or the `LastErrors` field in the `etcdopstask.status` field accordingly.
     - Once the `requeue` field is set to false, the task will move to the next phase or terminal state as applicable.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This Pr fixes broken links in the documentation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
