### PR TITLE
Upgrade pr-review-timeline GitHub Action to v0.2.2

### DIFF
--- a/.github/workflows/pr-review-timeline.yaml
+++ b/.github/workflows/pr-review-timeline.yaml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: read
     steps:
       - name: PR Review Timeline
-        uses: shreyas-s-rao/pr-review-timeline@v0.2.1
+        uses: shreyas-s-rao/pr-review-timeline@v0.2.2
         id: timeline
       - name: Output Timeline JSON
         run: |


### PR DESCRIPTION
/area dev-productivity
/kind task

**What this PR does / why we need it**:
Upgrades the pr-review-timeline GitHub Action from v0.2.1 to v0.2.2, which switches the action runtime from Node.js 20 to Node.js 24. Node.js 20 actions are deprecated and will be forced to run with Node.js 24 starting June 2, 2026.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Version bump only, no functional changes.

**Release note**:
```other operator
NONE
```