### PR TITLE
Implement e2e test for EtcdOpsTask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ go.work.sum
 # generated pki resources for e2e tests
 test/e2e/pki-resources/*
 test/e2e/controller/pki-resources/*
+test/e2e/controller/etcdopstask/pki-resources/*
 
 # AI coding agents
 # Claude Code

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,8 @@ ci-e2e-kind: $(GINKGO) $(YQ) $(KIND)
 .PHONY: clean-e2e-test-resources
 clean-e2e-test-resources: $(KUBECTL)
 	@rm -rf $(REPO_ROOT)/test/e2e/controller/pki-resources/*
-	@kubectl get ns -o custom-columns=":metadata.name" --no-headers | grep '^etcd-e2e-' |  xargs --no-run-if-empty kubectl delete ns
+	@rm -rf $(REPO_ROOT)/test/e2e/controller/etcdopstask/pki-resources/*
+	@kubectl get ns -o custom-columns=":metadata.name" --no-headers | grep -E '^(etcd-e2e|eot-e2e)-' |  xargs --no-run-if-empty kubectl delete ns
 # Rules related to binary build, Docker image build and release
 # -------------------------------------------------------------------------
 # Build manager binary

--- a/docs/development/controllers.md
+++ b/docs/development/controllers.md
@@ -11,6 +11,7 @@ Etcd-druid currently consists of the following controllers, each having its own 
 - *etcd* : responsible for the reconciliation of the `Etcd` CR spec, which allows users to run etcd clusters within the specified Kubernetes cluster, and also responsible for periodically updating the `Etcd` CR status with the up-to-date state of the managed etcd cluster.
 - *compaction* : responsible for [snapshot compaction](../proposals/02-snapshot-compaction.md).
 - *etcdcopybackupstask* : responsible for the reconciliation of the `EtcdCopyBackupsTask` CR, which helps perform the job of copying snapshot backups from one object store to another.
+- *etcdopstask* : responsible for the reconciliation of the `EtcdOpsTask` CR, which allows operators to perform out-of-band tasks (such as on-demand snapshots) on an `Etcd` cluster without modifying its spec.
 - *secret* : responsible in making sure `Secret`s being referenced by `Etcd` resources are not deleted while in use.
 
 ## Package Structure
@@ -102,6 +103,22 @@ This controller reacts to create/update events arising from EtcdCopyBackupsTask 
 
 The number of worker threads for the *etcdcopybackupstask controller* needs to be greater than or equal to 0 (default being 3), controlled by the CLI flag `--etcd-copy-backups-task-workers`.
 This is unlike other controllers who need at least one worker thread for the proper functioning of etcd-druid as `EtcdCopyBackupsTask` is not a core functionality for the etcd clusters to be deployed.
+
+## EtcdOpsTask Controller
+
+The *etcdopstask controller* is responsible for the reconciliation of the [`EtcdOpsTask`](https://github.com/gardener/etcd-druid/blob/master/api/core/v1alpha1/etcdopstask.go) CR, which allows operators to perform out-of-band tasks on an `Etcd` cluster managed by etcd-druid. Out-of-band here means the task does not modify the `Etcd` resource spec; it operates against an existing cluster to perform an operational action such as triggering an on-demand snapshot. The controller is designed to be extensible: new task types can be added by implementing a task-specific handler. Refer to [using-etcdopstask.md](../usage/using-etcdopstask.md) for usage details and [implementing-new-etcdopstask.md](./implementing-new-etcdopstask.md) for guidance on adding new task types.
+
+The controller follows a unified reconciliation flow for all task types, with task-specific behavior isolated behind a *handler* abstraction. A *task handler registry* maps each `spec.config` union member (e.g., `OnDemandSnapshot`) to a concrete handler implementation. The reconciler selects the appropriate handler at runtime based on the task's configuration, and drives it through three phases:
+
+- **Admit**: Validates preconditions for the task (e.g., target etcd cluster readiness, no other in-progress task for the same cluster, required configuration). On success, the task transitions from `Pending` to `InProgress`; on failure, it is marked as `Rejected`. The Admit phase is invoked only once per task.
+- **Execute**: Performs the requested operation (e.g., triggering a snapshot via the backup-restore sidecar). This phase may be invoked repeatedly in case of transient errors or timeouts, controlled by the `Requeue` field returned by the handler. On a non-retryable success or failure, the task transitions to `Succeeded` or `Failed` respectively.
+- **Cleanup**: Invoked once the task reaches a terminal state (`Succeeded`, `Failed`, or `Rejected`) and its TTL (`spec.ttlSecondsAfterFinished`) has expired. Cleans up any resources created during task execution, after which the `EtcdOpsTask` resource itself is deleted. Handlers without owned resources may implement this as a no-op.
+
+The top-level task lifecycle is reflected in `status.state`, which follows the irreversible flow `Pending → InProgress → Succeeded | Failed`, with `Pending → Rejected` as a terminal branch out of admission. The controller maintains fine-grained progress within each phase in the `status.lastOperation` field, where `Type` reflects the current phase (`Admit`, `Execution`, `Cleanup`) and `State` reflects its progress (`InProgress`, `Completed`, `Failed`). A unique `RunID` is assigned per reconciliation run for traceability. Errors encountered during execution are appended to `status.lastErrors`, capped at the 10 most recent.
+
+A serialization invariant is enforced at admission: at most one `EtcdOpsTask` may be active (in `Pending` or `InProgress`) for a given target `Etcd` cluster at any time. Subsequent tasks targeting the same cluster are `Rejected` during the Admit phase. This avoids conflicting operations on the same etcd cluster.
+
+The number of worker threads for the *etcdopstask controller* must be at least 1 (default being 3), controlled by the CLI flag `--etcd-ops-task-workers`. Although user-submitted `EtcdOpsTask` resources are themselves out-of-band, the *etcd controller* relies on the *etcdopstask controller* to drive auto-triggered tasks during hibernation and etcd version upgrade flows; disabling it would silently break those flows.
 
 ## Secret Controller
 

--- a/test/e2e/controller/compaction_test.go
+++ b/test/e2e/controller/compaction_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	e2eutils "github.com/gardener/etcd-druid/test/e2e/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	"github.com/go-logr/logr/testr"
@@ -81,28 +82,28 @@ func TestSnapshotCompaction(t *testing.T) {
 			continue
 		}
 		for _, tc := range testCases {
-			tcName := fmt.Sprintf("compaction-%s-%s", tc.name, getProviderSuffix(provider))
+			tcName := fmt.Sprintf("compaction-%s-%s", tc.name, e2eutils.GetProviderSuffix(provider))
 			t.Run(tcName, func(t *testing.T) {
 				t.Parallel()
 				g := NewWithT(t)
 				var testSucceeded bool
 
 				testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
-				logger := log.WithName(tcName).WithValues("etcdName", defaultEtcdName, "namespace", testNamespace)
+				logger := log.WithName(tcName).WithValues("etcdName", e2eutils.DefaultEtcdName, "namespace", testNamespace)
 				defer func() {
-					cleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+					e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
 				}()
-				initializeTestCase(g, testEnv, logger, testNamespace, defaultEtcdName, provider)
+				e2eutils.InitializeTestCase(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, provider)
 
 				logger.Info("running tests", "purpose", tc.purpose)
-				etcd := testutils.EtcdBuilderWithoutDefaults(defaultEtcdName, testNamespace).
+				etcd := testutils.EtcdBuilderWithoutDefaults(e2eutils.DefaultEtcdName, testNamespace).
 					WithReplicas(1).
 					WithEtcdClientPort(ptr.To[int32](2379)).
 					WithClientTLS().
 					WithPeerTLS().
 					WithGRPCGatewayEnabled().
 					WithDefaultBackup().
-					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, defaultEtcdName)).
+					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, e2eutils.DefaultEtcdName)).
 					WithDeltaSnapshotPeriod(300*time.Hour).                                                                   // TODO: set to 0 (disable scheduled delta snapshots) after https://github.com/gardener/etcd-backup-restore/issues/965 is resolved
 					WithGarbageCollection(600*time.Hour, druidv1alpha1.GarbageCollectionPolicyLimitBased, ptr.To[int32](10)). // TODO: remove this line once we set delta snapshot period to 0 after https://github.com/gardener/etcd-backup-restore/issues/965 is resolved
 					WithBackupRestoreTLS().

--- a/test/e2e/controller/compaction_test.go
+++ b/test/e2e/controller/compaction_test.go
@@ -115,7 +115,7 @@ func TestSnapshotCompaction(t *testing.T) {
 
 				if tc.revisionsForFullSnapshot > 0 {
 					logger.Info("creating EtcdLoader job to put data for full snapshot")
-					testEnv.DeployEtcdLoaderJob(g, testNamespace, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), *etcd.Spec.Etcd.ClientPort, etcd.Spec.Etcd.ClientUrlTLS, tc.revisionsForFullSnapshot, timeoutSnapshotCompaction)
+					testEnv.DeployEtcdLoaderJob(g, testNamespace, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), *etcd.Spec.Etcd.ClientPort, etcd.Spec.Etcd.ClientUrlTLS, tc.revisionsForFullSnapshot, 0, timeoutSnapshotCompaction)
 					logger.Info("successfully put data for full snapshot")
 
 					logger.Info("triggering full snapshot")
@@ -127,7 +127,7 @@ func TestSnapshotCompaction(t *testing.T) {
 					g.Expect(tc.revisionsForDeltaSnapshot).To(BeNumerically(">", tc.revisionsForFullSnapshot))
 
 					logger.Info("creating EtcdLoader job to put data for delta snapshot")
-					testEnv.DeployEtcdLoaderJob(g, testNamespace, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), *etcd.Spec.Etcd.ClientPort, etcd.Spec.Etcd.ClientUrlTLS, tc.revisionsForDeltaSnapshot, timeoutSnapshotCompaction)
+					testEnv.DeployEtcdLoaderJob(g, testNamespace, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), *etcd.Spec.Etcd.ClientPort, etcd.Spec.Etcd.ClientUrlTLS, tc.revisionsForDeltaSnapshot, 0, timeoutSnapshotCompaction)
 					logger.Info("successfully put data for delta snapshot")
 
 					logger.Info("triggering delta snapshot")

--- a/test/e2e/controller/etcd_test.go
+++ b/test/e2e/controller/etcd_test.go
@@ -189,7 +189,7 @@ func TestBootstrapWithExistingCluster(t *testing.T) {
 	)
 
 	for _, provider := range providers {
-		tcName := fmt.Sprintf("bootstrap-existing-%s", getProviderSuffix(provider))
+		tcName := fmt.Sprintf("bootstrap-existing-%s", e2eutils.GetProviderSuffix(provider))
 		t.Run(tcName, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
@@ -198,9 +198,9 @@ func TestBootstrapWithExistingCluster(t *testing.T) {
 			testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
 			logger := log.WithName(tcName).WithValues("namespace", testNamespace)
 			defer func() {
-				cleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+				e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
 			}()
-			initializeTestCase(g, testEnv, logger, testNamespace, defaultEtcdName, provider)
+			e2eutils.InitializeTestCase(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, provider)
 
 			logger.Info("creating 3-member source Etcd")
 			sourceEtcd := testutils.EtcdBuilderWithoutDefaults(sourceEtcdName, testNamespace).

--- a/test/e2e/controller/etcd_test.go
+++ b/test/e2e/controller/etcd_test.go
@@ -12,7 +12,7 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/test/e2e/testenv"
-	druide2etestutils "github.com/gardener/etcd-druid/test/e2e/utils"
+	e2eutils "github.com/gardener/etcd-druid/test/e2e/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	"github.com/go-logr/logr/testr"
@@ -23,12 +23,12 @@ import (
 
 // TestMain sets up the test environment.
 func TestMain(m *testing.M) {
-	kubeconfigPath, err := testutils.GetEnvOrError(envKubeconfigPath)
+	kubeconfigPath, err := testutils.GetEnvOrError(e2eutils.EnvKubeconfigPath)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "KUBECONFIG not provided: %v\n", err)
 		os.Exit(1)
 	}
-	cl, err := druide2etestutils.GetKubernetesClient(kubeconfigPath)
+	cl, err := e2eutils.GetKubernetesClient(kubeconfigPath)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to create Kubernetes client: %v\n", err)
 		os.Exit(1)
@@ -42,19 +42,18 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	val, err := testutils.GetEnvOrError(envRetainTestArtifacts)
-	switch retainTestArtifactsMode(val) {
-	case retainTestArtifactsAll:
-		retainTestArtifacts = retainTestArtifactsAll
-	case retainTestArtifactsFailed:
-		retainTestArtifacts = retainTestArtifactsFailed
+	val, _ := testutils.GetEnvOrError(e2eutils.EnvRetainTestArtifacts)
+	switch e2eutils.RetainTestArtifactsMode(val) {
+	case e2eutils.RetainTestArtifactsAll:
+		retainTestArtifacts = e2eutils.RetainTestArtifactsAll
+	case e2eutils.RetainTestArtifactsFailed:
+		retainTestArtifacts = e2eutils.RetainTestArtifactsFailed
 	default:
-		retainTestArtifacts = retainTestArtifactsNone
+		retainTestArtifacts = e2eutils.RetainTestArtifactsNone
 	}
 
-	// default to {"none"} if no providers are specified
-	backupProviders := testutils.GetEnvOrDefault(envBackupProviders, "none,local")
-	providers, err = druide2etestutils.ParseBackupProviders(backupProviders)
+	backupProviders := testutils.GetEnvOrDefault(e2eutils.EnvBackupProviders, "none,local")
+	providers, err = e2eutils.ParseBackupProviders(backupProviders)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to parse backup providers: %v\n", err)
 		os.Exit(1)
@@ -117,24 +116,24 @@ func TestBasic(t *testing.T) {
 
 	for _, provider := range providers {
 		for _, tc := range testCases {
-			tcName := fmt.Sprintf("basic-%s-%s", tc.name, getProviderSuffix(provider))
+			tcName := fmt.Sprintf("basic-%s-%s", tc.name, e2eutils.GetProviderSuffix(provider))
 			t.Run(tcName, func(t *testing.T) {
 				t.Parallel()
 				g := NewWithT(t)
 				var testSucceeded bool // cannot use t.Failed() in deferred functions since it is evaluated at the end of the test
 
 				testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
-				logger := log.WithName(tcName).WithValues("etcdName", defaultEtcdName, "namespace", testNamespace)
+				logger := log.WithName(tcName).WithValues("etcdName", e2eutils.DefaultEtcdName, "namespace", testNamespace)
 				defer func() {
-					cleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+					e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
 				}()
-				initializeTestCase(g, testEnv, logger, testNamespace, defaultEtcdName, provider)
+				e2eutils.InitializeTestCase(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, provider)
 
 				logger.Info("running tests", "purpose", tc.purpose)
-				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(defaultEtcdName, testNamespace).
+				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(e2eutils.DefaultEtcdName, testNamespace).
 					WithReplicas(tc.replicas).
 					WithDefaultBackup().
-					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, defaultEtcdName))
+					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, e2eutils.DefaultEtcdName))
 
 				if tc.tlsEnabled {
 					etcdBuilder = etcdBuilder.WithClientTLS().
@@ -340,26 +339,26 @@ func TestScaleOut(t *testing.T) {
 
 	for _, provider := range providers {
 		for _, tc := range testCases {
-			tcName := fmt.Sprintf("scaleout-%s-%s", tc.name, getProviderSuffix(provider))
+			tcName := fmt.Sprintf("scaleout-%s-%s", tc.name, e2eutils.GetProviderSuffix(provider))
 			t.Run(tcName, func(t *testing.T) {
 				t.Parallel()
 				g := NewWithT(t)
 				var testSucceeded bool
 
 				testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
-				logger := log.WithName(tcName).WithValues("etcdName", defaultEtcdName, "namespace", testNamespace)
+				logger := log.WithName(tcName).WithValues("etcdName", e2eutils.DefaultEtcdName, "namespace", testNamespace)
 				defer func() {
-					cleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+					e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
 				}()
-				initializeTestCase(g, testEnv, logger, testNamespace, defaultEtcdName, provider)
+				e2eutils.InitializeTestCase(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, provider)
 
 				logger.Info("running tests", "purpose", tc.purpose)
-				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(defaultEtcdName, testNamespace).
+				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(e2eutils.DefaultEtcdName, testNamespace).
 					WithReplicas(1).
 					WithClientTLS().
 					WithDefaultBackup().
 					WithBackupRestoreTLS().
-					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, defaultEtcdName))
+					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, e2eutils.DefaultEtcdName))
 
 				if tc.peerTLSEnabledBeforeScaleOut {
 					etcdBuilder = etcdBuilder.WithPeerTLS()
@@ -445,24 +444,24 @@ func TestTLSAndLabelUpdates(t *testing.T) {
 
 	for _, provider := range providers {
 		for _, tc := range testCases {
-			tcName := fmt.Sprintf("update1-%s-%s", tc.name, getProviderSuffix(provider))
+			tcName := fmt.Sprintf("update1-%s-%s", tc.name, e2eutils.GetProviderSuffix(provider))
 			t.Run(tcName, func(t *testing.T) {
 				t.Parallel()
 				g := NewWithT(t)
 				var testSucceeded bool
 
 				testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
-				logger := log.WithName(tcName).WithValues("etcdName", defaultEtcdName, "namespace", testNamespace)
+				logger := log.WithName(tcName).WithValues("etcdName", e2eutils.DefaultEtcdName, "namespace", testNamespace)
 				defer func() {
-					cleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+					e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
 				}()
-				initializeTestCase(g, testEnv, logger, testNamespace, defaultEtcdName, provider)
+				e2eutils.InitializeTestCase(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, provider)
 
 				logger.Info("running tests", "purpose", tc.purpose)
-				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(defaultEtcdName, testNamespace).
+				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(e2eutils.DefaultEtcdName, testNamespace).
 					WithReplicas(3).
 					WithDefaultBackup().
-					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, defaultEtcdName))
+					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, e2eutils.DefaultEtcdName))
 
 				if tc.clientTLSEnabledBeforeUpdate {
 					etcdBuilder = etcdBuilder.WithClientTLS()
@@ -571,21 +570,21 @@ func TestRecovery(t *testing.T) {
 
 	for _, provider := range providers {
 		for _, tc := range testCases {
-			tcName := fmt.Sprintf("recovery-%s-%s", tc.name, getProviderSuffix(provider))
+			tcName := fmt.Sprintf("recovery-%s-%s", tc.name, e2eutils.GetProviderSuffix(provider))
 			t.Run(tcName, func(t *testing.T) {
 				t.Parallel()
 				g := NewWithT(t)
 				var testSucceeded bool
 
 				testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
-				logger := log.WithName(tcName).WithValues("etcdName", defaultEtcdName, "namespace", testNamespace)
+				logger := log.WithName(tcName).WithValues("etcdName", e2eutils.DefaultEtcdName, "namespace", testNamespace)
 				defer func() {
-					cleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+					e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
 				}()
-				initializeTestCase(g, testEnv, logger, testNamespace, defaultEtcdName, provider)
+				e2eutils.InitializeTestCase(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, provider)
 
 				logger.Info("running tests", "purpose", tc.purpose)
-				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(defaultEtcdName, testNamespace).
+				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(e2eutils.DefaultEtcdName, testNamespace).
 					WithReplicas(tc.replicas).
 					WithEtcdClientPort(ptr.To[int32](2379)).
 					WithClientTLS().
@@ -593,7 +592,7 @@ func TestRecovery(t *testing.T) {
 					WithGRPCGatewayEnabled().
 					WithDefaultBackup().
 					WithBackupRestoreTLS().
-					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, defaultEtcdName)).
+					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, e2eutils.DefaultEtcdName)).
 					WithComponentProtectionDisabled()
 				etcd := etcdBuilder.Build()
 
@@ -664,21 +663,21 @@ func TestClusterUpdate(t *testing.T) {
 
 	for _, provider := range providers {
 		for _, tc := range testCases {
-			tcName := fmt.Sprintf("update2-%s-%s", tc.name, getProviderSuffix(provider))
+			tcName := fmt.Sprintf("update2-%s-%s", tc.name, e2eutils.GetProviderSuffix(provider))
 			t.Run(tcName, func(t *testing.T) {
 				t.Parallel()
 				g := NewWithT(t)
 				var testSucceeded bool
 
 				testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
-				logger := log.WithName(tcName).WithValues("etcdName", defaultEtcdName, "namespace", testNamespace)
+				logger := log.WithName(tcName).WithValues("etcdName", e2eutils.DefaultEtcdName, "namespace", testNamespace)
 				defer func() {
-					cleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+					e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
 				}()
-				initializeTestCase(g, testEnv, logger, testNamespace, defaultEtcdName, provider)
+				e2eutils.InitializeTestCase(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, provider)
 
 				logger.Info("running tests", "purpose", tc.purpose)
-				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(defaultEtcdName, testNamespace).
+				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(e2eutils.DefaultEtcdName, testNamespace).
 					WithReplicas(tc.replicas).
 					WithEtcdClientPort(ptr.To[int32](2379)).
 					WithClientTLS().
@@ -686,7 +685,7 @@ func TestClusterUpdate(t *testing.T) {
 					WithGRPCGatewayEnabled().
 					WithDefaultBackup().
 					WithBackupRestoreTLS().
-					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, defaultEtcdName))
+					WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, e2eutils.DefaultEtcdName))
 				etcd := etcdBuilder.Build()
 
 				logger.Info("creating Etcd")

--- a/test/e2e/controller/etcdopstask/etcdopstask_test.go
+++ b/test/e2e/controller/etcdopstask/etcdopstask_test.go
@@ -74,7 +74,8 @@ func TestAdmit(t *testing.T) {
 			continue
 		}
 		t.Run("duplicate-rejected-same-etcd-"+e2eutils.GetProviderSuffix(provider), testAdmitDuplicateRejected(provider))
-		t.Run("independent-different-etcd-"+e2eutils.GetProviderSuffix(provider), testAdmitIndependentEtcds(provider))
+		t.Run("independent-different-namespace-"+e2eutils.GetProviderSuffix(provider), testAdmitIndependentEtcds(provider, false))
+		t.Run("independent-same-namespace-"+e2eutils.GetProviderSuffix(provider), testAdmitIndependentEtcds(provider, true))
 	}
 }
 
@@ -108,12 +109,19 @@ func testAdmitDuplicateRejected(provider druidv1alpha1.StorageProvider) func(*te
 		logger.Info("successfully created Etcd resource")
 
 		logger.Info("loading data into etcd to ensure snapshot takes measurable time")
-		testEnv.DeployEtcdLoaderJob(g, testNamespace, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), *etcd.Spec.Etcd.ClientPort, etcd.Spec.Etcd.ClientUrlTLS, 1000, timeoutDeployJob)
+		testEnv.DeployEtcdLoaderJob(g, testNamespace, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), *etcd.Spec.Etcd.ClientPort, etcd.Spec.Etcd.ClientUrlTLS, 2000, 256*1024, timeoutLargeDeployJob)
 
 		firstTask := newOnDemandSnapshotTask(e2eutils.DefaultEtcdName+"-first-task", testNamespace, e2eutils.DefaultEtcdName, druidv1alpha1.OnDemandSnapshotTypeFull)
 
 		logger.Info("creating first EtcdOpsTask")
 		testEnv.CreateEtcdOpsTask(g, firstTask)
+
+		fetchedFirstTask, err := testEnv.GetEtcdOpsTask(firstTask.Name, firstTask.Namespace)
+		g.Expect(err).NotTo(HaveOccurred())
+		if fetchedFirstTask.Status.State == nil || *fetchedFirstTask.Status.State != druidv1alpha1.TaskStateInProgress {
+			logger.Info("waiting for first task to reach InProgress before creating the duplicate")
+			testEnv.CheckEtcdOpsTaskState(g, firstTask, druidv1alpha1.TaskStateInProgress, timeoutEtcdOpsTaskCompletion)
+		}
 
 		secondTask := newOnDemandSnapshotTask(e2eutils.DefaultEtcdName+"-second-task", testNamespace, e2eutils.DefaultEtcdName, druidv1alpha1.OnDemandSnapshotTypeFull)
 
@@ -128,61 +136,66 @@ func testAdmitDuplicateRejected(provider druidv1alpha1.StorageProvider) func(*te
 		testEnv.CheckEtcdOpsTaskDeleted(g, secondTask, defaultTaskDeletionTimeout)
 		logger.Info("second task deleted after TTL")
 
+		logger.Info("waiting for first task to be deleted after TTL")
+		testEnv.CheckEtcdOpsTaskDeleted(g, firstTask, defaultTaskDeletionTimeout)
+		logger.Info("first task deleted after TTL")
+
 		testSucceeded = true
 	}
 }
 
-func testAdmitIndependentEtcds(provider druidv1alpha1.StorageProvider) func(*testing.T) {
+func testAdmitIndependentEtcds(provider druidv1alpha1.StorageProvider, sameNamespace bool) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 		g := NewWithT(t)
 		log := testr.NewWithOptions(t, testr.Options{LogTimestamp: true})
 		var testSucceeded bool
 
-		tcName := fmt.Sprintf("admit-independent-different-etcd-%s", e2eutils.GetProviderSuffix(provider))
-		ns1 := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName+"-a", 4)
-		ns2 := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName+"-b", 4)
-		logger := log.WithName(tcName)
-		defer func() {
-			e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, ns1)
-			e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, ns2)
-		}()
+		layout := "different-namespace"
+		if sameNamespace {
+			layout = "same-namespace"
+		}
+		tcName := fmt.Sprintf("admit-independent-%s-%s", layout, e2eutils.GetProviderSuffix(provider))
 
 		etcdNameA := "etcd-a"
 		etcdNameB := "etcd-b"
 
-		e2eutils.InitializeTestCase(g, testEnv, logger, ns1, etcdNameA, provider)
-		e2eutils.InitializeTestCase(g, testEnv, logger, ns2, etcdNameB, provider)
+		var nsA, nsB string
+		if sameNamespace {
+			nsA = testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
+			nsB = nsA
+		} else {
+			nsA = testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName+"-a", 4)
+			nsB = testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName+"-b", 4)
+		}
+		logger := log.WithName(tcName)
+		defer func() {
+			e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, nsA)
+			if !sameNamespace {
+				e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, nsB)
+			}
+		}()
 
-		logger.Info("creating first Etcd resource", "namespace", ns1, "etcdName", etcdNameA)
-		etcdA := testutils.EtcdBuilderWithoutDefaults(etcdNameA, ns1).
-			WithReplicas(1).
-			WithEtcdClientPort(ptr.To[int32](2379)).
-			WithClientTLS().
-			WithPeerTLS().
-			WithDefaultBackup().
-			WithStorageProvider(provider, fmt.Sprintf("%s/%s", ns1, etcdNameA)).
-			WithBackupRestoreTLS().
-			Build()
+		if sameNamespace {
+			e2eutils.CreateNamespace(g, testEnv, logger, nsA)
+			e2eutils.CreateBackupSecret(g, testEnv, logger, nsA, provider)
+		} else {
+			e2eutils.InitializeTestCase(g, testEnv, logger, nsA, etcdNameA, provider)
+			e2eutils.InitializeTestCase(g, testEnv, logger, nsB, etcdNameB, provider)
+		}
+
+		logger.Info("creating first Etcd resource", "namespace", nsA, "etcdName", etcdNameA)
+		etcdA := buildIndependentEtcd(etcdNameA, nsA, provider, sameNamespace)
 		testEnv.CreateAndCheckEtcd(g, etcdA, timeoutEtcdCreation)
 
-		logger.Info("creating second Etcd resource", "namespace", ns2, "etcdName", etcdNameB)
-		etcdB := testutils.EtcdBuilderWithoutDefaults(etcdNameB, ns2).
-			WithReplicas(1).
-			WithEtcdClientPort(ptr.To[int32](2379)).
-			WithClientTLS().
-			WithPeerTLS().
-			WithDefaultBackup().
-			WithStorageProvider(provider, fmt.Sprintf("%s/%s", ns2, etcdNameB)).
-			WithBackupRestoreTLS().
-			Build()
+		logger.Info("creating second Etcd resource", "namespace", nsB, "etcdName", etcdNameB)
+		etcdB := buildIndependentEtcd(etcdNameB, nsB, provider, sameNamespace)
 		testEnv.CreateAndCheckEtcd(g, etcdB, timeoutEtcdCreation)
 
-		taskA := newOnDemandSnapshotTask(etcdNameA+"-task", ns1, etcdNameA, druidv1alpha1.OnDemandSnapshotTypeFull)
+		taskA := newOnDemandSnapshotTask(etcdNameA+"-task", nsA, etcdNameA, druidv1alpha1.OnDemandSnapshotTypeFull)
+		taskB := newOnDemandSnapshotTask(etcdNameB+"-task", nsB, etcdNameB, druidv1alpha1.OnDemandSnapshotTypeFull)
 
-		taskB := newOnDemandSnapshotTask(etcdNameB+"-task", ns2, etcdNameB, druidv1alpha1.OnDemandSnapshotTypeFull)
-
-		logger.Info("creating both EtcdOpsTask resources concurrently")
+		logger.Info("creating both EtcdOpsTask resources to be admitted and executed concurrently")
 		testEnv.CreateEtcdOpsTask(g, taskA)
 		testEnv.CreateEtcdOpsTask(g, taskB)
 
@@ -198,4 +211,16 @@ func testAdmitIndependentEtcds(provider druidv1alpha1.StorageProvider) func(*tes
 
 		testSucceeded = true
 	}
+}
+
+func buildIndependentEtcd(name, namespace string, provider druidv1alpha1.StorageProvider, sameNamespace bool) *druidv1alpha1.Etcd {
+	builder := testutils.EtcdBuilderWithoutDefaults(name, namespace).
+		WithReplicas(1).
+		WithEtcdClientPort(ptr.To[int32](2379)).
+		WithDefaultBackup().
+		WithStorageProvider(provider, fmt.Sprintf("%s/%s", namespace, name))
+	if !sameNamespace {
+		builder = builder.WithClientTLS().WithPeerTLS().WithBackupRestoreTLS()
+	}
+	return builder.Build()
 }

--- a/test/e2e/controller/etcdopstask/etcdopstask_test.go
+++ b/test/e2e/controller/etcdopstask/etcdopstask_test.go
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package etcdopstask
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	"github.com/gardener/etcd-druid/test/e2e/testenv"
+	e2eutils "github.com/gardener/etcd-druid/test/e2e/utils"
+	testutils "github.com/gardener/etcd-druid/test/utils"
+
+	"github.com/go-logr/logr/testr"
+	"k8s.io/utils/ptr"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestMain sets up the test environment.
+func TestMain(m *testing.M) {
+	kubeconfigPath, err := testutils.GetEnvOrError(e2eutils.EnvKubeconfigPath)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "KUBECONFIG not provided: %v\n", err)
+		os.Exit(1)
+	}
+	cl, err := e2eutils.GetKubernetesClient(kubeconfigPath)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to create Kubernetes client: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancelCtx := context.WithTimeout(context.Background(), timeoutTest)
+
+	testEnv = testenv.NewTestEnvironment(ctx, cancelCtx, cl)
+	if err = testEnv.PrepareScheme(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to prepare scheme: %v\n", err)
+		os.Exit(1)
+	}
+
+	val, _ := testutils.GetEnvOrError(e2eutils.EnvRetainTestArtifacts)
+	switch e2eutils.RetainTestArtifactsMode(val) {
+	case e2eutils.RetainTestArtifactsAll:
+		retainTestArtifacts = e2eutils.RetainTestArtifactsAll
+	case e2eutils.RetainTestArtifactsFailed:
+		retainTestArtifacts = e2eutils.RetainTestArtifactsFailed
+	default:
+		retainTestArtifacts = e2eutils.RetainTestArtifactsNone
+	}
+
+	backupProviders := testutils.GetEnvOrDefault(e2eutils.EnvBackupProviders, "none,local")
+	providers, err = e2eutils.ParseBackupProviders(backupProviders)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to parse backup providers: %v\n", err)
+		os.Exit(1)
+	}
+
+	exitCode := m.Run()
+
+	testEnv.Close()
+	os.Exit(exitCode)
+}
+
+// TestAdmit validates the task-agnostic admit conditions for an EtcdOpsTask.
+func TestAdmit(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range providers {
+		if provider == "none" {
+			continue
+		}
+		t.Run("duplicate-rejected-same-etcd-"+e2eutils.GetProviderSuffix(provider), testAdmitDuplicateRejected(provider))
+		t.Run("independent-different-etcd-"+e2eutils.GetProviderSuffix(provider), testAdmitIndependentEtcds(provider))
+	}
+}
+
+func testAdmitDuplicateRejected(provider druidv1alpha1.StorageProvider) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+		log := testr.NewWithOptions(t, testr.Options{LogTimestamp: true})
+		var testSucceeded bool
+
+		tcName := fmt.Sprintf("admit-duplicate-rejected-same-etcd-%s", e2eutils.GetProviderSuffix(provider))
+		testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
+		logger := log.WithName(tcName).WithValues("etcdName", e2eutils.DefaultEtcdName, "namespace", testNamespace)
+		defer func() {
+			e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+		}()
+		e2eutils.InitializeTestCase(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, provider)
+
+		logger.Info("creating Etcd resource")
+		etcd := testutils.EtcdBuilderWithoutDefaults(e2eutils.DefaultEtcdName, testNamespace).
+			WithReplicas(1).
+			WithEtcdClientPort(ptr.To[int32](2379)).
+			WithClientTLS().
+			WithPeerTLS().
+			WithGRPCGatewayEnabled().
+			WithDefaultBackup().
+			WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, e2eutils.DefaultEtcdName)).
+			WithBackupRestoreTLS().
+			Build()
+		testEnv.CreateAndCheckEtcd(g, etcd, timeoutEtcdCreation)
+		logger.Info("successfully created Etcd resource")
+
+		logger.Info("loading data into etcd to ensure snapshot takes measurable time")
+		testEnv.DeployEtcdLoaderJob(g, testNamespace, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), *etcd.Spec.Etcd.ClientPort, etcd.Spec.Etcd.ClientUrlTLS, 1000, timeoutDeployJob)
+
+		firstTask := newOnDemandSnapshotTask(e2eutils.DefaultEtcdName+"-first-task", testNamespace, e2eutils.DefaultEtcdName, druidv1alpha1.OnDemandSnapshotTypeFull)
+
+		logger.Info("creating first EtcdOpsTask")
+		testEnv.CreateEtcdOpsTask(g, firstTask)
+
+		secondTask := newOnDemandSnapshotTask(e2eutils.DefaultEtcdName+"-second-task", testNamespace, e2eutils.DefaultEtcdName, druidv1alpha1.OnDemandSnapshotTypeFull)
+
+		logger.Info("creating second EtcdOpsTask for the same Etcd (should be rejected)")
+		testEnv.CreateEtcdOpsTask(g, secondTask)
+
+		logger.Info("waiting for second task to be rejected")
+		testEnv.CheckEtcdOpsTaskState(g, secondTask, druidv1alpha1.TaskStateRejected, timeoutEtcdOpsTaskCompletion)
+		logger.Info("second task correctly rejected")
+
+		logger.Info("waiting for second task to be deleted after TTL")
+		testEnv.CheckEtcdOpsTaskDeleted(g, secondTask, defaultTaskDeletionTimeout)
+		logger.Info("second task deleted after TTL")
+
+		testSucceeded = true
+	}
+}
+
+func testAdmitIndependentEtcds(provider druidv1alpha1.StorageProvider) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+		log := testr.NewWithOptions(t, testr.Options{LogTimestamp: true})
+		var testSucceeded bool
+
+		tcName := fmt.Sprintf("admit-independent-different-etcd-%s", e2eutils.GetProviderSuffix(provider))
+		ns1 := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName+"-a", 4)
+		ns2 := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName+"-b", 4)
+		logger := log.WithName(tcName)
+		defer func() {
+			e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, ns1)
+			e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, ns2)
+		}()
+
+		etcdNameA := "etcd-a"
+		etcdNameB := "etcd-b"
+
+		e2eutils.InitializeTestCase(g, testEnv, logger, ns1, etcdNameA, provider)
+		e2eutils.InitializeTestCase(g, testEnv, logger, ns2, etcdNameB, provider)
+
+		logger.Info("creating first Etcd resource", "namespace", ns1, "etcdName", etcdNameA)
+		etcdA := testutils.EtcdBuilderWithoutDefaults(etcdNameA, ns1).
+			WithReplicas(1).
+			WithEtcdClientPort(ptr.To[int32](2379)).
+			WithClientTLS().
+			WithPeerTLS().
+			WithDefaultBackup().
+			WithStorageProvider(provider, fmt.Sprintf("%s/%s", ns1, etcdNameA)).
+			WithBackupRestoreTLS().
+			Build()
+		testEnv.CreateAndCheckEtcd(g, etcdA, timeoutEtcdCreation)
+
+		logger.Info("creating second Etcd resource", "namespace", ns2, "etcdName", etcdNameB)
+		etcdB := testutils.EtcdBuilderWithoutDefaults(etcdNameB, ns2).
+			WithReplicas(1).
+			WithEtcdClientPort(ptr.To[int32](2379)).
+			WithClientTLS().
+			WithPeerTLS().
+			WithDefaultBackup().
+			WithStorageProvider(provider, fmt.Sprintf("%s/%s", ns2, etcdNameB)).
+			WithBackupRestoreTLS().
+			Build()
+		testEnv.CreateAndCheckEtcd(g, etcdB, timeoutEtcdCreation)
+
+		taskA := newOnDemandSnapshotTask(etcdNameA+"-task", ns1, etcdNameA, druidv1alpha1.OnDemandSnapshotTypeFull)
+
+		taskB := newOnDemandSnapshotTask(etcdNameB+"-task", ns2, etcdNameB, druidv1alpha1.OnDemandSnapshotTypeFull)
+
+		logger.Info("creating both EtcdOpsTask resources concurrently")
+		testEnv.CreateEtcdOpsTask(g, taskA)
+		testEnv.CreateEtcdOpsTask(g, taskB)
+
+		logger.Info("waiting for both tasks to succeed independently")
+		testEnv.CheckEtcdOpsTaskState(g, taskA, druidv1alpha1.TaskStateSucceeded, timeoutEtcdOpsTaskCompletion)
+		testEnv.CheckEtcdOpsTaskState(g, taskB, druidv1alpha1.TaskStateSucceeded, timeoutEtcdOpsTaskCompletion)
+		logger.Info("both tasks succeeded independently")
+
+		logger.Info("waiting for both tasks to be deleted after TTL")
+		testEnv.CheckEtcdOpsTaskDeleted(g, taskA, defaultTaskDeletionTimeout)
+		testEnv.CheckEtcdOpsTaskDeleted(g, taskB, defaultTaskDeletionTimeout)
+		logger.Info("both tasks deleted after TTL")
+
+		testSucceeded = true
+	}
+}

--- a/test/e2e/controller/etcdopstask/ondemandsnapshot_test.go
+++ b/test/e2e/controller/etcdopstask/ondemandsnapshot_test.go
@@ -10,15 +10,11 @@ import (
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
-	"github.com/gardener/etcd-druid/test/e2e/testenv"
 	e2eutils "github.com/gardener/etcd-druid/test/e2e/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	"github.com/go-logr/logr/testr"
-	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
 )
@@ -63,6 +59,7 @@ func TestOnDemandSnapshotLifecycle(t *testing.T) {
 			snapshotType:  druidv1alpha1.OnDemandSnapshotTypeFull,
 			backupEnabled: true,
 			replicas:      1,
+			loadKeys:      5000,
 			disruptEtcd:   true,
 			expectedState: druidv1alpha1.TaskStateFailed,
 		},
@@ -108,15 +105,12 @@ func TestOnDemandSnapshotLifecycle(t *testing.T) {
 	}
 
 	for _, provider := range providers {
-		for _, tc := range testCases {
-			if !tc.backupEnabled && provider != "none" {
-				continue
-			}
-			if tc.backupEnabled && provider == "none" {
-				continue
-			}
+		if provider == "none" {
+			continue
+		}
 
-			tcName := fmt.Sprintf("lifecycle-%s-%s", tc.name, e2eutils.GetProviderSuffix(provider))
+		for _, tc := range testCases {
+			tcName := fmt.Sprintf("ondemsnap-%s-%s", tc.name, e2eutils.GetProviderSuffix(provider))
 			t.Run(tcName, func(t *testing.T) {
 				t.Parallel()
 				g := NewWithT(t)
@@ -171,8 +165,14 @@ func TestOnDemandSnapshotLifecycle(t *testing.T) {
 				}
 
 				if tc.loadKeys > 0 {
-					logger.Info("loading data into etcd", "keys", tc.loadKeys)
-					testEnv.DeployEtcdLoaderJob(g, testNamespace, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), *etcd.Spec.Etcd.ClientPort, etcd.Spec.Etcd.ClientUrlTLS, tc.loadKeys, timeoutDeployJob)
+					valueSizeBytes := int64(0)
+					loadTimeout := timeoutDeployJob
+					if tc.disruptEtcd || tc.deleteMidFlight {
+						valueSizeBytes = 256 * 1024
+						loadTimeout = timeoutLargeDeployJob
+					}
+					logger.Info("loading data into etcd", "keys", tc.loadKeys, "valueSizeBytes", valueSizeBytes)
+					testEnv.DeployEtcdLoaderJob(g, testNamespace, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), *etcd.Spec.Etcd.ClientPort, etcd.Spec.Etcd.ClientUrlTLS, tc.loadKeys, valueSizeBytes, loadTimeout)
 				}
 
 				var fullRevBefore, deltaRevBefore int64
@@ -200,8 +200,10 @@ func TestOnDemandSnapshotLifecycle(t *testing.T) {
 				testEnv.CreateEtcdOpsTask(g, task)
 
 				if tc.disruptEtcd {
+					logger.Info("waiting for task to reach InProgress before disrupting etcd")
+					testEnv.CheckEtcdOpsTaskState(g, task, druidv1alpha1.TaskStateInProgress, timeoutEtcdOpsTaskCompletion)
 					logger.Info("scaling StatefulSet to 0 to disrupt etcd")
-					scaleStatefulSetToZero(g, testEnv, etcd)
+					e2eutils.ScaleStatefulSetToZero(g, testEnv, etcd)
 					logger.Info("StatefulSet scaled to 0")
 				}
 
@@ -241,28 +243,4 @@ func TestOnDemandSnapshotLifecycle(t *testing.T) {
 			})
 		}
 	}
-}
-
-func scaleStatefulSetToZero(g *WithT, testEnv *testenv.TestEnvironment, etcd *druidv1alpha1.Etcd) {
-	stsName := druidv1alpha1.GetStatefulSetName(etcd.ObjectMeta)
-	sts := &appsv1.StatefulSet{}
-	g.Expect(testEnv.Client().Get(testEnv.Context(), types.NamespacedName{
-		Name:      stsName,
-		Namespace: etcd.Namespace,
-	}, sts)).To(Succeed())
-
-	patch := client.MergeFrom(sts.DeepCopy())
-	sts.Spec.Replicas = ptr.To[int32](0)
-	g.Expect(testEnv.Client().Patch(testEnv.Context(), sts, patch)).To(Succeed())
-
-	g.Eventually(func() int32 {
-		updated := &appsv1.StatefulSet{}
-		if err := testEnv.Client().Get(testEnv.Context(), types.NamespacedName{
-			Name:      stsName,
-			Namespace: etcd.Namespace,
-		}, updated); err != nil {
-			return -1
-		}
-		return updated.Status.ReadyReplicas
-	}, 60*time.Second, 2*time.Second).Should(Equal(int32(0)))
 }

--- a/test/e2e/controller/etcdopstask/ondemandsnapshot_test.go
+++ b/test/e2e/controller/etcdopstask/ondemandsnapshot_test.go
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package etcdopstask
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	"github.com/gardener/etcd-druid/test/e2e/testenv"
+	e2eutils "github.com/gardener/etcd-druid/test/e2e/utils"
+	testutils "github.com/gardener/etcd-druid/test/utils"
+
+	"github.com/go-logr/logr/testr"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestOnDemandSnapshotLifecycle validates the complete lifecycle of OnDemandSnapshot tasks.
+func TestOnDemandSnapshotLifecycle(t *testing.T) {
+	t.Parallel()
+	log := testr.NewWithOptions(t, testr.Options{LogTimestamp: true})
+
+	testCases := []struct {
+		name            string
+		purpose         string
+		snapshotType    druidv1alpha1.OnDemandSnapshotType
+		backupEnabled   bool
+		replicas        int32
+		loadKeys        int64
+		needsFullFirst  bool
+		disruptEtcd     bool
+		deleteMidFlight bool
+		expectedState   druidv1alpha1.TaskState
+		checkLease      bool
+	}{
+		{
+			name:          "rejected-backup-not-enabled",
+			purpose:       "test Rejected state of OnDemandSnapshot when backup is not enabled",
+			snapshotType:  druidv1alpha1.OnDemandSnapshotTypeFull,
+			backupEnabled: false,
+			replicas:      1,
+			expectedState: druidv1alpha1.TaskStateRejected,
+		},
+		{
+			name:          "rejected-etcd-not-ready",
+			purpose:       "test Rejected state of OnDemandSnapshot when Etcd is not in Ready state",
+			snapshotType:  druidv1alpha1.OnDemandSnapshotTypeFull,
+			backupEnabled: true,
+			replicas:      0,
+			expectedState: druidv1alpha1.TaskStateRejected,
+		},
+		{
+			name:          "full-snapshot-fails-etcd-disrupted",
+			purpose:       "test Failed state of full OnDemandSnapshot when etcd is disrupted by scaling down StatefulSet to 0 mid-execution",
+			snapshotType:  druidv1alpha1.OnDemandSnapshotTypeFull,
+			backupEnabled: true,
+			replicas:      1,
+			disruptEtcd:   true,
+			expectedState: druidv1alpha1.TaskStateFailed,
+		},
+		{
+			name:          "full-snapshot-succeeds",
+			purpose:       "test Succeeded state of full OnDemandSnapshot on completion of full snapshot",
+			snapshotType:  druidv1alpha1.OnDemandSnapshotTypeFull,
+			backupEnabled: true,
+			replicas:      1,
+			loadKeys:      1000,
+			expectedState: druidv1alpha1.TaskStateSucceeded,
+			checkLease:    true,
+		},
+		{
+			name:           "delta-snapshot-succeeds",
+			purpose:        "test Succeeded state of delta OnDemandSnapshot on completion of delta snapshot",
+			snapshotType:   druidv1alpha1.OnDemandSnapshotTypeDelta,
+			backupEnabled:  true,
+			replicas:       1,
+			loadKeys:       1000,
+			needsFullFirst: true,
+			expectedState:  druidv1alpha1.TaskStateSucceeded,
+			checkLease:     true,
+		},
+		{
+			name:           "delta-snapshot-skipped-no-events",
+			purpose:        "test Succeeded state of delta OnDemandSnapshot when the delta snapshot is skipped by backup-restore server",
+			snapshotType:   druidv1alpha1.OnDemandSnapshotTypeDelta,
+			backupEnabled:  true,
+			replicas:       1,
+			needsFullFirst: true,
+			expectedState:  druidv1alpha1.TaskStateSucceeded,
+		},
+		{
+			name:            "mid-flight-deletion-cleans-up",
+			purpose:         "test cleanup when deletion is triggered mid-execution",
+			snapshotType:    druidv1alpha1.OnDemandSnapshotTypeFull,
+			backupEnabled:   true,
+			replicas:        1,
+			loadKeys:        5000,
+			deleteMidFlight: true,
+		},
+	}
+
+	for _, provider := range providers {
+		for _, tc := range testCases {
+			if !tc.backupEnabled && provider != "none" {
+				continue
+			}
+			if tc.backupEnabled && provider == "none" {
+				continue
+			}
+
+			tcName := fmt.Sprintf("lifecycle-%s-%s", tc.name, e2eutils.GetProviderSuffix(provider))
+			t.Run(tcName, func(t *testing.T) {
+				t.Parallel()
+				g := NewWithT(t)
+				var testSucceeded bool
+
+				testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
+				logger := log.WithName(tcName).WithValues("etcdName", e2eutils.DefaultEtcdName, "namespace", testNamespace)
+				defer func() {
+					e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+				}()
+
+				logger.Info("running tests", "purpose", tc.purpose)
+
+				if tc.backupEnabled {
+					e2eutils.InitializeTestCase(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, provider)
+				} else {
+					e2eutils.CreateNamespace(g, testEnv, logger, testNamespace)
+					etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir := e2eutils.GeneratePKIResources(g, logger, testNamespace, e2eutils.DefaultEtcdName)
+					e2eutils.CreateTLSSecrets(g, testEnv, logger, testNamespace, etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir)
+				}
+
+				etcdBuilder := testutils.EtcdBuilderWithoutDefaults(e2eutils.DefaultEtcdName, testNamespace).
+					WithReplicas(tc.replicas).
+					WithEtcdClientPort(ptr.To[int32](2379)).
+					WithClientTLS().
+					WithPeerTLS().
+					WithGRPCGatewayEnabled()
+
+				if tc.backupEnabled {
+					etcdBuilder = etcdBuilder.
+						WithDefaultBackup().
+						WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, e2eutils.DefaultEtcdName)).
+						WithBackupRestoreTLS()
+				}
+				if tc.disruptEtcd {
+					etcdBuilder = etcdBuilder.WithComponentProtectionDisabled()
+				}
+				etcd := etcdBuilder.Build()
+
+				logger.Info("creating Etcd resource")
+				if tc.backupEnabled && tc.replicas > 0 {
+					testEnv.CreateAndCheckEtcd(g, etcd, timeoutEtcdCreation)
+				} else {
+					g.Expect(testEnv.Client().Create(testEnv.Context(), etcd)).To(Succeed())
+				}
+				logger.Info("successfully created Etcd resource")
+
+				if tc.needsFullFirst {
+					logger.Info("taking initial full snapshot")
+					testEnv.TakeFullSnapshot(g, etcd, timeoutFullSnapshot)
+					logger.Info("full snapshot taken successfully")
+				}
+
+				if tc.loadKeys > 0 {
+					logger.Info("loading data into etcd", "keys", tc.loadKeys)
+					testEnv.DeployEtcdLoaderJob(g, testNamespace, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), *etcd.Spec.Etcd.ClientPort, etcd.Spec.Etcd.ClientUrlTLS, tc.loadKeys, timeoutDeployJob)
+				}
+
+				var fullRevBefore, deltaRevBefore int64
+				if tc.checkLease {
+					var err error
+					fullRevBefore, deltaRevBefore, err = testEnv.GetSnapshotRevisions(etcd.ObjectMeta)
+					g.Expect(err).NotTo(HaveOccurred())
+					logger.Info("snapshot revisions before task", "fullRev", fullRevBefore, "deltaRev", deltaRevBefore)
+				}
+
+				taskName := fmt.Sprintf("%s-%s-task", e2eutils.DefaultEtcdName, tc.name)
+				var task *druidv1alpha1.EtcdOpsTask
+				if tc.deleteMidFlight {
+					// Long TTL ensures any deletion observed within the assertion window is driven by the manual-deletion flow, not by TTL-based reconciliation.
+					task = testutils.EtcdOpsTaskBuilderWithoutDefaults(taskName, testNamespace).
+						WithEtcdName(e2eutils.DefaultEtcdName).
+						WithTTLSecondsAfterFinished(int32(3600)).
+						WithOnDemandSnapshotConfig(&druidv1alpha1.OnDemandSnapshotConfig{Type: tc.snapshotType}).
+						Build()
+				} else {
+					task = newOnDemandSnapshotTask(taskName, testNamespace, e2eutils.DefaultEtcdName, tc.snapshotType)
+				}
+
+				logger.Info("creating EtcdOpsTask", "taskName", taskName, "snapshotType", tc.snapshotType)
+				testEnv.CreateEtcdOpsTask(g, task)
+
+				if tc.disruptEtcd {
+					logger.Info("scaling StatefulSet to 0 to disrupt etcd")
+					scaleStatefulSetToZero(g, testEnv, etcd)
+					logger.Info("StatefulSet scaled to 0")
+				}
+
+				if tc.deleteMidFlight {
+					logger.Info("manually deleting EtcdOpsTask mid-execution")
+					testEnv.DeleteEtcdOpsTask(g, task)
+					logger.Info("verifying task is removed regardless of in-flight state")
+					testEnv.CheckEtcdOpsTaskDeleted(g, task, timeoutEtcdOpsTaskCompletion)
+					logger.Info("task removed via manual deletion")
+					testSucceeded = true
+					return
+				}
+
+				logger.Info("waiting for EtcdOpsTask to reach expected state", "expectedState", tc.expectedState)
+				testEnv.CheckEtcdOpsTaskState(g, task, tc.expectedState, timeoutEtcdOpsTaskCompletion)
+				logger.Info("EtcdOpsTask reached expected state")
+
+				if tc.checkLease {
+					g.Eventually(func() bool {
+						fullRevAfter, deltaRevAfter, err := testEnv.GetSnapshotRevisions(etcd.ObjectMeta)
+						if err != nil {
+							return false
+						}
+						if tc.snapshotType == druidv1alpha1.OnDemandSnapshotTypeFull {
+							return fullRevAfter > fullRevBefore
+						}
+						return deltaRevAfter > deltaRevBefore
+					}, 30*time.Second, 2*time.Second).Should(BeTrue(), "snapshot lease revision did not advance after task completion")
+					logger.Info("snapshot lease revision advanced as expected")
+				}
+
+				logger.Info("waiting for task to be deleted after TTL")
+				testEnv.CheckEtcdOpsTaskDeleted(g, task, defaultTaskDeletionTimeout)
+				logger.Info("task deleted after TTL expiry")
+
+				testSucceeded = true
+			})
+		}
+	}
+}
+
+func scaleStatefulSetToZero(g *WithT, testEnv *testenv.TestEnvironment, etcd *druidv1alpha1.Etcd) {
+	stsName := druidv1alpha1.GetStatefulSetName(etcd.ObjectMeta)
+	sts := &appsv1.StatefulSet{}
+	g.Expect(testEnv.Client().Get(testEnv.Context(), types.NamespacedName{
+		Name:      stsName,
+		Namespace: etcd.Namespace,
+	}, sts)).To(Succeed())
+
+	patch := client.MergeFrom(sts.DeepCopy())
+	sts.Spec.Replicas = ptr.To[int32](0)
+	g.Expect(testEnv.Client().Patch(testEnv.Context(), sts, patch)).To(Succeed())
+
+	g.Eventually(func() int32 {
+		updated := &appsv1.StatefulSet{}
+		if err := testEnv.Client().Get(testEnv.Context(), types.NamespacedName{
+			Name:      stsName,
+			Namespace: etcd.Namespace,
+		}, updated); err != nil {
+			return -1
+		}
+		return updated.Status.ReadyReplicas
+	}, 60*time.Second, 2*time.Second).Should(Equal(int32(0)))
+}

--- a/test/e2e/controller/etcdopstask/utils.go
+++ b/test/e2e/controller/etcdopstask/utils.go
@@ -21,9 +21,10 @@ const (
 	timeoutEtcdOpsTaskCompletion = 3 * time.Minute
 	timeoutEtcdOpsTaskTTLExpiry  = 30 * time.Second
 	timeoutDeployJob             = 2 * time.Minute
+	timeoutLargeDeployJob        = 15 * time.Minute
 	timeoutFullSnapshot          = 30 * time.Second
 
-	defaultOpsTaskTTL = int32(30)
+	defaultOpsTaskTTLSeconds = int32(30)
 )
 
 var (
@@ -32,14 +33,14 @@ var (
 	providers           []druidv1alpha1.StorageProvider
 
 	// defaultTaskDeletionTimeout is the upper bound for waiting on TTL-driven deletion of the EtcdOpsTask.
-	defaultTaskDeletionTimeout = time.Duration(defaultOpsTaskTTL)*time.Second + timeoutEtcdOpsTaskTTLExpiry
+	defaultTaskDeletionTimeout = time.Duration(defaultOpsTaskTTLSeconds)*time.Second + timeoutEtcdOpsTaskTTLExpiry
 )
 
 // newOnDemandSnapshotTask returns an EtcdOpsTask for an on-demand snapshot of the given type, with the package's default TTL and timeout values.
 func newOnDemandSnapshotTask(name, namespace, etcdName string, snapshotType druidv1alpha1.OnDemandSnapshotType) *druidv1alpha1.EtcdOpsTask {
 	return testutils.EtcdOpsTaskBuilderWithoutDefaults(name, namespace).
 		WithEtcdName(etcdName).
-		WithTTLSecondsAfterFinished(defaultOpsTaskTTL).
+		WithTTLSecondsAfterFinished(defaultOpsTaskTTLSeconds).
 		WithOnDemandSnapshotConfig(&druidv1alpha1.OnDemandSnapshotConfig{
 			Type: snapshotType,
 		}).

--- a/test/e2e/controller/etcdopstask/utils.go
+++ b/test/e2e/controller/etcdopstask/utils.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package etcdopstask
+
+import (
+	"time"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	"github.com/gardener/etcd-druid/test/e2e/testenv"
+	e2eutils "github.com/gardener/etcd-druid/test/e2e/utils"
+	testutils "github.com/gardener/etcd-druid/test/utils"
+)
+
+const (
+	testNamespacePrefix = "eot-e2e"
+
+	timeoutTest                  = 1 * time.Hour
+	timeoutEtcdCreation          = 5 * time.Minute
+	timeoutEtcdOpsTaskCompletion = 3 * time.Minute
+	timeoutEtcdOpsTaskTTLExpiry  = 30 * time.Second
+	timeoutDeployJob             = 2 * time.Minute
+	timeoutFullSnapshot          = 30 * time.Second
+
+	defaultOpsTaskTTL = int32(30)
+)
+
+var (
+	testEnv             *testenv.TestEnvironment
+	retainTestArtifacts e2eutils.RetainTestArtifactsMode
+	providers           []druidv1alpha1.StorageProvider
+
+	// defaultTaskDeletionTimeout is the upper bound for waiting on TTL-driven deletion of the EtcdOpsTask.
+	defaultTaskDeletionTimeout = time.Duration(defaultOpsTaskTTL)*time.Second + timeoutEtcdOpsTaskTTLExpiry
+)
+
+// newOnDemandSnapshotTask returns an EtcdOpsTask for an on-demand snapshot of the given type, with the package's default TTL and timeout values.
+func newOnDemandSnapshotTask(name, namespace, etcdName string, snapshotType druidv1alpha1.OnDemandSnapshotType) *druidv1alpha1.EtcdOpsTask {
+	return testutils.EtcdOpsTaskBuilderWithoutDefaults(name, namespace).
+		WithEtcdName(etcdName).
+		WithTTLSecondsAfterFinished(defaultOpsTaskTTL).
+		WithOnDemandSnapshotConfig(&druidv1alpha1.OnDemandSnapshotConfig{
+			Type: snapshotType,
+		}).
+		Build()
+}

--- a/test/e2e/controller/secret_test.go
+++ b/test/e2e/controller/secret_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	e2eutils "github.com/gardener/etcd-druid/test/e2e/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	"github.com/go-logr/logr/testr"
@@ -27,27 +28,27 @@ func TestSecretFinalizers(t *testing.T) {
 	log := testr.NewWithOptions(t, testr.Options{LogTimestamp: true})
 
 	for _, provider := range providers {
-		tcName := fmt.Sprintf("secret-%s", getProviderSuffix(provider))
+		tcName := fmt.Sprintf("secret-%s", e2eutils.GetProviderSuffix(provider))
 		t.Run(tcName, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 			var testSucceeded bool
 
 			testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
-			logger := log.WithName(tcName).WithValues("etcdName", defaultEtcdName, "namespace", testNamespace)
+			logger := log.WithName(tcName).WithValues("etcdName", e2eutils.DefaultEtcdName, "namespace", testNamespace)
 			defer func() {
-				cleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+				e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
 			}()
-			initializeTestCase(g, testEnv, logger, testNamespace, defaultEtcdName, provider)
+			e2eutils.InitializeTestCase(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, provider)
 
 			logger.Info("running tests")
-			etcdBuilder := testutils.EtcdBuilderWithoutDefaults(defaultEtcdName, testNamespace).
+			etcdBuilder := testutils.EtcdBuilderWithoutDefaults(e2eutils.DefaultEtcdName, testNamespace).
 				WithReplicas(int32(0)).
 				WithClientTLS().
 				WithPeerTLS().
 				WithDefaultBackup().
 				WithBackupRestoreTLS().
-				WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, defaultEtcdName))
+				WithStorageProvider(provider, fmt.Sprintf("%s/%s", testNamespace, e2eutils.DefaultEtcdName))
 			etcd := etcdBuilder.Build()
 
 			referencedSecrets := []string{

--- a/test/e2e/controller/utils.go
+++ b/test/e2e/controller/utils.go
@@ -6,31 +6,21 @@ package controller
 
 import (
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
-	"github.com/gardener/etcd-druid/internal/store"
 	"github.com/gardener/etcd-druid/test/e2e/testenv"
-	e2etestutils "github.com/gardener/etcd-druid/test/e2e/utils"
+	e2eutils "github.com/gardener/etcd-druid/test/e2e/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	. "github.com/onsi/gomega"
 )
 
 const (
-	// environment variables
-	envKubeconfigPath      = "KUBECONFIG"
-	envRetainTestArtifacts = "RETAIN_TEST_ARTIFACTS"
-	envBackupProviders     = "PROVIDERS"
+	testNamespacePrefix = "etcd-e2e"
 
 	// test parameters
 	timeoutTest                = 1 * time.Hour
@@ -42,98 +32,13 @@ const (
 	timeoutEtcdDisruptionStart = 30 * time.Second
 	timeoutEtcdRecovery        = 5 * time.Minute
 	timeoutDeployJob           = 2 * time.Minute
-
-	testNamespacePrefix = "etcd-e2e"
-	defaultEtcdName     = "test"
 )
 
 var (
 	testEnv             *testenv.TestEnvironment
-	retainTestArtifacts retainTestArtifactsMode
+	retainTestArtifacts e2eutils.RetainTestArtifactsMode
 	providers           = []druidv1alpha1.StorageProvider{"none"}
 )
-
-type retainTestArtifactsMode string
-
-const (
-	// retainTestArtifactsAll indicates that all test artifacts should be retained.
-	retainTestArtifactsAll retainTestArtifactsMode = "all"
-	// retainTestArtifactsFailed indicates that only artifacts from failed tests should be retained.
-	retainTestArtifactsFailed retainTestArtifactsMode = "failed"
-	// retainTestArtifactsNone indicates that no test artifacts should be retained.
-	retainTestArtifactsNone retainTestArtifactsMode = "none"
-)
-
-const (
-	pkiResourcesDir              = "pki-resources"
-	defaultBackupStoreSecretName = "etcd-backup"
-)
-
-// getProviderSuffix returns the storage provider suffix for the given storage provider,
-// to be used for generating the namespace for a test case.
-func getProviderSuffix(provider druidv1alpha1.StorageProvider) string {
-	if provider == "none" {
-		return "none"
-	}
-	p, err := store.StorageProviderFromInfraProvider(ptr.To(provider))
-	if err != nil {
-		return ""
-	}
-	return strings.ToLower(p)
-}
-
-// initializeTestCase sets up the test environment by creating a namespace, generating PKI resources,
-// and creating the necessary TLS secrets and backup secret.
-func initializeTestCase(g *WithT, testEnv *testenv.TestEnvironment, logger logr.Logger, testNamespace, etcdName string, provider druidv1alpha1.StorageProvider) {
-	createNamespace(g, testEnv, logger, testNamespace)
-	etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir := generatePKIResourcesToDefaultDirectory(g, logger, testNamespace, etcdName)
-	createTLSSecrets(g, testEnv, logger, testNamespace, etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir)
-	createBackupSecret(g, testEnv, logger, testNamespace, provider)
-}
-
-// createNamespace creates a new namespace for testing.
-func createNamespace(g *WithT, testEnv *testenv.TestEnvironment, logger logr.Logger, testNamespace string) {
-	logger.Info("creating test namespace")
-	g.Expect(testEnv.CreateTestNamespace(testNamespace)).To(Succeed())
-	logger.Info("successfully created test namespace")
-}
-
-// generatePKIResourcesToDefaultDirectory generates PKI resources for etcd and returns the directories containing the generated certificates.
-func generatePKIResourcesToDefaultDirectory(g *WithT, logger logr.Logger, testNamespace, etcdName string) (string, string, string) {
-	logger.Info("generating PKI resources")
-	certDir := fmt.Sprintf("%s/%s", pkiResourcesDir, testNamespace)
-	// certs for etcd server-client communication
-	etcdCertsDir := fmt.Sprintf("%s/etcd", certDir)
-	g.Expect(os.MkdirAll(etcdCertsDir, 0755)).To(Succeed()) // #nosec: G301 -- local directory creation for test purposes.
-	g.Expect(testutils.GeneratePKIResourcesToDirectory(logger, etcdCertsDir, etcdName, testNamespace)).To(Succeed())
-	// certs for etcd peer communication
-	etcdPeerCertsDir := fmt.Sprintf("%s/etcd-peer", certDir)
-	g.Expect(os.MkdirAll(etcdPeerCertsDir, 0755)).To(Succeed()) // #nosec: G301 -- local directory creation for test purposes.
-	g.Expect(testutils.GeneratePKIResourcesToDirectory(logger, etcdPeerCertsDir, etcdName, testNamespace)).To(Succeed())
-	// certs for etcd-backup-restore TLS
-	etcdbrCertsDir := fmt.Sprintf("%s/etcd-backup-restore", certDir)
-	g.Expect(os.MkdirAll(etcdbrCertsDir, 0755)).To(Succeed()) // #nosec: G301 -- local directory creation for test purposes.
-	g.Expect(testutils.GeneratePKIResourcesToDirectory(logger, etcdbrCertsDir, etcdName, testNamespace)).To(Succeed())
-	logger.Info("successfully generated PKI resources")
-	return etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir
-}
-
-// createTLSSecrets creates the necessary TLS secrets in the specified namespace using the provided certificate directories.
-func createTLSSecrets(g *WithT, testEnv *testenv.TestEnvironment, logger logr.Logger, testNamespace string, etcdCertsDir string, etcdPeerCertsDir string, etcdbrCertsDir string) {
-	logger.Info("creating TLS secrets")
-	// TLS secrets for etcd server-client communication
-	g.Expect(e2etestutils.CreateCASecret(testEnv.Context(), testEnv.Client(), testutils.ClientTLSCASecretName, testNamespace, etcdCertsDir)).To(Succeed())
-	g.Expect(e2etestutils.CreateServerTLSSecret(testEnv.Context(), testEnv.Client(), testutils.ClientTLSServerCertSecretName, testNamespace, etcdCertsDir)).To(Succeed())
-	g.Expect(e2etestutils.CreateClientTLSSecret(testEnv.Context(), testEnv.Client(), testutils.ClientTLSClientCertSecretName, testNamespace, etcdCertsDir)).To(Succeed())
-	// TLS secrets for etcd peer communication
-	g.Expect(e2etestutils.CreateCASecret(testEnv.Context(), testEnv.Client(), testutils.PeerTLSCASecretName, testNamespace, etcdPeerCertsDir)).To(Succeed())
-	g.Expect(e2etestutils.CreateServerTLSSecret(testEnv.Context(), testEnv.Client(), testutils.PeerTLSServerCertSecretName, testNamespace, etcdPeerCertsDir)).To(Succeed())
-	// TLS secrets for etcd-backup-restore TLS
-	g.Expect(e2etestutils.CreateCASecret(testEnv.Context(), testEnv.Client(), testutils.BackupRestoreTLSCASecretName, testNamespace, etcdbrCertsDir)).To(Succeed())
-	g.Expect(e2etestutils.CreateServerTLSSecret(testEnv.Context(), testEnv.Client(), testutils.BackupRestoreTLSServerCertSecretName, testNamespace, etcdbrCertsDir)).To(Succeed())
-	g.Expect(e2etestutils.CreateClientTLSSecret(testEnv.Context(), testEnv.Client(), testutils.BackupRestoreTLSClientCertSecretName, testNamespace, etcdbrCertsDir)).To(Succeed())
-	logger.Info("successfully created TLS secrets")
-}
 
 // getSecret retrieves a secret by name from the specified namespace.
 func getSecret(testEnv *testenv.TestEnvironment, namespace, secretName string) (*corev1.Secret, error) {
@@ -158,13 +63,6 @@ func checkSecretFinalizer(testEnv *testenv.TestEnvironment, namespace, secretNam
 	return fmt.Errorf("expected finalizer %v on secret %s in namespace %s, but was not satisfied", druidapicommon.EtcdFinalizerName, secretName, namespace)
 }
 
-// createBackupSecret creates a backup secret in the specified namespace.
-func createBackupSecret(g *WithT, testEnv *testenv.TestEnvironment, logger logr.Logger, namespace string, provider druidv1alpha1.StorageProvider) {
-	logger.Info("creating backup secret")
-	g.Expect(testutils.CreateBackupSecret(testEnv.Context(), testEnv.Client(), defaultBackupStoreSecretName, namespace, provider)).To(Succeed())
-	logger.Info("successfully created backup secret")
-}
-
 // updateEtcdTLSAndLabels updates the TLS configurations and labels of the given Etcd resource.
 func updateEtcdTLSAndLabels(etcd *druidv1alpha1.Etcd, clientTLSEnabled, peerTLSEnabled, backupRestoreTLSEnabled bool, additionalLabels map[string]string) {
 	etcd.Spec.Etcd.ClientUrlTLS = nil
@@ -183,22 +81,4 @@ func updateEtcdTLSAndLabels(etcd *druidv1alpha1.Etcd, clientTLSEnabled, peerTLSE
 	}
 
 	etcd.Spec.Labels = testutils.MergeMaps(etcd.Spec.Labels, additionalLabels)
-}
-
-// cleanupTestArtifacts deletes the test namespace if shouldCleanup is true.
-func cleanupTestArtifacts(retainTestArtifacts retainTestArtifactsMode, testSucceeded bool, testEnv *testenv.TestEnvironment, logger logr.Logger, g *WithT, ns string) {
-	switch retainTestArtifacts {
-	case retainTestArtifactsAll:
-		logger.Info("retaining test artifacts as per configuration")
-		return
-	case retainTestArtifactsFailed:
-		if !testSucceeded {
-			logger.Info("retaining test artifacts for failed test as per configuration")
-			return
-		}
-	}
-
-	logger.Info(fmt.Sprintf("deleting namespace %s", ns))
-	g.Expect(testEnv.DeleteTestNamespace(ns)).To(Succeed())
-	logger.Info("successfully deleted namespace")
 }

--- a/test/e2e/testenv/testenv.go
+++ b/test/e2e/testenv/testenv.go
@@ -637,7 +637,7 @@ func getSnapshotterJob(g *WithT, etcd *druidv1alpha1.Etcd, snapshotType string) 
 // EnsureCompaction checks if compaction has succeeded by verifying the snapshot revisions.
 func (t *TestEnvironment) EnsureCompaction(g *WithT, etcdObjectMeta metav1.ObjectMeta, expectedFullSnapshotRevision, expectedDeltaSnapshotRevision int64, timeout time.Duration) {
 	g.Eventually(func() error {
-		fullSnapshotRevision, deltaSnapshotRevision, err := t.getSnapshotRevisions(etcdObjectMeta)
+		fullSnapshotRevision, deltaSnapshotRevision, err := t.GetSnapshotRevisions(etcdObjectMeta)
 		if err != nil {
 			return err
 		}
@@ -658,7 +658,7 @@ func (t *TestEnvironment) EnsureCompaction(g *WithT, etcdObjectMeta metav1.Objec
 func (t *TestEnvironment) EnsureNoCompaction(g *WithT, etcdObjectMeta metav1.ObjectMeta, expectedFullSnapshotRevision, expectedDeltaSnapshotRevision int64, duration time.Duration) {
 	t.waitForMinimumDuration(duration)
 
-	fullSnapshotRevision, deltaSnapshotRevision, err := t.getSnapshotRevisions(etcdObjectMeta)
+	fullSnapshotRevision, deltaSnapshotRevision, err := t.GetSnapshotRevisions(etcdObjectMeta)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	g.Expect(fullSnapshotRevision).To(Equal(expectedFullSnapshotRevision))
@@ -675,8 +675,60 @@ func (t *TestEnvironment) waitForMinimumDuration(minDuration time.Duration) {
 	}
 }
 
-// getSnapshotRevisions fetches the full and delta snapshot revisions from the snapshot leases of the Etcd resource.
-func (t *TestEnvironment) getSnapshotRevisions(etcdObjectMeta metav1.ObjectMeta) (int64, int64, error) {
+// CreateEtcdOpsTask creates an EtcdOpsTask resource in the cluster.
+func (t *TestEnvironment) CreateEtcdOpsTask(g *WithT, task *druidv1alpha1.EtcdOpsTask) {
+	g.Expect(t.cl.Create(t.ctx, task)).To(Succeed())
+}
+
+// DeleteEtcdOpsTask deletes the given EtcdOpsTask resource.
+func (t *TestEnvironment) DeleteEtcdOpsTask(g *WithT, task *druidv1alpha1.EtcdOpsTask) {
+	g.Expect(t.cl.Delete(t.ctx, task)).To(Succeed())
+}
+
+// GetEtcdOpsTask returns the EtcdOpsTask object with the given name and namespace.
+func (t *TestEnvironment) GetEtcdOpsTask(name, namespace string) (*druidv1alpha1.EtcdOpsTask, error) {
+	task := &druidv1alpha1.EtcdOpsTask{}
+	err := t.cl.Get(t.ctx, types.NamespacedName{Name: name, Namespace: namespace}, task)
+	if err != nil {
+		return nil, err
+	}
+	return task, nil
+}
+
+// CheckEtcdOpsTaskState polls until the EtcdOpsTask reaches the expected state or times out.
+func (t *TestEnvironment) CheckEtcdOpsTaskState(g *WithT, task *druidv1alpha1.EtcdOpsTask, expectedState druidv1alpha1.TaskState, timeout time.Duration) {
+	g.Eventually(func() error {
+		current := &druidv1alpha1.EtcdOpsTask{}
+		if err := t.cl.Get(t.ctx, client.ObjectKeyFromObject(task), current); err != nil {
+			return fmt.Errorf("failed to get EtcdOpsTask %s: %w", task.Name, err)
+		}
+		if current.Status.State == nil {
+			return fmt.Errorf("EtcdOpsTask %s state is nil", task.Name)
+		}
+		if *current.Status.State != expectedState {
+			return fmt.Errorf("EtcdOpsTask %s state is %s, expected %s", task.Name, *current.Status.State, expectedState)
+		}
+		return nil
+	}, timeout, defaultPollingInterval).Should(Succeed())
+}
+
+// CheckEtcdOpsTaskDeleted polls until the EtcdOpsTask resource no longer exists.
+func (t *TestEnvironment) CheckEtcdOpsTaskDeleted(g *WithT, task *druidv1alpha1.EtcdOpsTask, timeout time.Duration) {
+	g.Eventually(func() error {
+		current := &druidv1alpha1.EtcdOpsTask{}
+		err := t.cl.Get(t.ctx, client.ObjectKeyFromObject(task), current)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get EtcdOpsTask %s: %w", task.Name, err)
+		}
+		return fmt.Errorf("EtcdOpsTask %s still exists", task.Name)
+	}, timeout, defaultPollingInterval).Should(Succeed())
+}
+
+// GetSnapshotRevisions fetches the full and delta snapshot revisions from the snapshot leases of the Etcd resource.
+func (t *TestEnvironment) GetSnapshotRevisions(etcdObjectMeta metav1.ObjectMeta) (int64, int64, error) {
 	fullSnapshotLease := &coordinationv1.Lease{}
 	deltaSnapshotLease := &coordinationv1.Lease{}
 

--- a/test/e2e/testenv/testenv.go
+++ b/test/e2e/testenv/testenv.go
@@ -464,8 +464,8 @@ func getProbe(filePath string) *corev1.Probe {
 }
 
 // DeployEtcdLoaderJob deploys the etcd loader job which loads keys into etcd.
-func (t *TestEnvironment) DeployEtcdLoaderJob(g *WithT, namespace, etcdClientServiceName string, etcdClientServicePort int32, etcdClientTLS *druidv1alpha1.TLSConfig, numKeys int64, timeout time.Duration) {
-	etcdLoaderJob, err := getEtcdLoaderJob(g, namespace, etcdClientServiceName, etcdClientServicePort, etcdClientTLS, numKeys)
+func (t *TestEnvironment) DeployEtcdLoaderJob(g *WithT, namespace, etcdClientServiceName string, etcdClientServicePort int32, etcdClientTLS *druidv1alpha1.TLSConfig, numKeys, valueSizeBytes int64, timeout time.Duration) {
+	etcdLoaderJob, err := getEtcdLoaderJob(g, namespace, etcdClientServiceName, etcdClientServicePort, etcdClientTLS, numKeys, valueSizeBytes)
 	g.Expect(err).ShouldNot(HaveOccurred())
 	g.Expect(t.cl.Create(t.ctx, etcdLoaderJob)).To(Succeed())
 
@@ -489,7 +489,7 @@ func (t *TestEnvironment) DeployEtcdLoaderJob(g *WithT, namespace, etcdClientSer
 }
 
 // getEtcdLoaderJob returns the job object for loading keys into etcd.
-func getEtcdLoaderJob(g *WithT, namespace, etcdClientServiceName string, etcdClientServicePort int32, etcdClientTLS *druidv1alpha1.TLSConfig, numKeys int64) (*batchv1.Job, error) {
+func getEtcdLoaderJob(g *WithT, namespace, etcdClientServiceName string, etcdClientServicePort int32, etcdClientTLS *druidv1alpha1.TLSConfig, numKeys, valueSizeBytes int64) (*batchv1.Job, error) {
 	if numKeys <= 0 {
 		return nil, fmt.Errorf("number of keys must be greater than zero")
 	}
@@ -508,7 +508,7 @@ func getEtcdLoaderJob(g *WithT, namespace, etcdClientServiceName string, etcdCli
 							Image:           "alpine/curl",
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"/bin/sh", "-c"},
-							Args:            []string{getEtcdLoaderScript(numKeys, etcdClientServiceName, etcdClientServicePort)},
+							Args:            []string{getEtcdLoaderScript(numKeys, valueSizeBytes, etcdClientServiceName, etcdClientServicePort)},
 							VolumeMounts: []corev1.VolumeMount{
 								{MountPath: common.VolumeMountPathEtcdCA, Name: testutils.ClientTLSCASecretName},
 								{MountPath: common.VolumeMountPathEtcdClientTLS, Name: testutils.ClientTLSClientCertSecretName},
@@ -528,20 +528,28 @@ func getEtcdLoaderJob(g *WithT, namespace, etcdClientServiceName string, etcdCli
 }
 
 // getEtcdLoaderScript generates the shell script used by the etcd loader job to populate etcd with keys.
-func getEtcdLoaderScript(numKeys int64, etcdClientServiceName string, etcdClientServicePort int32) string {
+func getEtcdLoaderScript(numKeys, valueSizeBytes int64, etcdClientServiceName string, etcdClientServicePort int32) string {
+	preLoop, inLoopValue := "", `value=$(echo -n "value-$i" | base64)`
+	if valueSizeBytes > 0 {
+		preLoop = fmt.Sprintf(`value=$(head -c %d /dev/zero | tr '\0' 'x' | base64 | tr -d '\n')`, valueSizeBytes)
+		inLoopValue = ""
+	}
+
 	return fmt.Sprintf(`
+	%s
 	for i in $(seq 1 %d); do
 		key=$(echo -n "key-$i" | base64)
-		value=$(echo -n "value-$i" | base64)
+		%s
+		printf '{"key": "%%s", "value": "%%s"}' "$key" "$value" > /tmp/payload.json
 		curl -s -X POST \
 		-H "Content-Type: application/json" \
 		--cacert %s/ca.crt \
 		--cert %s/tls.crt \
 		--key %s/tls.key \
-		-d "{\"key\": \"$key\", \"value\": \"$value\"}" \
+		-d @/tmp/payload.json \
 		-L https://%s:%d/v3/kv/put;
 	done
-	`, numKeys, common.VolumeMountPathEtcdCA, common.VolumeMountPathEtcdClientTLS, common.VolumeMountPathEtcdClientTLS, etcdClientServiceName, etcdClientServicePort)
+	`, preLoop, numKeys, inLoopValue, common.VolumeMountPathEtcdCA, common.VolumeMountPathEtcdClientTLS, common.VolumeMountPathEtcdClientTLS, etcdClientServiceName, etcdClientServicePort)
 }
 
 // getTLSVolume creates a volume for the TLS secret.

--- a/test/e2e/utils/setup.go
+++ b/test/e2e/utils/setup.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	"github.com/gardener/etcd-druid/internal/store"
+	"github.com/gardener/etcd-druid/test/e2e/testenv"
+	testutils "github.com/gardener/etcd-druid/test/utils"
+
+	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	PKIResourcesDir              = "pki-resources"
+	DefaultBackupStoreSecretName = "etcd-backup"
+	DefaultEtcdName              = "test"
+
+	// Environment variables read by e2e TestMain entry points.
+	EnvKubeconfigPath      = "KUBECONFIG"
+	EnvRetainTestArtifacts = "RETAIN_TEST_ARTIFACTS"
+	EnvBackupProviders     = "PROVIDERS"
+)
+
+// RetainTestArtifactsMode controls whether test artifacts are retained after test execution.
+type RetainTestArtifactsMode string
+
+const (
+	RetainTestArtifactsAll    RetainTestArtifactsMode = "all"
+	RetainTestArtifactsFailed RetainTestArtifactsMode = "failed"
+	RetainTestArtifactsNone   RetainTestArtifactsMode = "none"
+)
+
+// GetProviderSuffix returns the storage provider suffix for the given storage provider.
+func GetProviderSuffix(provider druidv1alpha1.StorageProvider) string {
+	if provider == "none" {
+		return "none"
+	}
+	p, err := store.StorageProviderFromInfraProvider(ptr.To(provider))
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(p)
+}
+
+// InitializeTestCase sets up the test environment by creating a namespace, generating PKI resources,
+// and creating the necessary TLS secrets and backup secret.
+func InitializeTestCase(g *WithT, testEnv *testenv.TestEnvironment, logger logr.Logger, testNamespace, etcdName string, provider druidv1alpha1.StorageProvider) {
+	CreateNamespace(g, testEnv, logger, testNamespace)
+	etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir := GeneratePKIResources(g, logger, testNamespace, etcdName)
+	CreateTLSSecrets(g, testEnv, logger, testNamespace, etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir)
+	CreateBackupSecret(g, testEnv, logger, testNamespace, provider)
+}
+
+// CreateNamespace creates a new namespace for testing.
+func CreateNamespace(g *WithT, testEnv *testenv.TestEnvironment, logger logr.Logger, testNamespace string) {
+	logger.Info("creating test namespace")
+	g.Expect(testEnv.CreateTestNamespace(testNamespace)).To(Succeed())
+	logger.Info("successfully created test namespace")
+}
+
+// GeneratePKIResources generates PKI resources for etcd and returns the directories containing the generated certificates.
+func GeneratePKIResources(g *WithT, logger logr.Logger, testNamespace, etcdName string) (string, string, string) {
+	logger.Info("generating PKI resources")
+	certDir := fmt.Sprintf("%s/%s", PKIResourcesDir, testNamespace)
+	etcdCertsDir := fmt.Sprintf("%s/etcd", certDir)
+	g.Expect(os.MkdirAll(etcdCertsDir, 0755)).To(Succeed()) // #nosec: G301
+	g.Expect(testutils.GeneratePKIResourcesToDirectory(logger, etcdCertsDir, etcdName, testNamespace)).To(Succeed())
+	etcdPeerCertsDir := fmt.Sprintf("%s/etcd-peer", certDir)
+	g.Expect(os.MkdirAll(etcdPeerCertsDir, 0755)).To(Succeed()) // #nosec: G301
+	g.Expect(testutils.GeneratePKIResourcesToDirectory(logger, etcdPeerCertsDir, etcdName, testNamespace)).To(Succeed())
+	etcdbrCertsDir := fmt.Sprintf("%s/etcd-backup-restore", certDir)
+	g.Expect(os.MkdirAll(etcdbrCertsDir, 0755)).To(Succeed()) // #nosec: G301
+	g.Expect(testutils.GeneratePKIResourcesToDirectory(logger, etcdbrCertsDir, etcdName, testNamespace)).To(Succeed())
+	logger.Info("successfully generated PKI resources")
+	return etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir
+}
+
+// CreateTLSSecrets creates the necessary TLS secrets in the specified namespace using the provided certificate directories.
+func CreateTLSSecrets(g *WithT, testEnv *testenv.TestEnvironment, logger logr.Logger, testNamespace, etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir string) {
+	logger.Info("creating TLS secrets")
+	g.Expect(CreateCASecret(testEnv.Context(), testEnv.Client(), testutils.ClientTLSCASecretName, testNamespace, etcdCertsDir)).To(Succeed())
+	g.Expect(CreateServerTLSSecret(testEnv.Context(), testEnv.Client(), testutils.ClientTLSServerCertSecretName, testNamespace, etcdCertsDir)).To(Succeed())
+	g.Expect(CreateClientTLSSecret(testEnv.Context(), testEnv.Client(), testutils.ClientTLSClientCertSecretName, testNamespace, etcdCertsDir)).To(Succeed())
+	g.Expect(CreateCASecret(testEnv.Context(), testEnv.Client(), testutils.PeerTLSCASecretName, testNamespace, etcdPeerCertsDir)).To(Succeed())
+	g.Expect(CreateServerTLSSecret(testEnv.Context(), testEnv.Client(), testutils.PeerTLSServerCertSecretName, testNamespace, etcdPeerCertsDir)).To(Succeed())
+	g.Expect(CreateCASecret(testEnv.Context(), testEnv.Client(), testutils.BackupRestoreTLSCASecretName, testNamespace, etcdbrCertsDir)).To(Succeed())
+	g.Expect(CreateServerTLSSecret(testEnv.Context(), testEnv.Client(), testutils.BackupRestoreTLSServerCertSecretName, testNamespace, etcdbrCertsDir)).To(Succeed())
+	g.Expect(CreateClientTLSSecret(testEnv.Context(), testEnv.Client(), testutils.BackupRestoreTLSClientCertSecretName, testNamespace, etcdbrCertsDir)).To(Succeed())
+	logger.Info("successfully created TLS secrets")
+}
+
+// CreateBackupSecret creates a backup secret in the specified namespace.
+func CreateBackupSecret(g *WithT, testEnv *testenv.TestEnvironment, logger logr.Logger, namespace string, provider druidv1alpha1.StorageProvider) {
+	logger.Info("creating backup secret")
+	g.Expect(testutils.CreateBackupSecret(testEnv.Context(), testEnv.Client(), DefaultBackupStoreSecretName, namespace, provider)).To(Succeed())
+	logger.Info("successfully created backup secret")
+}
+
+// CleanupTestArtifacts deletes the test namespace based on the retention mode and test result.
+func CleanupTestArtifacts(retainTestArtifacts RetainTestArtifactsMode, testSucceeded bool, testEnv *testenv.TestEnvironment, logger logr.Logger, g *WithT, ns string) {
+	switch retainTestArtifacts {
+	case RetainTestArtifactsAll:
+		logger.Info("retaining test artifacts as per configuration")
+		return
+	case RetainTestArtifactsFailed:
+		if !testSucceeded {
+			logger.Info("retaining test artifacts for failed test as per configuration")
+			return
+		}
+	}
+	logger.Info(fmt.Sprintf("deleting namespace %s", ns))
+	g.Expect(testEnv.DeleteTestNamespace(ns)).To(Succeed())
+	logger.Info("successfully deleted namespace")
+}

--- a/test/e2e/utils/setup.go
+++ b/test/e2e/utils/setup.go
@@ -73,13 +73,13 @@ func GeneratePKIResources(g *WithT, logger logr.Logger, testNamespace, etcdName 
 	logger.Info("generating PKI resources")
 	certDir := fmt.Sprintf("%s/%s", PKIResourcesDir, testNamespace)
 	etcdCertsDir := fmt.Sprintf("%s/etcd", certDir)
-	g.Expect(os.MkdirAll(etcdCertsDir, 0755)).To(Succeed()) // #nosec: G301
+	g.Expect(os.MkdirAll(etcdCertsDir, 0755)).To(Succeed()) // #nosec: G301 -- local directory creation for test purposes.
 	g.Expect(testutils.GeneratePKIResourcesToDirectory(logger, etcdCertsDir, etcdName, testNamespace)).To(Succeed())
 	etcdPeerCertsDir := fmt.Sprintf("%s/etcd-peer", certDir)
-	g.Expect(os.MkdirAll(etcdPeerCertsDir, 0755)).To(Succeed()) // #nosec: G301
+	g.Expect(os.MkdirAll(etcdPeerCertsDir, 0755)).To(Succeed()) // #nosec: G301 -- local directory creation for test purposes.
 	g.Expect(testutils.GeneratePKIResourcesToDirectory(logger, etcdPeerCertsDir, etcdName, testNamespace)).To(Succeed())
 	etcdbrCertsDir := fmt.Sprintf("%s/etcd-backup-restore", certDir)
-	g.Expect(os.MkdirAll(etcdbrCertsDir, 0755)).To(Succeed()) // #nosec: G301
+	g.Expect(os.MkdirAll(etcdbrCertsDir, 0755)).To(Succeed()) // #nosec: G301 -- local directory creation for test purposes.
 	g.Expect(testutils.GeneratePKIResourcesToDirectory(logger, etcdbrCertsDir, etcdName, testNamespace)).To(Succeed())
 	logger.Info("successfully generated PKI resources")
 	return etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -9,14 +9,20 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/store"
+	"github.com/gardener/etcd-druid/test/e2e/testenv"
 
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/gomega"
 )
 
 var knownBackupProviders = []druidv1alpha1.StorageProvider{
@@ -70,4 +76,29 @@ func ParseBackupProviders(providers string) ([]druidv1alpha1.StorageProvider, er
 	}
 
 	return providerList, nil
+}
+
+// ScaleStatefulSetToZero scales the Etcd's StatefulSet down to zero replicas and waits until no replicas are ready.
+func ScaleStatefulSetToZero(g *WithT, testEnv *testenv.TestEnvironment, etcd *druidv1alpha1.Etcd) {
+	stsName := druidv1alpha1.GetStatefulSetName(etcd.ObjectMeta)
+	sts := &appsv1.StatefulSet{}
+	g.Expect(testEnv.Client().Get(testEnv.Context(), types.NamespacedName{
+		Name:      stsName,
+		Namespace: etcd.Namespace,
+	}, sts)).To(Succeed())
+
+	patch := client.MergeFrom(sts.DeepCopy())
+	sts.Spec.Replicas = ptr.To[int32](0)
+	g.Expect(testEnv.Client().Patch(testEnv.Context(), sts, patch)).To(Succeed())
+
+	g.Eventually(func() int32 {
+		updated := &appsv1.StatefulSet{}
+		if err := testEnv.Client().Get(testEnv.Context(), types.NamespacedName{
+			Name:      stsName,
+			Namespace: etcd.Namespace,
+		}, updated); err != nil {
+			return -1
+		}
+		return updated.Status.ReadyReplicas
+	}, 60*time.Second, 2*time.Second).Should(Equal(int32(0)))
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Implements e2e tests for `EtcdOpsTask`, specifically the `OnDemand Snapshot` task introduced in #1129 with the new test framework introduced in #1060 
The tests introduced in this PR are specifically for on-demand snapshot task types and more tests will have to be introduced as and when new `EtcdOpsTasks` are implemented.

**Which issue(s) this PR fixes**:
Fixes #1201 #1200 

**Checklist**:
- [ ] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [ ] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [ ] Add tests that cover your changes (if applicable)
    - [ ] Unit tests
    - [ ] Integration tests
    - [ x ] E2E tests

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
implement e2e tests for `EtcdOpsTask`
```
