### PR TITLE
Upgrade github.com/gardener/etcd-backup-restore from v0.41.1 to v0.41.2

### DIFF
--- a/internal/images/images.yaml
+++ b/internal/images/images.yaml
@@ -12,7 +12,7 @@ images:
     name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-  tag: "v0.41.1"
+  tag: "v0.41.2"
 - name: etcd-backup-restore-next
   resourceId:
     name: 'etcdbrctl-next'


### PR DESCRIPTION
**Release Notes**:

# [github.com/gardener/etcd-backup-restore:v0.41.2]

## 📰 Noteworthy
- `[DEVELOPER]` Migrate e2e tests from archived LocalStack community image to licensed `localstack/localstack:stable`. Running AWS e2e tests now requires a `LOCALSTACK_AUTH_TOKEN` environment variable. by @ishan16696 [[#1022](https://github.com/gardener/etcd-backup-restore/pull/1022)]

## 🏃 Others
- `[OPERATOR]` The `copy` operation now fetches the latest 4 full snapshots when checking if a `final` full snapshot is present. by @plkokanov [[#1021](https://github.com/gardener/etcd-backup-restore/pull/1021)]

