### PR TITLE
Integrate druidctl into CI pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       - "/"
       - "/api"
       - "/client"
+      - "/druidctl"
     schedule:
       interval: monthly
     open-pull-requests-limit: 5

--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -111,6 +111,10 @@ jobs:
           git config --global user.email "gardener@sap.com"
           git config --global user.name "Gardener CI/CD"
           make --directory=api check-generate
+      - name: druidctl-tidy
+        run: make --directory=druidctl tidy
+      - name: druidctl-check
+        run: make --directory=druidctl check
       - name: prepare helm charts
         run: make prepare-helm-charts
         env:
@@ -129,6 +133,8 @@ jobs:
         args:
           - name: api-test-unit
             run: make --directory=api test-unit
+          - name: druidctl-test-unit
+            run: make --directory=druidctl test
           - name: test-unit
             run: make test-unit
           - name: test-integration

--- a/.github/workflows/base.yaml
+++ b/.github/workflows/base.yaml
@@ -175,5 +175,7 @@ jobs:
       - prepare
     with:
       linter: gosec
-      run: make sast-report
+      run: |
+        make sast-report
+        make --directory=druidctl sast-report
       go-version: '1.25'

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,8 @@ ci-checks:
 	@$(MAKE) --directory=api tidy
 	@$(MAKE) --directory=api check
 	@$(MAKE) --directory=api check-generate
+	@$(MAKE) --directory=druidctl tidy
+	@$(MAKE) --directory=druidctl check
 	@$(MAKE) ci-prepare-helm-charts
 	@$(MAKE) check-git-status
 

--- a/druidctl/Makefile
+++ b/druidctl/Makefile
@@ -80,6 +80,11 @@ sast: $(GOSEC)
 	@echo "> Running gosec for druidctl module"
 	@$(GOSEC) -exclude-generated ./...
 
+.PHONY: sast-report
+sast-report: $(GOSEC)
+	@echo "> Running gosec report for druidctl module"
+	@$(GOSEC) -exclude-generated -track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout ./...
+
 .PHONY: clean clean-all
 clean:
 	rm -rf $(BIN_DIR) coverage.out

--- a/druidctl/cmd/listresources/listresources.go
+++ b/druidctl/cmd/listresources/listresources.go
@@ -47,12 +47,12 @@ func (l *listResourcesCmdCtx) complete() error {
 	}
 
 	// Build etcd reference list from resource args using kubectl-compatible parsing
-	l.etcdRefList = l.GlobalOptions.BuildEtcdRefList()
+	l.etcdRefList = l.BuildEtcdRefList()
 	return nil
 }
 
 func (l *listResourcesCmdCtx) validate() error {
-	return l.GlobalOptions.ValidateResourceSelection()
+	return l.ValidateResourceSelection()
 }
 
 // execute lists the managed resources for the selected etcd resources based on the filter.

--- a/druidctl/cmd/reconciliation/command.go
+++ b/druidctl/cmd/reconciliation/command.go
@@ -80,7 +80,7 @@ Use subcommands 'trigger', 'suspend', and 'resume' to control reconciliation sta
 func NewTriggerCommand(cmdCtx *cmdutils.CommandContext) *cobra.Command {
 	var waitTillReady bool
 	var watch bool
-	var timeout time.Duration = defaultTimeout
+	var timeout = defaultTimeout
 
 	cmd := &cobra.Command{
 		Use:     "trigger [resources] [flags]",

--- a/druidctl/cmd/reconciliation/reconcile.go
+++ b/druidctl/cmd/reconciliation/reconcile.go
@@ -29,12 +29,12 @@ func (r *reconcileCmdCtx) complete() error {
 		return fmt.Errorf("unable to create etcd client: %w", err)
 	}
 	r.etcdClient = etcdClient
-	r.etcdRefList = r.GlobalOptions.BuildEtcdRefList()
+	r.etcdRefList = r.BuildEtcdRefList()
 	return nil
 }
 
 func (r *reconcileCmdCtx) validate() error {
-	if err := r.GlobalOptions.ValidateResourceSelection(); err != nil {
+	if err := r.ValidateResourceSelection(); err != nil {
 		return err
 	}
 	// timeout is only valid if wait-till-ready is set
@@ -47,6 +47,7 @@ func (r *reconcileCmdCtx) validate() error {
 	}
 	return nil
 }
+
 // There are two types of reconciles, one where you add the reconcile annotation and exit.
 // Another where you wait till all the changes done to the Etcd resource have successfully reconciled and post reconciliation
 // all the etcd cluster members are Ready

--- a/druidctl/cmd/reconciliation/resumeetcdreconcile.go
+++ b/druidctl/cmd/reconciliation/resumeetcdreconcile.go
@@ -26,12 +26,12 @@ func (r *resumeReconcileCmdCtx) complete() error {
 		return fmt.Errorf("unable to create etcd client: %w", err)
 	}
 	r.etcdClient = etcdClient
-	r.etcdRefList = r.GlobalOptions.BuildEtcdRefList()
+	r.etcdRefList = r.BuildEtcdRefList()
 	return nil
 }
 
 func (r *resumeReconcileCmdCtx) validate() error {
-	return r.GlobalOptions.ValidateResourceSelection()
+	return r.ValidateResourceSelection()
 }
 
 // execute removes the suspend reconcile annotation from the Etcd resource.

--- a/druidctl/cmd/reconciliation/suspendetcdreconcile.go
+++ b/druidctl/cmd/reconciliation/suspendetcdreconcile.go
@@ -26,12 +26,12 @@ func (s *suspendReconcileCmdCtx) complete() error {
 		return fmt.Errorf("unable to create etcd client: %w", err)
 	}
 	s.etcdClient = etcdClient
-	s.etcdRefList = s.GlobalOptions.BuildEtcdRefList()
+	s.etcdRefList = s.BuildEtcdRefList()
 	return nil
 }
 
 func (s *suspendReconcileCmdCtx) validate() error {
-	return s.GlobalOptions.ValidateResourceSelection()
+	return s.ValidateResourceSelection()
 }
 
 // execute adds the suspend reconcile annotation to the Etcd resource.

