### PR TITLE
Migrate LocalStack e2e tests to licensed image

### DIFF
--- a/docs/deployment/getting-started-locally/manage-s3-emulator.md
+++ b/docs/deployment/getting-started-locally/manage-s3-emulator.md
@@ -8,6 +8,13 @@ Ensure that you have setup the development environment as per the [documentation
 
 > **Note:** It is assumed that you have already created kind cluster and the `KUBECONFIG` is pointing to this Kubernetes cluster.
 
+> [!NOTE]
+> Deploying LocalStack requires a `LOCALSTACK_AUTH_TOKEN` environment variable to be set.
+> The project has a [LocalStack for Open Source](https://localstack.cloud/open-source) license. Ask a
+> maintainer for the token, or apply for your own. Alternatively, the frozen community archive image
+> `localstack/localstack:s3-community-archive` can be used without a token, but it will not receive
+> updates or security patches.
+
 ### Installing AWS CLI
 
 To interact with `LocalStack` you must also install the AWS CLI `(version >=1.29.0 or version >=2.13.0)`

--- a/docs/development/running-e2e-tests.md
+++ b/docs/development/running-e2e-tests.md
@@ -132,6 +132,13 @@ export AWS_REGION=your-aws-region
 
 #### Running tests against Localstack S3 emulator
 
+> [!NOTE]
+> Running the AWS e2e tests requires a `LOCALSTACK_AUTH_TOKEN` environment variable to be set.
+> The project has a [LocalStack for Open Source](https://localstack.cloud/open-source) license. Ask a
+> maintainer for the token, or apply for your own. Alternatively, the frozen community archive image
+> `localstack/localstack:s3-community-archive` can be used without a token, but it will not receive
+> updates or security patches.
+
 Please refer to the [Localstack S3 emulator documentation](../deployment/getting-started-locally/manage-s3-emulator.md) for detailed instructions on deploying Localstack.
 
 **Setup steps for e2e tests:**

--- a/hack/deploy-localstack.sh
+++ b/hack/deploy-localstack.sh
@@ -7,6 +7,29 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]]; then
+  printf '%s\n' "Error: LOCALSTACK_AUTH_TOKEN is not set. Get a token from https://app.localstack.cloud." >&2
+  exit 1
+fi
+
+kubectl create secret generic localstack-auth \
+  --from-literal=auth-token="${LOCALSTACK_AUTH_TOKEN}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
 kubectl apply -f ./hack/e2e-test/infrastructure/localstack/localstack.yaml
 kubectl rollout status deploy/localstack
 kubectl wait --for=condition=ready pod -l app=localstack --timeout=240s
+
+# Wait for LocalStack to be reachable from the host via the kind node port mapping.
+# The pod may be ready before the hostPort is actually forwarded.
+printf '%s' "Waiting for LocalStack to be reachable on localhost:4566"
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:4566/_localstack/health > /dev/null 2>&1; then
+    printf '\n%s\n' "LocalStack is ready."
+    exit 0
+  fi
+  printf '%s' "."
+  sleep 2
+done
+printf '\n%s\n' "Error: LocalStack did not become reachable on localhost:4566 within 120s." >&2
+exit 1

--- a/hack/e2e-test/infrastructure/localstack/localstack.yaml
+++ b/hack/e2e-test/infrastructure/localstack/localstack.yaml
@@ -24,7 +24,12 @@ spec:
               value: "1"
             - name: SERVICES
               value: s3
-          image: localstack/localstack:s3-latest
+            - name: LOCALSTACK_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: localstack-auth
+                  key: auth-token
+          image: localstack/localstack:stable
           imagePullPolicy: IfNotPresent
           name: localstack-service
           ports:


### PR DESCRIPTION
/area testing
/kind enhancement

**What this PR does / why we need it**:

LocalStack archived its open-source repository and consolidated into a single image that requires authentication. The `s3-latest` tag we currently use is a stub image that prints an error and exits.

This PR migrates the e2e tests to use `localstack/localstack:stable` with the project's LocalStack for Open Source license. Changes:

- Update image to `localstack/localstack:stable`
- Inject `LOCALSTACK_AUTH_TOKEN` via a Kubernetes Secret
- Require the token in `deploy-localstack.sh` (fail fast if missing)
- Add a localhost reachability check before returning from the deploy script
- Document the token requirement in `docs/development/running-e2e-tests.md`

Mirrors gardener/etcd-backup-restore#1014.

**Which issue(s) this PR fixes**:
Fixes #1313

**Checklist**:
- [x] Update documentation in the `/docs` folder (if applicable)

**Special notes for your reviewer**:

Running the e2e tests now requires `LOCALSTACK_AUTH_TOKEN` to be set. The project has 2 OSS licenses. The Prow job will need a separate PR to `gardener/ci-infra` to inject the token as a secret.

**Release note**:
```noteworthy developer
Migrate e2e tests from archived LocalStack community image to licensed `localstack/localstack:stable`. Running AWS e2e tests now requires a `LOCALSTACK_AUTH_TOKEN` environment variable.
```