### PR TITLE
Add correct resource Id to the images.yaml for the etcd-wrapper and etcd-backup restore images.

### DIFF
--- a/internal/images/images.yaml
+++ b/internal/images/images.yaml
@@ -1,9 +1,13 @@
 images:
 - name: etcd-wrapper
+  resourceId:
+    name: 'etcd-wrapper'
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
   tag: "v0.6.2"
 - name: etcd-wrapper-next
+  resourceId:
+    name: 'etcd-wrapper'
   sourceRepository: github.com/gardener/etcd-wrapper
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper
   tag: "v0.7.0"
@@ -15,7 +19,7 @@ images:
   tag: "v0.41.2"
 - name: etcd-backup-restore-next
   resourceId:
-    name: 'etcdbrctl-next'
+    name: 'etcdbrctl'
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
   tag: "v0.42.0"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area delivery
/kind task

**What this PR does / why we need it**:
This PR fixes internal/images/images.yaml to ensure correct and consistent resourceId mappings for all etcd-related
  images. Specifically:

  1. Added missing resourceId for etcd-wrapper and etcd-wrapper-next: Both entries were missing the resourceId field. Without it, the image vector resolution cannot correctly map these images to their corresponding component descriptor resources. A resourceId with name: 'etcd-wrapper' has been added to both, pointing to the gardener/etcd-wrapper
  component.
  2. Fixed incorrect resourceId for etcd-backup-restore-next: The resourceId.name was set to 'etcdbrctl-next', but the actual resource published in the component descriptor is 'etcdbrctl' (same as the stable variant). This mismatch would cause image vector overwrite to fail for the -next variant since no resource with the name etcdbrctl-next exists. It has been corrected to 'etcdbrctl', consistent with the gardener/etcd-backup-restore component.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**:
- [ ] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [ ] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [ ] Add tests that cover your changes (if applicable)
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
add resourceid to the etcd wrapper and etcd backup-restore images.
```