--- a/druidctl/cmd/resourceprotection/etcdprotection.go
+++ b/druidctl/cmd/resourceprotection/etcdprotection.go
@@ -20,12 +20,12 @@ func (r *resourceProtectionCmdCtx) complete() error {
 		return fmt.Errorf("unable to create etcd client: %w", err)
 	}
 	r.etcdClient = etcdClient
-	r.etcdRefList = r.GlobalOptions.BuildEtcdRefList()
+	r.etcdRefList = r.BuildEtcdRefList()
 	return nil
 }
 
 func (r *resourceProtectionCmdCtx) validate() error {
-	return r.GlobalOptions.ValidateResourceSelection()
+	return r.ValidateResourceSelection()
 }
 
 // addDisableProtectionAnnotation adds the disable protection annotation to the Etcd resource. It makes the resources vulnerable

--- a/druidctl/hack/tools.mk
+++ b/druidctl/hack/tools.mk
@@ -9,7 +9,7 @@ GOIMPORTS_REVISER			:= $(TOOLS_BIN_DIR)/goimports-reviser
 GOSEC						:= $(TOOLS_BIN_DIR)/gosec
 
 # Tool versions
-GOLANGCI_LINT_VERSION ?= v1.64.8
+GOLANGCI_LINT_VERSION ?= v2.8.0
 GOIMPORTS_REVISER_VERSION ?= v3.9.1
 GOIMPORTS_VERSION ?= latest
 GOSEC_VERSION ?= v2.22.2
@@ -26,7 +26,7 @@ tools: $(GOLANGCI_LINT) $(GOIMPORTS) $(GOIMPORTS_REVISER) $(GOSEC)
 $(GOLANGCI_LINT):
 	@# CGO_ENABLED has to be set to 1 in order for golangci-lint to be able to load plugins
 	@# see https://github.com/golangci/golangci-lint/issues/1276
-	GOBIN=$(abspath $(TOOLS_BIN_DIR)) CGO_ENABLED=1 go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	GOBIN=$(abspath $(TOOLS_BIN_DIR)) CGO_ENABLED=1 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 $(GOIMPORTS):
 	@# Install goimports without mutating this module's go.mod to avoid tidy/build race.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR integrates the druidctl submodule (merged in #1212 ) into the repo's CI pipeline and dependency monitoring. As previously the druidctl's lint checks, unit tests, and Go module dependencies were not covered by CI or Dependabot.

The changes include the following:

- add `druidctl-tidy` and `druidctl-check` steps to the GHA checks job and root ci-checks Makefile target                                                                                          
- add `druidctl-test-unit` to the GHA tests job matrix                                                                                                                                           
- add `/druidctl` to Dependabot gomod directories                                                                                                                                                
- upgrade druidctl's `golangci-lint` from v1 to v2 to adapt to the changes from #1276

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**:
- [ ] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [ ] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [ ] Add tests that cover your changes (if applicable)
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Integrate druidctl submodule into CI pipeline (checks, tests, Dependabot)
```
