### PR TITLE
Take full snapshot before any container image or replica change

### DIFF
--- a/api/core/v1alpha1/constants.go
+++ b/api/core/v1alpha1/constants.go
@@ -39,12 +39,11 @@ const (
 	// This value will only be effective if etcd-druid is not configured with auto-reconciliation of Etcd resource specification via
 	// --enable-etcd-spec-auto-reconcile CLI flag.
 	DruidOperationReconcile = "reconcile"
-	// SkipNextUpdateSnapshotAnnotation, when present on an Etcd resource, instructs etcd-druid to skip the pre-sync
-	// full snapshot for the immediately pending StatefulSet update triggered by a container image or replica change.
-	// It's a one-shot annotation: etcd-druid removes it as soon as the skip is applied, so it only affects the next
-	// immediate pending update. Its presence alone is sufficient; the annotation value is ignored. It does not affect the
-	// snapshot taken before hibernation.
-	SkipNextUpdateSnapshotAnnotation = "druid.gardener.cloud/skip-next-update-snapshot"
+	// SkipSpecUpdateSnapshotAnnotation is an annotation when present on an Etcd resource, instructs the etcd-druid to skip the pre-sync full
+	// snapshot which would otherwise be taken before the etcd StatefulSet is rolled due to a container image or replica change.
+	// Its presence alone is sufficient; the annotation value is ignored. While the annotation is present the snapshot is always skipped, and etcd-druid does not remove the annotation.
+	// It does not affect the full snapshot taken before hibernation.
+	SkipSpecUpdateSnapshotAnnotation = "druid.gardener.cloud/skip-spec-update-snapshot"
 )
 
 // Compaction Job/Pod reasons that are used to set the reason for a pod condition in the status of an Etcd resource.

--- a/api/core/v1alpha1/constants.go
+++ b/api/core/v1alpha1/constants.go
@@ -39,6 +39,12 @@ const (
 	// This value will only be effective if etcd-druid is not configured with auto-reconciliation of Etcd resource specification via
 	// --enable-etcd-spec-auto-reconcile CLI flag.
 	DruidOperationReconcile = "reconcile"
+	// SkipNextUpdateSnapshotAnnotation, when present on an Etcd resource, instructs etcd-druid to skip the pre-sync
+	// full snapshot for the immediately pending StatefulSet update triggered by a container image or replica change.
+	// It's a one-shot annotation: etcd-druid removes it as soon as the skip is applied, so it only affects the next
+	// immediate pending update. Its presence alone is sufficient; the annotation value is ignored. It does not affect the
+	// snapshot taken before hibernation.
+	SkipNextUpdateSnapshotAnnotation = "druid.gardener.cloud/skip-next-update-snapshot"
 )
 
 // Compaction Job/Pod reasons that are used to set the reason for a pod condition in the status of an Etcd resource.

--- a/api/core/v1alpha1/helper.go
+++ b/api/core/v1alpha1/helper.go
@@ -160,11 +160,9 @@ func AreManagedResourcesProtected(etcdObjMeta metav1.ObjectMeta) bool {
 	return !metav1.HasAnnotation(etcdObjMeta, DisableEtcdComponentProtectionAnnotation)
 }
 
-// HasSkipNextUpdateSnapshotAnnotation returns true if the Etcd resource has the
-// `druid.gardener.cloud/skip-next-update-snapshot` annotation set, indicating that the pre-sync full snapshot for the
-// next pending StatefulSet update should be skipped.
-func HasSkipNextUpdateSnapshotAnnotation(etcdObjMeta metav1.ObjectMeta) bool {
-	return metav1.HasAnnotation(etcdObjMeta, SkipNextUpdateSnapshotAnnotation)
+// HasSkipSpecUpdateSnapshotAnnotation returns true if the Etcd resource has the `druid.gardener.cloud/skip-spec-update-snapshot` annotation set
+func HasSkipSpecUpdateSnapshotAnnotation(etcdObjMeta metav1.ObjectMeta) bool {
+	return metav1.HasAnnotation(etcdObjMeta, SkipSpecUpdateSnapshotAnnotation)
 }
 
 // GetDefaultLabels returns the default labels for etcd.

--- a/api/core/v1alpha1/helper.go
+++ b/api/core/v1alpha1/helper.go
@@ -160,6 +160,13 @@ func AreManagedResourcesProtected(etcdObjMeta metav1.ObjectMeta) bool {
 	return !metav1.HasAnnotation(etcdObjMeta, DisableEtcdComponentProtectionAnnotation)
 }
 
+// HasSkipNextUpdateSnapshotAnnotation returns true if the Etcd resource has the
+// `druid.gardener.cloud/skip-next-update-snapshot` annotation set, indicating that the pre-sync full snapshot for the
+// next pending StatefulSet update should be skipped.
+func HasSkipNextUpdateSnapshotAnnotation(etcdObjMeta metav1.ObjectMeta) bool {
+	return metav1.HasAnnotation(etcdObjMeta, SkipNextUpdateSnapshotAnnotation)
+}
+
 // GetDefaultLabels returns the default labels for etcd.
 func GetDefaultLabels(etcdObjMeta metav1.ObjectMeta) map[string]string {
 	return map[string]string{

--- a/api/core/v1alpha1/helper_test.go
+++ b/api/core/v1alpha1/helper_test.go
@@ -273,7 +273,7 @@ func TestAreManagedResourcesProtected(t *testing.T) {
 	}
 }
 
-func TestHasSkipNextUpdateSnapshotAnnotation(t *testing.T) {
+func TestHasSkipSpecUpdateSnapshotAnnotation(t *testing.T) {
 	tests := []struct {
 		name        string
 		annotations map[string]string
@@ -285,13 +285,13 @@ func TestHasSkipNextUpdateSnapshotAnnotation(t *testing.T) {
 			expected:    false,
 		},
 		{
-			name:        "SkipNextUpdateSnapshotAnnotation is set with empty value",
-			annotations: map[string]string{SkipNextUpdateSnapshotAnnotation: ""},
+			name:        "annotation set with empty value",
+			annotations: map[string]string{SkipSpecUpdateSnapshotAnnotation: ""},
 			expected:    true,
 		},
 		{
-			name:        "SkipNextUpdateSnapshotAnnotation is set with a value",
-			annotations: map[string]string{SkipNextUpdateSnapshotAnnotation: "true"},
+			name:        "annotation set with a value (value is ignored)",
+			annotations: map[string]string{SkipSpecUpdateSnapshotAnnotation: "true"},
 			expected:    true,
 		},
 	}
@@ -301,7 +301,7 @@ func TestHasSkipNextUpdateSnapshotAnnotation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), test.annotations, nil, false)
-			g.Expect(HasSkipNextUpdateSnapshotAnnotation(etcdObjMeta)).To(Equal(test.expected))
+			g.Expect(HasSkipSpecUpdateSnapshotAnnotation(etcdObjMeta)).To(Equal(test.expected))
 		})
 	}
 }

--- a/api/core/v1alpha1/helper_test.go
+++ b/api/core/v1alpha1/helper_test.go
@@ -273,6 +273,39 @@ func TestAreManagedResourcesProtected(t *testing.T) {
 	}
 }
 
+func TestHasSkipNextUpdateSnapshotAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "no annotation is set",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name:        "SkipNextUpdateSnapshotAnnotation is set with empty value",
+			annotations: map[string]string{SkipNextUpdateSnapshotAnnotation: ""},
+			expected:    true,
+		},
+		{
+			name:        "SkipNextUpdateSnapshotAnnotation is set with a value",
+			annotations: map[string]string{SkipNextUpdateSnapshotAnnotation: "true"},
+			expected:    true,
+		},
+	}
+	g := NewWithT(t)
+	t.Parallel()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), test.annotations, nil, false)
+			g.Expect(HasSkipNextUpdateSnapshotAnnotation(etcdObjMeta)).To(Equal(test.expected))
+		})
+	}
+}
+
 func TestGetDefaultLabels(t *testing.T) {
 	g := NewWithT(t)
 	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)

--- a/docs/usage/managing-etcd-clusters.md
+++ b/docs/usage/managing-etcd-clusters.md
@@ -13,6 +13,7 @@ In order to track the progress of creation of etcd cluster resources you can do 
 * `status.lastOperation` can be monitored to check the status of reconciliation.
 
 * Additional printer columns have been defined for `Etcd` custom resource. You can execute the following command to know if an `Etcd` cluster is ready/quorate.
+
 ```bash
 kubectl get etcd <etcd-name> -n <namespace> -owide
   # you will see additional columns which will indicate the state of an etcd cluster
@@ -23,11 +24,13 @@ kubectl get etcd <etcd-name> -n <namespace> -owide
 * You can additional monitor [all etcd cluster resources](../concepts/etcd-cluster-components.md) that are created for every etcd cluster. 
 
   For etcd-druid version <v0.23.0 use the following command:
+
 ```bash
 kubectl get all,cm,role,rolebinding,lease,sa -n <namespace> --selector=instance=<etcd-name>
 ```
 
   For etcd-druid version >=v0.23.0 use the following command:
+
 ```bash
 kubectl get all,cm,role,rolebinding,lease,sa -n <namespace> --selector=app.kubernetes.io/managed-by=etcd-druid,app.kubernetes.io/part-of=<etcd-name>
 ```
@@ -89,6 +92,7 @@ If `etcd-druid` has been deployed with auto-reconciliation then any change done 
 > For a complete list of CLI args you can see [this](../deployment/configure-etcd-druid.md) document.
 
 #### Explicit reconciliation
+
 If `--enable-etcd-spec-auto-reconcile` is set to false or not set at all, then any change to an `Etcd` resource will not be automatically reconciled. To trigger a reconcile you must set the following annotation on the `Etcd` resource:
 
 ```bash
@@ -99,32 +103,35 @@ This option is sometimes recommeded as you would like avoid auto-reconciliation 
 
 ### Full snapshot before a StatefulSet update
 
-Before `etcd-druid` rolls the etcd `StatefulSet` due to a container image change or a replica count change (in both HA and non-HA setups), it triggers a full snapshot via an `EtcdOpsTask`. This ensures there is a recent, safe state to restore from should the rollout run into data corruption or data loss. The snapshot is attempted a bounded number of times; if all attempts fail, `etcd-druid` proceeds with the update regardless (so that a persistently failing snapshot does not block updates indefinitely).
+Before `etcd-druid` rolls the etcd `StatefulSet` due to a container image or replica count change, it triggers a full snapshot via an [`EtcdOpsTask`](using-etcdopstask.md). This provides a recent recovery point in case the rollout results in data corruption or data loss. This behavior applies to both HA and non-HA setups.
+
+The snapshot is attempted a bounded number of times. If all attempts fail, `etcd-druid` proceeds with the update without a fresh snapshot, so that a persistently failing snapshot does not block updates indefinitely.
 
 #### Skip the snapshot before updates
 
 If snapshots are known to be failing, or you need changes to roll out quickly without waiting for a snapshot, you can instruct `etcd-druid` to skip the pre-update snapshot by annotating the `Etcd` resource with `druid.gardener.cloud/skip-spec-update-snapshot`:
 
 ```bash
-   kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/skip-spec-update-snapshot=
+kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/skip-spec-update-snapshot=
 ```
 
 This annotation is:
 
-- **Presence-only**: the annotation value is ignored; simply having the key present enables the skip.
-- **Persistent**: while the annotation is present, the pre-update snapshot is always skipped. `etcd-druid` does not remove it — remove the annotation yourself to re-enable pre-update snapshots.
-- **Scoped to image/replica updates**: it does not affect the full snapshot taken before hibernation (scaling the cluster to zero replicas).
+* **Presence-only**: the annotation value is ignored; simply having the key present enables the skip.
+* **Persistent**: while the annotation is present, the pre-update snapshot is always skipped. `etcd-druid` does not remove it — remove the annotation yourself to re-enable pre-update snapshots.
+* **Scoped to image/replica updates**: it does not affect the full snapshot taken before hibernation (scaling the cluster to zero replicas).
+* **Limited to the pre-update snapshot**: the regular scheduled full and delta snapshots, as well as out-of-band snapshots, continue to be taken as usual while the annotation is present.
 
 #### Surfacing snapshot failures
 
-When the pre-update snapshot exhausts its retries and `etcd-druid` proceeds with the update without a fresh snapshot, it records a `Warning` event with reason `PreSyncSnapshotFailed` on the `Etcd` resource so operators are aware. You can see it via:
+If the pre-update snapshot exhausts its retries, `etcd-druid` proceeds with the update without a fresh snapshot and records a `Warning` event with the reason `PreSyncSnapshotFailed` on the `Etcd` resource. You can view the event using:
 
 ```bash
-   kubectl describe etcd <etcd-name> -n <namespace>
+kubectl describe etcd <etcd-name> -n <namespace>
 ```
 
-!!! note
-    A `PreSyncSnapshotFailed` event means the update proceeded without a fresh snapshot. Inspect the `presync-snapshot-update-*` `EtcdOpsTask` resources and the backup configuration to find out why the snapshot failed.
+> [!NOTE]
+> A `PreSyncSnapshotFailed` event means that the update proceeded without a fresh snapshot. Inspect the `presync-snapshot-update-*` [`EtcdOpsTask`](using-etcdopstask.md) resources and the backup configuration to determine why the snapshot failed.
 
 ## Overwrite Container OCI Images
 
@@ -163,6 +170,7 @@ Edit the `etcd-druid` `Deployment` with:
 * Set `IMAGEVECTOR_OVERWRITE` environment variable whose value must be the path you choose to mount the `ConfigMap`.
 
 To illustrate the changes you can see the following `etcd-druid` Deployment YAML:
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -195,22 +203,21 @@ We provide a generic way to suspend etcd cluster reconciliation via etcd-druid, 
 
 ## Manually modify individual etcd cluster resources
 
-`etcd` cluster resources are managed by `etcd-druid` and since v0.23.0 version of `etcd-druid` any changes to these managed resources are protected via a validating webhook. You can find more information about this webhook [here](../concepts/etcd-cluster-resource-protection.md). To be able to manually modify etcd cluster managed resources two things needs to be done:
+`etcd` cluster resources are managed by `etcd-druid` and since v0.23.0 version of `etcd-druid` any changes to these managed resources are protected via a validating webhook. You can find more information about this webhook in the [concept](../concepts/etcd-cluster-resource-protection.md). To be able to manually modify etcd cluster managed resources two things needs to be done:
 
 1. Annotate the target `Etcd` resource suspending any reconciliation by `etcd-druid`. You can do this by invoking the following command:
 
 ```bash
-   kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/suspend-etcd-spec-reconcile=
+kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/suspend-etcd-spec-reconcile=
 ```
 
 2. Add another annotation to the target `Etcd` resource disabling managed resource protection via the webhook. You can do this by invoking the following command:
 
 ```bash
-   kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/disable-etcd-component-protection=
+kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/disable-etcd-component-protection=
 ```
 
 Now you are free to make changes to any managed etcd cluster resource.
 
 !!! note
     As long as the above two annotations are there, no reconciliation will be done for this etcd cluster by `etcd-druid`. Therefore it is essential that you remove this annotations eventually.
-

--- a/docs/usage/managing-etcd-clusters.md
+++ b/docs/usage/managing-etcd-clusters.md
@@ -133,6 +133,9 @@ kubectl describe etcd <etcd-name> -n <namespace>
 > [!NOTE]
 > A `PreSyncSnapshotFailed` event means that the update proceeded without a fresh snapshot. Inspect the `presync-snapshot-update-*` [`EtcdOpsTask`](using-etcdopstask.md) resources and the backup configuration to determine why the snapshot failed.
 
+> [!WARNING]
+> `etcd-druid` detects a container image change by comparing the images it expects (derived from the `Etcd` resource and the configured image vector) against the images currently set on the `StatefulSet`. Always customize container images declaratively via the `Etcd` spec (see [Overwrite Container OCI Images](#overwrite-container-oci-images)) so that `etcd-druid` applies them as part of its own reconciliation. Do **not** mutate the images on the managed `StatefulSet` out-of-band through a mutating admission webhook, etc since such mutations are not reconciled by `etcd-druid`, so every reconciliation will detect an image difference and repeatedly trigger a pre-update snapshot.
+
 ## Overwrite Container OCI Images
 
 To find out image versions of `etcd-backup-restore` and `etcd-wrapper` used by a specific version of `etcd-druid` one way is look for the image versions in [images.yaml](https://github.com/gardener/etcd-druid/blob/master/internal/images/images.yaml). There are times that you might wish to override these images that come bundled with `etcd-druid`. There are two ways in which you can do that:

--- a/docs/usage/managing-etcd-clusters.md
+++ b/docs/usage/managing-etcd-clusters.md
@@ -97,6 +97,35 @@ kubectl annotate etcd <etcd-name> gardener.cloud/operation=reconcile -n <namespa
 
 This option is sometimes recommeded as you would like avoid auto-reconciliation of accidental changes to `Etcd` resources outside the maintenance time window, thus preventing a potential transient quorum loss due to misconfiguration, attach-detach issues of persistent volumes etc.
 
+### Full snapshot before a StatefulSet update
+
+Before `etcd-druid` rolls the etcd `StatefulSet` due to a container image change or a replica count change (in both HA and non-HA setups), it triggers a full snapshot via an `EtcdOpsTask`. This ensures there is a recent, safe state to restore from should the rollout run into data corruption or data loss. The snapshot is attempted a bounded number of times; if all attempts fail, `etcd-druid` proceeds with the update regardless (so that a persistently failing snapshot does not block updates indefinitely).
+
+#### Skip the snapshot before updates
+
+If snapshots are known to be failing, or you need changes to roll out quickly without waiting for a snapshot, you can instruct `etcd-druid` to skip the pre-update snapshot by annotating the `Etcd` resource with `druid.gardener.cloud/skip-spec-update-snapshot`:
+
+```bash
+   kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/skip-spec-update-snapshot=
+```
+
+This annotation is:
+
+- **Presence-only**: the annotation value is ignored; simply having the key present enables the skip.
+- **Persistent**: while the annotation is present, the pre-update snapshot is always skipped. `etcd-druid` does not remove it — remove the annotation yourself to re-enable pre-update snapshots.
+- **Scoped to image/replica updates**: it does not affect the full snapshot taken before hibernation (scaling the cluster to zero replicas).
+
+#### Surfacing snapshot failures
+
+When the pre-update snapshot exhausts its retries and `etcd-druid` proceeds with the update without a fresh snapshot, it records a `Warning` event with reason `PreSyncSnapshotFailed` on the `Etcd` resource so operators are aware. You can see it via:
+
+```bash
+   kubectl describe etcd <etcd-name> -n <namespace>
+```
+
+!!! note
+    A `PreSyncSnapshotFailed` event means the update proceeded without a fresh snapshot. Inspect the `presync-snapshot-update-*` `EtcdOpsTask` resources and the backup configuration to find out why the snapshot failed.
+
 ## Overwrite Container OCI Images
 
 To find out image versions of `etcd-backup-restore` and `etcd-wrapper` used by a specific version of `etcd-druid` one way is look for the image versions in [images.yaml](https://github.com/gardener/etcd-druid/blob/master/internal/images/images.yaml). There are times that you might wish to override these images that come bundled with `etcd-druid`. There are two ways in which you can do that:
@@ -185,31 +214,3 @@ Now you are free to make changes to any managed etcd cluster resource.
 !!! note
     As long as the above two annotations are there, no reconciliation will be done for this etcd cluster by `etcd-druid`. Therefore it is essential that you remove this annotations eventually.
 
-## Full snapshot before a StatefulSet update
-
-Before `etcd-druid` rolls the etcd `StatefulSet` due to a container image change or a replica count change (in both HA and non-HA setups), it triggers a full snapshot via an `EtcdOpsTask`. This ensures there is a recent, safe state to restore from should the rollout run into data corruption or data loss. The snapshot is attempted a bounded number of times; if all attempts fail, `etcd-druid` proceeds with the update regardless (so that a persistently failing snapshot does not block updates indefinitely).
-
-### Skip the snapshot for the next update
-
-If snapshots are known to be failing, or you need a change to roll out quickly without waiting for a snapshot, you can instruct `etcd-druid` to skip the pre-update snapshot for the immediately pending update by annotating the `Etcd` resource:
-
-```bash
-   kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/skip-next-update-snapshot=
-```
-
-This annotation is:
-
-- **One-shot**: `etcd-druid` removes it as soon as the skip is applied, so it only affects the next pending update. Any subsequent image or replica change will again trigger a full snapshot.
-- **Presence-only**: the annotation value is ignored; simply having the key present enables the skip.
-- **Scoped to image/replica updates**: it does not affect the full snapshot taken before hibernation (scaling the cluster to zero replicas).
-
-### Surfacing snapshot failures
-
-When the pre-update snapshot exhausts its retries and `etcd-druid` proceeds with the update without a fresh snapshot, it records a `Warning` event with reason `PreSyncSnapshotFailed` on the `Etcd` resource so operators are aware. You can see it via:
-
-```bash
-   kubectl describe etcd <etcd-name> -n <namespace>
-```
-
-!!! note
-    A `PreSyncSnapshotFailed` event means the update proceeded without a fresh snapshot. Inspect the `presync-snapshot-update-*` `EtcdOpsTask` resources and the backup configuration to find out why the snapshot failed.

--- a/docs/usage/managing-etcd-clusters.md
+++ b/docs/usage/managing-etcd-clusters.md
@@ -184,3 +184,32 @@ Now you are free to make changes to any managed etcd cluster resource.
 
 !!! note
     As long as the above two annotations are there, no reconciliation will be done for this etcd cluster by `etcd-druid`. Therefore it is essential that you remove this annotations eventually.
+
+## Full snapshot before a StatefulSet update
+
+Before `etcd-druid` rolls the etcd `StatefulSet` due to a container image change or a replica count change (in both HA and non-HA setups), it triggers a full snapshot via an `EtcdOpsTask`. This ensures there is a recent, safe state to restore from should the rollout run into data corruption or data loss. The snapshot is attempted a bounded number of times; if all attempts fail, `etcd-druid` proceeds with the update regardless (so that a persistently failing snapshot does not block updates indefinitely).
+
+### Skip the snapshot for the next update
+
+If snapshots are known to be failing, or you need a change to roll out quickly without waiting for a snapshot, you can instruct `etcd-druid` to skip the pre-update snapshot for the immediately pending update by annotating the `Etcd` resource:
+
+```bash
+   kubectl annotate etcd <etcd-name> -n <namespace> druid.gardener.cloud/skip-next-update-snapshot=
+```
+
+This annotation is:
+
+- **One-shot**: `etcd-druid` removes it as soon as the skip is applied, so it only affects the next pending update. Any subsequent image or replica change will again trigger a full snapshot.
+- **Presence-only**: the annotation value is ignored; simply having the key present enables the skip.
+- **Scoped to image/replica updates**: it does not affect the full snapshot taken before hibernation (scaling the cluster to zero replicas).
+
+### Surfacing snapshot failures
+
+When the pre-update snapshot exhausts its retries and `etcd-druid` proceeds with the update without a fresh snapshot, it records a `Warning` event with reason `PreSyncSnapshotFailed` on the `Etcd` resource so operators are aware. You can see it via:
+
+```bash
+   kubectl describe etcd <etcd-name> -n <namespace>
+```
+
+!!! note
+    A `PreSyncSnapshotFailed` event means the update proceeded without a fresh snapshot. Inspect the `presync-snapshot-update-*` `EtcdOpsTask` resources and the backup configuration to find out why the snapshot failed.

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -9,10 +9,10 @@ const (
 	// place an annotation on the StatefulSet pods. The value contains the check-sum of the latest configmap that
 	// should be reflected on the pods.
 	CheckSumKeyConfigMap = "checksum/etcd-configmap"
-	// KeyPreSyncSnapshotExhausted is a key set in OperatorContext.Data by the StatefulSet component's PreSync when a
+	// KeyPreSyncSnapshotFailed is a key set in OperatorContext.Data by the StatefulSet component's PreSync when a
 	// pre-sync full snapshot has exhausted its retries and etcd-druid is proceeding with the update without a fresh
 	// snapshot. The etcd controller reads this key after pre-sync to surface the failure via a warning event.
-	KeyPreSyncSnapshotExhausted = "presync-snapshot-exhausted"
+	KeyPreSyncSnapshotFailed = "presync-snapshot-failed"
 )
 
 // LeaseAnnotationKeyPeerURLTLSEnabled is the annotation key present on the member lease.

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -9,6 +9,10 @@ const (
 	// place an annotation on the StatefulSet pods. The value contains the check-sum of the latest configmap that
 	// should be reflected on the pods.
 	CheckSumKeyConfigMap = "checksum/etcd-configmap"
+	// KeyPreSyncSnapshotExhausted is a key set in OperatorContext.Data by the StatefulSet component's PreSync when a
+	// pre-sync full snapshot has exhausted its retries and etcd-druid is proceeding with the update without a fresh
+	// snapshot. The etcd controller reads this key after pre-sync to surface the failure via a warning event.
+	KeyPreSyncSnapshotExhausted = "presync-snapshot-exhausted"
 )
 
 // LeaseAnnotationKeyPeerURLTLSEnabled is the annotation key present on the member lease.

--- a/internal/component/statefulset/statefulset.go
+++ b/internal/component/statefulset/statefulset.go
@@ -47,7 +47,7 @@ const (
 	// Pre-sync snapshot task constants
 	preSyncTaskPrefixHibernation = "presync-snapshot-hibernation-"
 	preSyncTaskPrefixUpdate      = "presync-snapshot-update-"
-	// maxPreSyncRetries defines the maximum number of pre-sync snapshot attempts before giving up and proceeding with the upgrade.
+	// maxPreSyncRetries defines the maximum number of pre-sync snapshot attempts before giving up and proceeding with the sync.
 	maxPreSyncRetries = 3
 )
 

--- a/internal/component/statefulset/statefulset.go
+++ b/internal/component/statefulset/statefulset.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
-	druidconfigv1alpha1 "github.com/gardener/etcd-druid/api/config/v1alpha1"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/common"
 	"github.com/gardener/etcd-druid/internal/component"
@@ -47,7 +46,7 @@ const (
 
 	// Pre-sync snapshot task constants
 	preSyncTaskPrefixHibernation = "presync-snapshot-hibernation-"
-	preSyncTaskPrefixUpgrade     = "presync-snapshot-upgrade-"
+	preSyncTaskPrefixUpdate      = "presync-snapshot-update-"
 	// maxPreSyncRetries defines the maximum number of pre-sync snapshot attempts before giving up and proceeding with the upgrade.
 	maxPreSyncRetries = 3
 )
@@ -107,29 +106,51 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskPrefixHibernation)
 	}
 
-	if !druidconfigv1alpha1.DefaultFeatureGates.IsEnabled(druidconfigv1alpha1.UpgradeEtcdVersion) {
-		return nil
-	}
-
-	etcdWrapperImageFromImageVector, _, _, err := utils.GetEtcdImages(etcd, r.imageVector)
+	changed, err := r.hasImageOrReplicaChanged(etcd, existingSts)
 	if err != nil {
 		return druiderr.WrapError(err, ErrGetEtcdWrapperImage, component.OperationPreSync,
 			fmt.Sprintf("Error getting etcd images for etcd: %v", client.ObjectKeyFromObject(etcd)))
 	}
-
-	var existingWrapperImageFromSts string
-	for _, c := range existingSts.Spec.Template.Spec.Containers {
-		if c.Name == common.ContainerNameEtcd {
-			existingWrapperImageFromSts = c.Image
-			break
-		}
-	}
-
-	if existingWrapperImageFromSts != "" && etcdWrapperImageFromImageVector != existingWrapperImageFromSts {
-		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskPrefixUpgrade)
+	if changed {
+		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskPrefixUpdate)
 	}
 
 	return nil
+}
+
+// collectExpectedImages returns the expected images keyed by container name for the etcd pod template.
+func (r _resource) collectExpectedImages(etcd *druidv1alpha1.Etcd) (map[string]string, error) {
+	wrapperImg, brImg, initImg, err := utils.GetEtcdImages(etcd, r.imageVector)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		common.ContainerNameEtcd:                              wrapperImg,
+		common.ContainerNameEtcdBackupRestore:                 brImg,
+		common.InitContainerNameChangeBackupBucketPermissions: initImg,
+	}, nil
+}
+
+// hasImageOrReplicaChanged reports whether the etcd spec replicas differ from the STS, or any tracked container/init-container image differs from the expected image vector.
+func (r _resource) hasImageOrReplicaChanged(etcd *druidv1alpha1.Etcd, sts *appsv1.StatefulSet) (bool, error) {
+	if etcd.Spec.Replicas != ptr.Deref(sts.Spec.Replicas, 0) {
+		return true, nil
+	}
+	expected, err := r.collectExpectedImages(etcd)
+	if err != nil {
+		return false, err
+	}
+	for _, c := range sts.Spec.Template.Spec.InitContainers {
+		if want, ok := expected[c.Name]; ok && want != c.Image {
+			return true, nil
+		}
+	}
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		if want, ok := expected[c.Name]; ok && want != c.Image {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // ensurePreSyncSnapshot ensures a pre-sync snapshot is taken via an etcdopstask with retry logic up to maxPreSyncRetries attempts.

--- a/internal/component/statefulset/statefulset.go
+++ b/internal/component/statefulset/statefulset.go
@@ -45,8 +45,8 @@ const (
 	ErrGetEtcdWrapperImage druidapicommon.ErrorCode = "ERR_GET_ETCD_WRAPPER_IMAGE"
 
 	// Pre-sync snapshot task constants
-	preSyncTaskPrefixHibernation = "presync-snapshot-hibernation-"
-	preSyncTaskPrefixUpdate      = "presync-snapshot-update-"
+	preSyncTaskHibernationPrefix = "presync-snapshot-hibernation-"
+	preSyncTaskUpdatePrefix      = "presync-snapshot-update-"
 	// maxPreSyncRetries defines the maximum number of pre-sync snapshot attempts before giving up and proceeding with the sync.
 	maxPreSyncRetries = 3
 )
@@ -107,7 +107,7 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 	// hibernation support [gardener/etcd-druid#922](https://github.com/gardener/etcd-druid/issues/922) is implemented,
 	// we need to switch to the dedicated hibernation signal on the Etcd resource instead of inferring it from the replica count.
 	if etcd.Spec.Replicas == 0 {
-		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskPrefixHibernation)
+		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskHibernationPrefix)
 	}
 
 	if druidv1alpha1.HasSkipSpecUpdateSnapshotAnnotation(etcd.ObjectMeta) {
@@ -122,7 +122,7 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 			fmt.Sprintf("Error getting component images for etcd: %v", client.ObjectKeyFromObject(etcd)))
 	}
 	if changed {
-		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskPrefixUpdate)
+		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskUpdatePrefix)
 	}
 
 	return nil
@@ -198,7 +198,7 @@ func (r _resource) ensurePreSyncSnapshot(ctx component.OperatorContext, etcd *dr
 				"etcd", client.ObjectKeyFromObject(etcd), "lastTask", latestTask.Name, "lastState", *latestTask.Status.State)
 			// Signal the exhaustion to the controller (via the per-run OperatorContext.Data) so it can surface the
 			// failure via a warning event, while still proceeding with the sync.
-			ctx.Data[common.KeyPreSyncSnapshotExhausted] = etcd.Name
+			ctx.Data[common.KeyPreSyncSnapshotFailed] = etcd.Name
 			return nil
 		}
 		nextIndex := 0

--- a/internal/component/statefulset/statefulset.go
+++ b/internal/component/statefulset/statefulset.go
@@ -107,7 +107,7 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 	// hibernation support [gardener/etcd-druid#922](https://github.com/gardener/etcd-druid/issues/922) is implemented,
 	// we need to switch to the dedicated hibernation signal on the Etcd resource instead of inferring it from the replica count.
 	if etcd.Spec.Replicas == 0 {
-		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskHibernationPrefix)
+		return r.ensurePreSyncSnapshot(ctx, etcd, fmt.Sprintf("%s%d-", preSyncTaskHibernationPrefix, etcd.Generation))
 	}
 
 	if druidv1alpha1.HasSkipSpecUpdateSnapshotAnnotation(etcd.ObjectMeta) {
@@ -122,7 +122,7 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 			fmt.Sprintf("Error getting component images for etcd: %v", client.ObjectKeyFromObject(etcd)))
 	}
 	if changed {
-		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskUpdatePrefix)
+		return r.ensurePreSyncSnapshot(ctx, etcd, fmt.Sprintf("%s%d-", preSyncTaskUpdatePrefix, etcd.Generation))
 	}
 
 	return nil

--- a/internal/component/statefulset/statefulset.go
+++ b/internal/component/statefulset/statefulset.go
@@ -43,6 +43,8 @@ const (
 	ErrCreateEtcdOpsTask druidapicommon.ErrorCode = "ERR_CREATE_ETCDOPSTASK"
 	// ErrGetEtcdWrapperImage indicates an error in getting the etcd wrapper image from the image vector.
 	ErrGetEtcdWrapperImage druidapicommon.ErrorCode = "ERR_GET_ETCD_WRAPPER_IMAGE"
+	// ErrRemoveSkipAnnotation indicates an error in removing the skip-next-update-snapshot annotation from the Etcd resource.
+	ErrRemoveSkipAnnotation druidapicommon.ErrorCode = "ERR_REMOVE_SKIP_ANNOTATION"
 
 	// Pre-sync snapshot task constants
 	preSyncTaskPrefixHibernation = "presync-snapshot-hibernation-"
@@ -88,6 +90,7 @@ func (r _resource) GetExistingResourceNames(ctx component.OperatorContext, etcdO
 
 // PreSync performs pre-sync operations for the statefulset component.
 func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
+	r.logger = ctx.Logger.WithValues("component", component.StatefulSetKind, "operation", component.OperationPreSync)
 	if !etcd.IsBackupStoreEnabled() {
 		return nil
 	}
@@ -109,13 +112,29 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 	changed, err := r.hasImageOrReplicaChanged(etcd, existingSts)
 	if err != nil {
 		return druiderr.WrapError(err, ErrGetEtcdWrapperImage, component.OperationPreSync,
-			fmt.Sprintf("Error getting etcd images for etcd: %v", client.ObjectKeyFromObject(etcd)))
+			fmt.Sprintf("Error getting component images for etcd: %v", client.ObjectKeyFromObject(etcd)))
 	}
 	if changed {
+		if druidv1alpha1.HasSkipNextUpdateSnapshotAnnotation(etcd.ObjectMeta) {
+			r.logger.Info("Skipping pre-sync snapshot for pending update due to presence of annotation", "annotation", druidv1alpha1.SkipNextUpdateSnapshotAnnotation)
+			if err := r.removeSkipNextUpdateSnapshotAnnotation(ctx, etcd); err != nil {
+				return druiderr.WrapError(err, ErrRemoveSkipAnnotation, component.OperationPreSync,
+					fmt.Sprintf("Failed to remove %s annotation for etcd: %v", druidv1alpha1.SkipNextUpdateSnapshotAnnotation, client.ObjectKeyFromObject(etcd)))
+			}
+			return nil
+		}
 		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskPrefixUpdate)
 	}
 
 	return nil
+}
+
+// removeSkipNextUpdateSnapshotAnnotation removes the skip-next-update-snapshot annotation from the Etcd resource so that
+// it only applies to the immediately pending update (only once). It patches the object metadata.
+func (r _resource) removeSkipNextUpdateSnapshotAnnotation(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
+	originalEtcd := etcd.DeepCopy()
+	delete(etcd.Annotations, druidv1alpha1.SkipNextUpdateSnapshotAnnotation)
+	return r.client.Patch(ctx, etcd, client.MergeFrom(originalEtcd))
 }
 
 // collectExpectedImages returns the expected images keyed by container name for the etcd pod template.
@@ -179,6 +198,9 @@ func (r _resource) ensurePreSyncSnapshot(ctx component.OperatorContext, etcd *dr
 		if latestIndex != nil && *latestIndex >= maxPreSyncRetries-1 {
 			r.logger.Error(fmt.Errorf("max retries exceeded"), "Pre-sync snapshot failed after max attempts",
 				"etcd", client.ObjectKeyFromObject(etcd), "lastTask", latestTask.Name, "lastState", *latestTask.Status.State)
+			// Signal the exhaustion to the controller (via the per-run OperatorContext.Data) so it can surface the
+			// failure via a warning event, while still proceeding with the sync.
+			ctx.Data[common.KeyPreSyncSnapshotExhausted] = etcd.Name
 			return nil
 		}
 		nextIndex := 0

--- a/internal/component/statefulset/statefulset.go
+++ b/internal/component/statefulset/statefulset.go
@@ -43,8 +43,6 @@ const (
 	ErrCreateEtcdOpsTask druidapicommon.ErrorCode = "ERR_CREATE_ETCDOPSTASK"
 	// ErrGetEtcdWrapperImage indicates an error in getting the etcd wrapper image from the image vector.
 	ErrGetEtcdWrapperImage druidapicommon.ErrorCode = "ERR_GET_ETCD_WRAPPER_IMAGE"
-	// ErrRemoveSkipAnnotation indicates an error in removing the skip-next-update-snapshot annotation from the Etcd resource.
-	ErrRemoveSkipAnnotation druidapicommon.ErrorCode = "ERR_REMOVE_SKIP_ANNOTATION"
 
 	// Pre-sync snapshot task constants
 	preSyncTaskPrefixHibernation = "presync-snapshot-hibernation-"
@@ -105,8 +103,17 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 		return nil
 	}
 
+	// TODO: currently replicas == 0 is used as a proxy for "the cluster is being hibernated". Once native
+	// hibernation support [gardener/etcd-druid#922](https://github.com/gardener/etcd-druid/issues/922) is implemented,
+	// we need to switch to the dedicated hibernation signal on the Etcd resource instead of inferring it from the replica count.
 	if etcd.Spec.Replicas == 0 {
 		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskPrefixHibernation)
+	}
+
+	if druidv1alpha1.HasSkipSpecUpdateSnapshotAnnotation(etcd.ObjectMeta) {
+		r.logger.Info("Skipping pre-sync snapshot for update due to presence of annotation",
+			"annotation", druidv1alpha1.SkipSpecUpdateSnapshotAnnotation)
+		return nil
 	}
 
 	changed, err := r.hasImageOrReplicaChanged(etcd, existingSts)
@@ -115,26 +122,10 @@ func (r _resource) PreSync(ctx component.OperatorContext, etcd *druidv1alpha1.Et
 			fmt.Sprintf("Error getting component images for etcd: %v", client.ObjectKeyFromObject(etcd)))
 	}
 	if changed {
-		if druidv1alpha1.HasSkipNextUpdateSnapshotAnnotation(etcd.ObjectMeta) {
-			r.logger.Info("Skipping pre-sync snapshot for pending update due to presence of annotation", "annotation", druidv1alpha1.SkipNextUpdateSnapshotAnnotation)
-			if err := r.removeSkipNextUpdateSnapshotAnnotation(ctx, etcd); err != nil {
-				return druiderr.WrapError(err, ErrRemoveSkipAnnotation, component.OperationPreSync,
-					fmt.Sprintf("Failed to remove %s annotation for etcd: %v", druidv1alpha1.SkipNextUpdateSnapshotAnnotation, client.ObjectKeyFromObject(etcd)))
-			}
-			return nil
-		}
 		return r.ensurePreSyncSnapshot(ctx, etcd, preSyncTaskPrefixUpdate)
 	}
 
 	return nil
-}
-
-// removeSkipNextUpdateSnapshotAnnotation removes the skip-next-update-snapshot annotation from the Etcd resource so that
-// it only applies to the immediately pending update (only once). It patches the object metadata.
-func (r _resource) removeSkipNextUpdateSnapshotAnnotation(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
-	originalEtcd := etcd.DeepCopy()
-	delete(etcd.Annotations, druidv1alpha1.SkipNextUpdateSnapshotAnnotation)
-	return r.client.Patch(ctx, etcd, client.MergeFrom(originalEtcd))
 }
 
 // collectExpectedImages returns the expected images keyed by container name for the etcd pod template.
@@ -155,21 +146,28 @@ func (r _resource) hasImageOrReplicaChanged(etcd *druidv1alpha1.Etcd, sts *appsv
 	if etcd.Spec.Replicas != ptr.Deref(sts.Spec.Replicas, 0) {
 		return true, nil
 	}
-	expected, err := r.collectExpectedImages(etcd)
+	expectedImages, err := r.collectExpectedImages(etcd)
 	if err != nil {
 		return false, err
 	}
-	for _, c := range sts.Spec.Template.Spec.InitContainers {
-		if want, ok := expected[c.Name]; ok && want != c.Image {
-			return true, nil
-		}
+	if imagesChanged(sts.Spec.Template.Spec.InitContainers, expectedImages) {
+		return true, nil
 	}
-	for _, c := range sts.Spec.Template.Spec.Containers {
-		if want, ok := expected[c.Name]; ok && want != c.Image {
-			return true, nil
-		}
+	if imagesChanged(sts.Spec.Template.Spec.Containers, expectedImages) {
+		return true, nil
 	}
 	return false, nil
+}
+
+// imagesChanged reports whether any container's image differs from the expected image for that container name.
+// Container names not present in expectedImages are ignored.
+func imagesChanged(containers []corev1.Container, expectedImages map[string]string) bool {
+	for _, container := range containers {
+		if expectedImage, ok := expectedImages[container.Name]; ok && expectedImage != container.Image {
+			return true
+		}
+	}
+	return false
 }
 
 // ensurePreSyncSnapshot ensures a pre-sync snapshot is taken via an etcdopstask with retry logic up to maxPreSyncRetries attempts.

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -133,7 +133,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:   3,
 			etcdReplicas:  3,
 		},
-		// ---------------- Hibernation rows (regression) ----------------
+		// ---------------- Hibernation rows ----------------
 		{
 			name:            "hibernation requeues when no task exists",
 			backupEnabled:   true,

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -175,7 +175,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:        3,
 			etcdReplicas:       3,
 			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpgrade, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
 			name:               "upgrade proceeds after max retries exceeded",
@@ -185,7 +185,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:        3,
 			etcdReplicas:       3,
 			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpgrade, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
 		},
 		{
 			name:               "hibernation requeues when no task exists",
@@ -237,7 +237,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:        3,
 			etcdReplicas:       3,
 			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpgrade, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
+			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
 			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
@@ -248,7 +248,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:        3,
 			etcdReplicas:       3,
 			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpgrade, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
 			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 	}

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -7,10 +7,10 @@ package statefulset
 import (
 	"context"
 	"fmt"
+	"maps"
 	"testing"
 
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
-	druidconfigv1alpha1 "github.com/gardener/etcd-druid/api/config/v1alpha1"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/client/kubernetes"
 	"github.com/gardener/etcd-druid/internal/common"
@@ -90,21 +90,22 @@ func TestGetExistingResourceNames(t *testing.T) {
 // ----------------------------------- PreSync -----------------------------------
 func TestPreSync(t *testing.T) {
 	const (
-		oldImage     = "europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:v0.6.2"
-		currentImage = ""
+		oldWrapperImage       = "europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:v0.6.2"
+		oldBackupRestoreImage = "europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:v0.30.0"
+		oldInitImage          = "europe-docker.pkg.dev/gardener-project/public/3rd/alpine:3.18.4"
 	)
 
 	testCases := []struct {
-		name               string
-		backupEnabled      bool
-		stsExists          bool
-		featureGateEnabled bool
-		stsReplicas        int32
-		etcdReplicas       int32
-		etcdWrapperImage   string
-		existingTasks      []*druidv1alpha1.EtcdOpsTask
-		expectedErrCode    *druidapicommon.ErrorCode
+		name            string
+		backupEnabled   bool
+		stsExists       bool
+		stsReplicas     int32
+		etcdReplicas    int32
+		stsImages       map[string]string // keyed by container name; nil = use current image-vector defaults for all containers
+		existingTasks   []*druidv1alpha1.EtcdOpsTask
+		expectedErrCode *druidapicommon.ErrorCode
 	}{
+		// ---------------- No-op rows ----------------
 		{
 			name:          "returns nil when backup is disabled",
 			backupEnabled: false,
@@ -119,147 +120,142 @@ func TestPreSync(t *testing.T) {
 			etcdReplicas:  3,
 		},
 		{
-			name:               "returns nil when no hibernation and no upgrade",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   currentImage,
+			name:          "returns nil when STS replicas are 0",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   0,
+			etcdReplicas:  3,
 		},
 		{
-			name:               "hibernation succeeds when task completed",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: false,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   currentImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			name:          "returns nil when no image change and no replica change",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  3,
+		},
+		// ---------------- Hibernation rows (regression) ----------------
+		{
+			name:            "hibernation requeues when no task exists",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    0,
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "hibernation proceeds after max retries exceeded",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: false,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   currentImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			name:          "hibernation succeeds when task completed",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  0,
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
-			name:               "hibernation with upgrade succeeds when task completed",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			name:          "hibernation proceeds after max retries exceeded",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  0,
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+		},
+		// ---------------- Image-change rows ----------------
+		{
+			name:            "update requeues when wrapper image changed and no task exists",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "hibernation with upgrade proceeds after max retries exceeded",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			name:            "update requeues when backup-restore image changed and no task exists",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.ContainerNameEtcdBackupRestore: oldBackupRestoreImage},
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "upgrade succeeds when task completed",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			name:            "update requeues when init-container image changed and no task exists",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.InitContainerNameChangeBackupBucketPermissions: oldInitImage},
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "upgrade proceeds after max retries exceeded",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			name:          "update succeeds when task completed",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  3,
+			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
-			name:               "hibernation requeues when no task exists",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: false,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   currentImage,
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+			name:          "update proceeds after max retries exceeded",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  3,
+			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
 		},
 		{
-			name:               "hibernation requeues when task is in progress",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: false,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   currentImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+			name:            "update requeues when task is in progress",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "hibernation requeues when task failed and retries remain",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: false,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   currentImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+			name:            "update requeues when task failed and retries remain",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+		},
+		// ---------------- Replica-change rows ----------------
+		{
+			name:            "update requeues when replicas scale up (3->5)",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    5,
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "upgrade requeues when no task exists",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   oldImage,
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+			name:            "update requeues when replicas scale down to non-zero (5->3)",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     5,
+			etcdReplicas:    3,
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
+		// ---------------- Combination row ----------------
 		{
-			name:               "upgrade requeues when task is in progress",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
-		},
-		{
-			name:               "upgrade requeues when task failed and retries remain",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+			name:          "hibernation prefix wins when replicas go to 0 even if images also changed",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  0,
+			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := druidconfigv1alpha1.DefaultFeatureGates.SetEnabledFeaturesFromMap(
-				map[string]bool{druidconfigv1alpha1.UpgradeEtcdVersion: tc.featureGateEnabled},
-			)
-			g.Expect(err).ToNot(HaveOccurred())
 
 			etcdBuilder := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).
 				WithReplicas(tc.etcdReplicas)
@@ -270,15 +266,19 @@ func TestPreSync(t *testing.T) {
 
 			iv := testutils.CreateImageVector(true, true)
 
-			etcdWrapperImage := tc.etcdWrapperImage
-			if etcdWrapperImage == currentImage {
-				etcdWrapperImage, _, _, err = utils.GetEtcdImages(etcd, iv)
-				g.Expect(err).ToNot(HaveOccurred())
+			defaultWrapperImage, defaultBRImage, defaultInitImage, err := utils.GetEtcdImages(etcd, iv)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			stsImages := map[string]string{
+				common.ContainerNameEtcd:                              defaultWrapperImage,
+				common.ContainerNameEtcdBackupRestore:                 defaultBRImage,
+				common.InitContainerNameChangeBackupBucketPermissions: defaultInitImage,
 			}
+			maps.Copy(stsImages, tc.stsImages)
 
 			var existingObjects []client.Object
 			if tc.stsExists {
-				existingObjects = append(existingObjects, buildStatefulSetWithImage(etcd.ObjectMeta, tc.stsReplicas, etcdWrapperImage))
+				existingObjects = append(existingObjects, buildStatefulSetWithImages(etcd.ObjectMeta, tc.stsReplicas, stsImages))
 			}
 			for _, task := range tc.existingTasks {
 				existingObjects = append(existingObjects, task)
@@ -418,7 +418,27 @@ func buildPreSyncTask(prefix string, index int, state *druidv1alpha1.TaskState) 
 	return task
 }
 
-func buildStatefulSetWithImage(objMeta metav1.ObjectMeta, replicas int32, image string) *appsv1.StatefulSet {
+func buildStatefulSetWithImages(objMeta metav1.ObjectMeta, replicas int32, images map[string]string) *appsv1.StatefulSet {
+	containers := make([]corev1.Container, 0, 2)
+	if img, ok := images[common.ContainerNameEtcd]; ok {
+		containers = append(containers, corev1.Container{
+			Name:  common.ContainerNameEtcd,
+			Image: img,
+		})
+	}
+	if img, ok := images[common.ContainerNameEtcdBackupRestore]; ok {
+		containers = append(containers, corev1.Container{
+			Name:  common.ContainerNameEtcdBackupRestore,
+			Image: img,
+		})
+	}
+	var initContainers []corev1.Container
+	if img, ok := images[common.InitContainerNameChangeBackupBucketPermissions]; ok {
+		initContainers = append(initContainers, corev1.Container{
+			Name:  common.InitContainerNameChangeBackupBucketPermissions,
+			Image: img,
+		})
+	}
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      objMeta.Name,
@@ -434,12 +454,8 @@ func buildStatefulSetWithImage(objMeta metav1.ObjectMeta, replicas int32, image 
 			},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  common.ContainerNameEtcd,
-							Image: image,
-						},
-					},
+					InitContainers: initContainers,
+					Containers:     containers,
 				},
 			},
 		},

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -103,7 +103,7 @@ func TestPreSync(t *testing.T) {
 		etcdReplicas    int32
 		stsImages       map[string]string // keyed by container name; nil = use current image-vector defaults for all containers
 		existingTasks   []*druidv1alpha1.EtcdOpsTask
-		skipAnnotation  bool // when true, sets the skip-next-update-snapshot annotation on the Etcd
+		skipAnnotation  bool // when true, sets the skip-spec-update-snapshot annotation on the Etcd
 		expectedErrCode *druidapicommon.ErrorCode
 		expectNoTasks   bool // when true, asserts that no EtcdOpsTask exists after PreSync
 		expectExhausted bool // when true, asserts the exhaustion flag is set in OperatorContext.Data
@@ -276,6 +276,15 @@ func TestPreSync(t *testing.T) {
 			skipAnnotation: true,
 			expectNoTasks:  true,
 		},
+		{
+			name:           "skip annotation short-circuits even when no image or replica change",
+			backupEnabled:  true,
+			stsExists:      true,
+			stsReplicas:    3,
+			etcdReplicas:   3,
+			skipAnnotation: true,
+			expectNoTasks:  true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -288,7 +297,7 @@ func TestPreSync(t *testing.T) {
 				etcdBuilder = etcdBuilder.WithoutProvider()
 			}
 			if tc.skipAnnotation {
-				etcdBuilder = etcdBuilder.WithAnnotations(map[string]string{druidv1alpha1.SkipNextUpdateSnapshotAnnotation: ""})
+				etcdBuilder = etcdBuilder.WithAnnotations(map[string]string{druidv1alpha1.SkipSpecUpdateSnapshotAnnotation: ""})
 			}
 			etcd := etcdBuilder.Build()
 
@@ -305,10 +314,6 @@ func TestPreSync(t *testing.T) {
 			maps.Copy(stsImages, tc.stsImages)
 
 			var existingObjects []client.Object
-			if tc.skipAnnotation {
-				// The annotation-removal patch in PreSync requires the Etcd object to exist in the API.
-				existingObjects = append(existingObjects, etcd)
-			}
 			if tc.stsExists {
 				existingObjects = append(existingObjects, buildStatefulSetWithImages(etcd.ObjectMeta, tc.stsReplicas, stsImages))
 			}
@@ -341,10 +346,8 @@ func TestPreSync(t *testing.T) {
 			}
 
 			if tc.skipAnnotation {
-				// The one-shot annotation must be removed by PreSync once the skip is applied.
-				updatedEtcd := &druidv1alpha1.Etcd{}
-				g.Expect(cl.Get(opCtx, client.ObjectKeyFromObject(etcd), updatedEtcd)).To(Succeed())
-				g.Expect(updatedEtcd.Annotations).ToNot(HaveKey(druidv1alpha1.SkipNextUpdateSnapshotAnnotation))
+				// etcd-druid never removes the skip annotation; it must remain on the resource after PreSync.
+				g.Expect(etcd.Annotations).To(HaveKey(druidv1alpha1.SkipSpecUpdateSnapshotAnnotation))
 			}
 
 			_, exhausted := opCtx.Data[common.KeyPreSyncSnapshotExhausted]

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -7,10 +7,10 @@ package statefulset
 import (
 	"context"
 	"fmt"
+	"maps"
 	"testing"
 
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
-	druidconfigv1alpha1 "github.com/gardener/etcd-druid/api/config/v1alpha1"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/client/kubernetes"
 	"github.com/gardener/etcd-druid/internal/common"
@@ -90,21 +90,22 @@ func TestGetExistingResourceNames(t *testing.T) {
 // ----------------------------------- PreSync -----------------------------------
 func TestPreSync(t *testing.T) {
 	const (
-		oldImage     = "europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:v0.6.2"
-		currentImage = ""
+		oldWrapperImage       = "europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:v0.6.2"
+		oldBackupRestoreImage = "europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:v0.30.0"
+		oldInitImage          = "europe-docker.pkg.dev/gardener-project/public/3rd/alpine:3.18.4"
 	)
 
 	testCases := []struct {
-		name               string
-		backupEnabled      bool
-		stsExists          bool
-		featureGateEnabled bool
-		stsReplicas        int32
-		etcdReplicas       int32
-		etcdWrapperImage   string
-		existingTasks      []*druidv1alpha1.EtcdOpsTask
-		expectedErrCode    *druidapicommon.ErrorCode
+		name            string
+		backupEnabled   bool
+		stsExists       bool
+		stsReplicas     int32
+		etcdReplicas    int32
+		stsImages       map[string]string // keyed by container name; nil = use current image-vector defaults for all containers
+		existingTasks   []*druidv1alpha1.EtcdOpsTask
+		expectedErrCode *druidapicommon.ErrorCode
 	}{
+		// ---------------- No-op rows ----------------
 		{
 			name:          "returns nil when backup is disabled",
 			backupEnabled: false,
@@ -119,147 +120,142 @@ func TestPreSync(t *testing.T) {
 			etcdReplicas:  3,
 		},
 		{
-			name:               "returns nil when no hibernation and no upgrade",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   currentImage,
+			name:          "returns nil when STS replicas are 0",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   0,
+			etcdReplicas:  3,
 		},
 		{
-			name:               "hibernation succeeds when task completed",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: false,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   currentImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			name:          "returns nil when no image change and no replica change",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  3,
+		},
+		// ---------------- Hibernation rows (regression) ----------------
+		{
+			name:            "hibernation requeues when no task exists",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    0,
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "hibernation proceeds after max retries exceeded",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: false,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   currentImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			name:          "hibernation succeeds when task completed",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  0,
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
-			name:               "hibernation with upgrade succeeds when task completed",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			name:          "hibernation proceeds after max retries exceeded",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  0,
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+		},
+		// ---------------- Image-change rows ----------------
+		{
+			name:            "update requeues when wrapper image changed and no task exists",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "hibernation with upgrade proceeds after max retries exceeded",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			name:            "update requeues when backup-restore image changed and no task exists",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.ContainerNameEtcdBackupRestore: oldBackupRestoreImage},
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "upgrade succeeds when task completed",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			name:            "update requeues when init-container image changed and no task exists",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.InitContainerNameChangeBackupBucketPermissions: oldInitImage},
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "upgrade proceeds after max retries exceeded",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			name:          "update succeeds when task completed",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  3,
+			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
-			name:               "hibernation requeues when no task exists",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: false,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   currentImage,
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+			name:          "update proceeds after max retries exceeded",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  3,
+			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
 		},
 		{
-			name:               "hibernation requeues when task is in progress",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: false,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   currentImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+			name:            "update requeues when task is in progress",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "hibernation requeues when task failed and retries remain",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: false,
-			stsReplicas:        3,
-			etcdReplicas:       0,
-			etcdWrapperImage:   currentImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+			name:            "update requeues when task failed and retries remain",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+		},
+		// ---------------- Replica-change rows ----------------
+		{
+			name:            "update requeues when replicas scale up (3->5)",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    5,
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
-			name:               "upgrade requeues when no task exists",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   oldImage,
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+			name:            "update requeues when replicas scale down to non-zero (5->3)",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     5,
+			etcdReplicas:    3,
+			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
+		// ---------------- Combination row ----------------
 		{
-			name:               "upgrade requeues when task is in progress",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
-		},
-		{
-			name:               "upgrade requeues when task failed and retries remain",
-			backupEnabled:      true,
-			stsExists:          true,
-			featureGateEnabled: true,
-			stsReplicas:        3,
-			etcdReplicas:       3,
-			etcdWrapperImage:   oldImage,
-			existingTasks:      []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
-			expectedErrCode:    ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
+			name:          "hibernation prefix wins when replicas go to 0 even if images also changed",
+			backupEnabled: true,
+			stsExists:     true,
+			stsReplicas:   3,
+			etcdReplicas:  0,
+			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := druidconfigv1alpha1.DefaultFeatureGates.SetEnabledFeaturesFromMap(
-				map[string]bool{druidconfigv1alpha1.UpgradeEtcdVersion: tc.featureGateEnabled},
-			)
-			g.Expect(err).ToNot(HaveOccurred())
 
 			etcdBuilder := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).
 				WithReplicas(tc.etcdReplicas)
@@ -270,15 +266,19 @@ func TestPreSync(t *testing.T) {
 
 			iv := testutils.CreateImageVector(true, true)
 
-			etcdWrapperImage := tc.etcdWrapperImage
-			if etcdWrapperImage == currentImage {
-				etcdWrapperImage, _, _, err = utils.GetEtcdImages(etcd, iv)
-				g.Expect(err).ToNot(HaveOccurred())
+			defaultWrapperImage, defaultBRImage, defaultInitImage, err := utils.GetEtcdImages(etcd, iv)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			stsImages := map[string]string{
+				common.ContainerNameEtcd:                              defaultWrapperImage,
+				common.ContainerNameEtcdBackupRestore:                 defaultBRImage,
+				common.InitContainerNameChangeBackupBucketPermissions: defaultInitImage,
 			}
+			maps.Copy(stsImages, tc.stsImages)
 
 			var existingObjects []client.Object
 			if tc.stsExists {
-				existingObjects = append(existingObjects, buildStatefulSetWithImage(etcd.ObjectMeta, tc.stsReplicas, etcdWrapperImage))
+				existingObjects = append(existingObjects, buildStatefulSetWithImages(etcd.ObjectMeta, tc.stsReplicas, stsImages))
 			}
 			for _, task := range tc.existingTasks {
 				existingObjects = append(existingObjects, task)
@@ -475,7 +475,27 @@ func buildPreSyncTask(prefix string, index int, state *druidv1alpha1.TaskState) 
 	return task
 }
 
-func buildStatefulSetWithImage(objMeta metav1.ObjectMeta, replicas int32, image string) *appsv1.StatefulSet {
+func buildStatefulSetWithImages(objMeta metav1.ObjectMeta, replicas int32, images map[string]string) *appsv1.StatefulSet {
+	containers := make([]corev1.Container, 0, 2)
+	if img, ok := images[common.ContainerNameEtcd]; ok {
+		containers = append(containers, corev1.Container{
+			Name:  common.ContainerNameEtcd,
+			Image: img,
+		})
+	}
+	if img, ok := images[common.ContainerNameEtcdBackupRestore]; ok {
+		containers = append(containers, corev1.Container{
+			Name:  common.ContainerNameEtcdBackupRestore,
+			Image: img,
+		})
+	}
+	var initContainers []corev1.Container
+	if img, ok := images[common.InitContainerNameChangeBackupBucketPermissions]; ok {
+		initContainers = append(initContainers, corev1.Container{
+			Name:  common.InitContainerNameChangeBackupBucketPermissions,
+			Image: img,
+		})
+	}
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      objMeta.Name,
@@ -491,12 +511,8 @@ func buildStatefulSetWithImage(objMeta metav1.ObjectMeta, replicas int32, image 
 			},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  common.ContainerNameEtcd,
-							Image: image,
-						},
-					},
+					InitContainers: initContainers,
+					Containers:     containers,
 				},
 			},
 		},

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -106,7 +106,7 @@ func TestPreSync(t *testing.T) {
 		skipAnnotation  bool // when true, sets the skip-spec-update-snapshot annotation on the Etcd
 		expectedErrCode *druidapicommon.ErrorCode
 		expectNoTasks   bool // when true, asserts that no EtcdOpsTask exists after PreSync
-		expectExhausted bool // when true, asserts the exhaustion flag is set in OperatorContext.Data
+		expectedFailure bool // when true, asserts the failure flag is set in OperatorContext.Data
 	}{
 		{
 			name:          "returns nil when backup is disabled",
@@ -149,7 +149,7 @@ func TestPreSync(t *testing.T) {
 			stsExists:     true,
 			stsReplicas:   3,
 			etcdReplicas:  0,
-			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskHibernationPrefix, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
 			name:            "hibernation proceeds after max retries exceeded",
@@ -157,8 +157,8 @@ func TestPreSync(t *testing.T) {
 			stsExists:       true,
 			stsReplicas:     3,
 			etcdReplicas:    0,
-			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
-			expectExhausted: true,
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskHibernationPrefix, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			expectedFailure: true,
 		},
 		{
 			name:            "update requeues when wrapper image changed and no task exists",
@@ -194,7 +194,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:   3,
 			etcdReplicas:  3,
 			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskUpdatePrefix, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
 			name:            "update proceeds after max retries exceeded",
@@ -203,8 +203,8 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:     3,
 			etcdReplicas:    3,
 			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
-			expectExhausted: true,
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskUpdatePrefix, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			expectedFailure: true,
 		},
 		{
 			name:            "update requeues when task is in progress",
@@ -213,7 +213,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:     3,
 			etcdReplicas:    3,
 			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskUpdatePrefix, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
 			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
@@ -223,7 +223,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:     3,
 			etcdReplicas:    3,
 			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskUpdatePrefix, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
 			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
@@ -249,7 +249,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:   3,
 			etcdReplicas:  0,
 			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskHibernationPrefix, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
 			name:           "update skipped when skip annotation present (image change)",
@@ -344,8 +344,8 @@ func TestPreSync(t *testing.T) {
 				g.Expect(etcd.Annotations).To(HaveKey(druidv1alpha1.SkipSpecUpdateSnapshotAnnotation))
 			}
 
-			_, exhausted := opCtx.Data[common.KeyPreSyncSnapshotExhausted]
-			g.Expect(exhausted).To(Equal(tc.expectExhausted))
+			_, isSnapshotFailed := opCtx.Data[common.KeyPreSyncSnapshotFailed]
+			g.Expect(isSnapshotFailed).To(Equal(tc.expectedFailure))
 		})
 	}
 }

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -149,7 +149,7 @@ func TestPreSync(t *testing.T) {
 			stsExists:     true,
 			stsReplicas:   3,
 			etcdReplicas:  0,
-			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskHibernationPrefix, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(fmt.Sprintf("%s%d-", preSyncTaskHibernationPrefix, 0), 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
 			name:            "hibernation proceeds after max retries exceeded",
@@ -157,7 +157,7 @@ func TestPreSync(t *testing.T) {
 			stsExists:       true,
 			stsReplicas:     3,
 			etcdReplicas:    0,
-			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskHibernationPrefix, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(fmt.Sprintf("%s%d-", preSyncTaskHibernationPrefix, 0), maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
 			expectedFailure: true,
 		},
 		{
@@ -194,7 +194,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:   3,
 			etcdReplicas:  3,
 			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskUpdatePrefix, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(fmt.Sprintf("%s%d-", preSyncTaskUpdatePrefix, 0), 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
 			name:            "update proceeds after max retries exceeded",
@@ -203,7 +203,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:     3,
 			etcdReplicas:    3,
 			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskUpdatePrefix, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(fmt.Sprintf("%s%d-", preSyncTaskUpdatePrefix, 0), maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
 			expectedFailure: true,
 		},
 		{
@@ -213,7 +213,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:     3,
 			etcdReplicas:    3,
 			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskUpdatePrefix, 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(fmt.Sprintf("%s%d-", preSyncTaskUpdatePrefix, 0), 0, ptr.To(druidv1alpha1.TaskStateInProgress))},
 			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
@@ -223,7 +223,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:     3,
 			etcdReplicas:    3,
 			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskUpdatePrefix, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(fmt.Sprintf("%s%d-", preSyncTaskUpdatePrefix, 0), 1, ptr.To(druidv1alpha1.TaskStateFailed))},
 			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
 		{
@@ -249,7 +249,7 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:   3,
 			etcdReplicas:  0,
 			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskHibernationPrefix, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
+			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(fmt.Sprintf("%s%d-", preSyncTaskHibernationPrefix, 0), 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
 			name:           "update skipped when skip annotation present (image change)",

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -103,7 +103,10 @@ func TestPreSync(t *testing.T) {
 		etcdReplicas    int32
 		stsImages       map[string]string // keyed by container name; nil = use current image-vector defaults for all containers
 		existingTasks   []*druidv1alpha1.EtcdOpsTask
+		skipAnnotation  bool // when true, sets the skip-next-update-snapshot annotation on the Etcd
 		expectedErrCode *druidapicommon.ErrorCode
+		expectNoTasks   bool // when true, asserts that no EtcdOpsTask exists after PreSync
+		expectExhausted bool // when true, asserts the exhaustion flag is set in OperatorContext.Data
 	}{
 		// ---------------- No-op rows ----------------
 		{
@@ -151,12 +154,13 @@ func TestPreSync(t *testing.T) {
 			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
-			name:          "hibernation proceeds after max retries exceeded",
-			backupEnabled: true,
-			stsExists:     true,
-			stsReplicas:   3,
-			etcdReplicas:  0,
-			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			name:            "hibernation proceeds after max retries exceeded",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    0,
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			expectExhausted: true,
 		},
 		// ---------------- Image-change rows ----------------
 		{
@@ -196,13 +200,14 @@ func TestPreSync(t *testing.T) {
 			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
 		{
-			name:          "update proceeds after max retries exceeded",
-			backupEnabled: true,
-			stsExists:     true,
-			stsReplicas:   3,
-			etcdReplicas:  3,
-			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
-			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			name:            "update proceeds after max retries exceeded",
+			backupEnabled:   true,
+			stsExists:       true,
+			stsReplicas:     3,
+			etcdReplicas:    3,
+			stsImages:       map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
+			expectExhausted: true,
 		},
 		{
 			name:            "update requeues when task is in progress",
@@ -251,6 +256,26 @@ func TestPreSync(t *testing.T) {
 			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
 			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
+		// ---------------- Skip-annotation rows ----------------
+		{
+			name:           "update skipped when skip annotation present (image change)",
+			backupEnabled:  true,
+			stsExists:      true,
+			stsReplicas:    3,
+			etcdReplicas:   3,
+			stsImages:      map[string]string{common.ContainerNameEtcd: oldWrapperImage},
+			skipAnnotation: true,
+			expectNoTasks:  true,
+		},
+		{
+			name:           "update skipped when skip annotation present (replica change)",
+			backupEnabled:  true,
+			stsExists:      true,
+			stsReplicas:    3,
+			etcdReplicas:   5,
+			skipAnnotation: true,
+			expectNoTasks:  true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -261,6 +286,9 @@ func TestPreSync(t *testing.T) {
 				WithReplicas(tc.etcdReplicas)
 			if !tc.backupEnabled {
 				etcdBuilder = etcdBuilder.WithoutProvider()
+			}
+			if tc.skipAnnotation {
+				etcdBuilder = etcdBuilder.WithAnnotations(map[string]string{druidv1alpha1.SkipNextUpdateSnapshotAnnotation: ""})
 			}
 			etcd := etcdBuilder.Build()
 
@@ -277,6 +305,10 @@ func TestPreSync(t *testing.T) {
 			maps.Copy(stsImages, tc.stsImages)
 
 			var existingObjects []client.Object
+			if tc.skipAnnotation {
+				// The annotation-removal patch in PreSync requires the Etcd object to exist in the API.
+				existingObjects = append(existingObjects, etcd)
+			}
 			if tc.stsExists {
 				existingObjects = append(existingObjects, buildStatefulSetWithImages(etcd.ObjectMeta, tc.stsReplicas, stsImages))
 			}
@@ -301,6 +333,22 @@ func TestPreSync(t *testing.T) {
 				g.Expect(druidErr).ToNot(BeNil())
 				g.Expect(druidErr.Code).To(Equal(*tc.expectedErrCode))
 			}
+
+			if tc.expectNoTasks {
+				taskList := &druidv1alpha1.EtcdOpsTaskList{}
+				g.Expect(cl.List(opCtx, taskList, client.InNamespace(etcd.Namespace))).To(Succeed())
+				g.Expect(taskList.Items).To(BeEmpty(), "expected no EtcdOpsTask to be created when the update snapshot is skipped")
+			}
+
+			if tc.skipAnnotation {
+				// The one-shot annotation must be removed by PreSync once the skip is applied.
+				updatedEtcd := &druidv1alpha1.Etcd{}
+				g.Expect(cl.Get(opCtx, client.ObjectKeyFromObject(etcd), updatedEtcd)).To(Succeed())
+				g.Expect(updatedEtcd.Annotations).ToNot(HaveKey(druidv1alpha1.SkipNextUpdateSnapshotAnnotation))
+			}
+
+			_, exhausted := opCtx.Data[common.KeyPreSyncSnapshotExhausted]
+			g.Expect(exhausted).To(Equal(tc.expectExhausted))
 		})
 	}
 }

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -108,7 +108,6 @@ func TestPreSync(t *testing.T) {
 		expectNoTasks   bool // when true, asserts that no EtcdOpsTask exists after PreSync
 		expectExhausted bool // when true, asserts the exhaustion flag is set in OperatorContext.Data
 	}{
-		// ---------------- No-op rows ----------------
 		{
 			name:          "returns nil when backup is disabled",
 			backupEnabled: false,
@@ -136,7 +135,6 @@ func TestPreSync(t *testing.T) {
 			stsReplicas:   3,
 			etcdReplicas:  3,
 		},
-		// ---------------- Hibernation rows ----------------
 		{
 			name:            "hibernation requeues when no task exists",
 			backupEnabled:   true,
@@ -162,7 +160,6 @@ func TestPreSync(t *testing.T) {
 			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, maxPreSyncRetries-1, ptr.To(druidv1alpha1.TaskStateFailed))},
 			expectExhausted: true,
 		},
-		// ---------------- Image-change rows ----------------
 		{
 			name:            "update requeues when wrapper image changed and no task exists",
 			backupEnabled:   true,
@@ -229,7 +226,6 @@ func TestPreSync(t *testing.T) {
 			existingTasks:   []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixUpdate, 1, ptr.To(druidv1alpha1.TaskStateFailed))},
 			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
-		// ---------------- Replica-change rows ----------------
 		{
 			name:            "update requeues when replicas scale up (3->5)",
 			backupEnabled:   true,
@@ -246,7 +242,6 @@ func TestPreSync(t *testing.T) {
 			etcdReplicas:    3,
 			expectedErrCode: ptr.To(druidapicommon.ErrorCode(druiderr.ErrRequeueAfter)),
 		},
-		// ---------------- Combination row ----------------
 		{
 			name:          "hibernation prefix wins when replicas go to 0 even if images also changed",
 			backupEnabled: true,
@@ -256,7 +251,6 @@ func TestPreSync(t *testing.T) {
 			stsImages:     map[string]string{common.ContainerNameEtcd: oldWrapperImage},
 			existingTasks: []*druidv1alpha1.EtcdOpsTask{buildPreSyncTask(preSyncTaskPrefixHibernation, 0, ptr.To(druidv1alpha1.TaskStateSucceeded))},
 		},
-		// ---------------- Skip-annotation rows ----------------
 		{
 			name:           "update skipped when skip annotation present (image change)",
 			backupEnabled:  true,

--- a/internal/controller/etcd/reconcile_spec.go
+++ b/internal/controller/etcd/reconcile_spec.go
@@ -71,7 +71,7 @@ func (r *Reconciler) preSyncEtcdResources(ctx component.OperatorContext, etcd *d
 	}
 	// If a pre-sync snapshot exhausted its retries, the component proceeded with the update without a fresh snapshot.
 	// Surface this via a warning event so operators are aware the update rolled without a safety snapshot.
-	if _, exhausted := ctx.Data[common.KeyPreSyncSnapshotExhausted]; exhausted {
+	if _, isSnapshotFailed := ctx.Data[common.KeyPreSyncSnapshotFailed]; isSnapshotFailed {
 		r.recorder.Eventf(etcd, corev1.EventTypeWarning, "PreSyncSnapshotFailed",
 			"pre-sync full snapshot for %s/%s failed after max attempts; proceeding with StatefulSet update without a fresh snapshot",
 			etcd.Namespace, etcd.Name)

--- a/internal/controller/etcd/reconcile_spec.go
+++ b/internal/controller/etcd/reconcile_spec.go
@@ -10,6 +10,7 @@ import (
 
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	"github.com/gardener/etcd-druid/internal/common"
 	"github.com/gardener/etcd-druid/internal/component"
 	ctrlutils "github.com/gardener/etcd-druid/internal/controller/utils"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
@@ -67,6 +68,13 @@ func (r *Reconciler) preSyncEtcdResources(ctx component.OperatorContext, etcd *d
 			ctx.Logger.Error(err, "failed to sync etcd resource", "kind", kind)
 			return ctrlutils.ReconcileWithError(err)
 		}
+	}
+	// If a pre-sync snapshot exhausted its retries, the component proceeded with the update without a fresh snapshot.
+	// Surface this via a warning event so operators are aware the update rolled without a safety snapshot.
+	if _, exhausted := ctx.Data[common.KeyPreSyncSnapshotExhausted]; exhausted {
+		r.recorder.Eventf(etcd, corev1.EventTypeWarning, "PreSyncSnapshotFailed",
+			"pre-sync full snapshot for %s/%s failed after max attempts; proceeding with StatefulSet update without a fresh snapshot",
+			etcd.Namespace, etcd.Name)
 	}
 	return ctrlutils.ContinueReconcile()
 }

--- a/test/it/controller/etcd/assertions.go
+++ b/test/it/controller/etcd/assertions.go
@@ -15,6 +15,7 @@ import (
 
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	"github.com/gardener/etcd-druid/internal/common"
 	"github.com/gardener/etcd-druid/internal/component"
 	"github.com/gardener/etcd-druid/internal/controller/etcd"
 	"github.com/gardener/etcd-druid/internal/utils"
@@ -495,4 +496,21 @@ func simulatePreSyncTaskCompletion(ctx context.Context, t *testing.T, cl client.
 	task.Status.State = &state
 	task.Status.LastTransitionTime = ptr.To(metav1.Now())
 	g.Expect(cl.Status().Update(ctx, task)).To(Succeed())
+}
+
+// assertEtcdContainerImage waits until the StatefulSet's etcd container image matches the expected value.
+func assertEtcdContainerImage(ctx context.Context, t *testing.T, cl client.Client, stsObjectKey client.ObjectKey, expectedImage string, timeout, pollInterval time.Duration) {
+	g := NewWithT(t)
+	g.Eventually(func() string {
+		sts := &appsv1.StatefulSet{}
+		if err := cl.Get(ctx, stsObjectKey, sts); err != nil {
+			return ""
+		}
+		for _, c := range sts.Spec.Template.Spec.Containers {
+			if c.Name == common.ContainerNameEtcd {
+				return c.Image
+			}
+		}
+		return ""
+	}).WithContext(ctx).WithTimeout(timeout).WithPolling(pollInterval).Should(Equal(expectedImage))
 }

--- a/test/it/controller/etcd/assertions.go
+++ b/test/it/controller/etcd/assertions.go
@@ -488,6 +488,41 @@ func assertPreSyncTaskCreated(ctx context.Context, t *testing.T, cl client.Clien
 	g.Eventually(checkFn).Within(timeout).WithPolling(pollInterval).WithContext(ctx).Should(Succeed())
 }
 
+// assertPreSyncTaskNotCreated asserts that no pre-sync EtcdOpsTask with the given name is created within the given duration.
+func assertPreSyncTaskNotCreated(ctx context.Context, t *testing.T, cl client.Client, namespace, taskName string, duration, pollInterval time.Duration) {
+	g := NewWithT(t)
+	checkFn := func() error {
+		task := &druidv1alpha1.EtcdOpsTask{}
+		err := cl.Get(ctx, client.ObjectKey{Name: taskName, Namespace: namespace}, task)
+		if err == nil {
+			return fmt.Errorf("expected EtcdOpsTask %s to not be created, but it exists", taskName)
+		}
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+	g.Consistently(checkFn).Within(duration).WithPolling(pollInterval).WithContext(ctx).Should(Succeed())
+}
+
+// assertPreSyncSnapshotFailedEventRecorded asserts that a Warning event with reason PreSyncSnapshotFailed is recorded on the Etcd resource.
+func assertPreSyncSnapshotFailedEventRecorded(ctx context.Context, t *testing.T, cl client.Client, etcdObjectKey client.ObjectKey, timeout, pollInterval time.Duration) {
+	g := NewWithT(t)
+	checkFn := func() error {
+		events := &corev1.EventList{}
+		if err := cl.List(ctx, events, client.InNamespace(etcdObjectKey.Namespace), client.MatchingFields{"involvedObject.name": etcdObjectKey.Name, "type": "Warning"}); err != nil {
+			return err
+		}
+		for _, e := range events.Items {
+			if e.Reason == "PreSyncSnapshotFailed" {
+				return nil
+			}
+		}
+		return fmt.Errorf("expected a Warning event with reason PreSyncSnapshotFailed, found none")
+	}
+	g.Eventually(checkFn).Within(timeout).WithPolling(pollInterval).Should(Succeed())
+}
+
 // simulatePreSyncTaskCompletion simulates the completion of a pre-sync task by updating its status to the given state.
 func simulatePreSyncTaskCompletion(ctx context.Context, t *testing.T, cl client.Client, namespace, taskName string, state druidv1alpha1.TaskState) {
 	g := NewWithT(t)

--- a/test/it/controller/etcd/reconciler_test.go
+++ b/test/it/controller/etcd/reconciler_test.go
@@ -585,6 +585,90 @@ func testPreSyncHibernationProceedsAfterMaxRetries(t *testing.T, testNs string, 
 	t.Log("StatefulSet replicas successfully scaled to 0 after max retries exceeded")
 }
 
+// ------------------------------ presync image change tests ------------------------------
+
+func TestPreSyncImageChange(t *testing.T) {
+	g := NewWithT(t)
+
+	// A different IT test environment is required since an additional CRD for the EtcdOpsTask needs to be installed.
+	k8sVersion, err := assets.GetK8sVersionFromEnv()
+	g.Expect(err).ToNot(HaveOccurred())
+	etcdCrd, err := assets.GetEtcdCrd(k8sVersion)
+	g.Expect(err).ToNot(HaveOccurred())
+	etcdOpsTaskCrd, err := assets.GetEtcdOpsTaskCrd(k8sVersion)
+	g.Expect(err).ToNot(HaveOccurred())
+	itTestEnv, itTestEnvCloser, err := setup.NewDruidTestEnvironment("etcd-presync-image-change", []*apiextensionsv1.CustomResourceDefinition{etcdCrd, etcdOpsTaskCrd})
+	g.Expect(err).ToNot(HaveOccurred())
+	defer itTestEnvCloser()
+
+	reconcilerTestEnv := initializeEtcdReconcilerTestEnv(t, "etcd-controller-presync-image-change", itTestEnv, false, testutils.NewTestClientBuilder())
+	tests := []struct {
+		name string
+		fn   func(t *testing.T, testNamespace string, reconcilerTestEnv ReconcilerTestEnv)
+	}{
+		{"should succeed with image change after presync task completes", testPreSyncImageChangeSucceeds},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testNs := testutils.GenerateTestNamespaceName(t, testNamespacePrefix, 8)
+			t.Logf("successfully create namespace: %s to run test => '%s'", testNs, t.Name())
+			g.Expect(itTestEnv.CreateTestNamespace(testNs)).To(Succeed())
+			test.fn(t, testNs, reconcilerTestEnv)
+		})
+	}
+}
+
+func testPreSyncImageChangeSucceeds(t *testing.T, testNs string, reconcilerTestEnv ReconcilerTestEnv) {
+	const (
+		timeout         = time.Minute * 3
+		pollingInterval = time.Second * 2
+	)
+
+	g := NewWithT(t)
+	etcdInstance := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testNs).
+		WithClientTLS().
+		WithPeerTLS().
+		WithReplicas(3).
+		Build()
+	g.Expect(etcdInstance.Spec.Backup.Store).ToNot(BeNil())
+	g.Expect(etcdInstance.Spec.Backup.Store.SecretRef).ToNot(BeNil())
+	cl := reconcilerTestEnv.itTestEnv.GetClient()
+	ctx := context.Background()
+	g.Expect(testutils.CreateSecrets(ctx, cl, testNs, etcdInstance.Spec.Backup.Store.SecretRef.Name)).To(Succeed())
+	createAndAssertEtcdReconciliation(ctx, t, reconcilerTestEnv, etcdInstance)
+
+	// mark member leases as TLS-enabled so subsequent reconciles do not requeue on the peer-URL TLS check.
+	memberLeaseNames := druidv1alpha1.GetMemberLeaseNames(etcdInstance)
+	mlcs := []etcdMemberLeaseConfig{
+		{name: memberLeaseNames[0], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+		{name: memberLeaseNames[1], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+		{name: memberLeaseNames[2], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+	}
+	updateMemberLeases(ctx, t, cl, testNs, mlcs)
+
+	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
+	newImage := "europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:v0.6.99-test"
+	etcdInstance.Spec.Etcd.Image = &newImage
+	etcdInstance.Annotations = map[string]string{druidv1alpha1.DruidOperationAnnotation: druidv1alpha1.DruidOperationReconcile}
+	g.Expect(cl.Update(ctx, etcdInstance)).To(Succeed())
+	t.Log("triggered image change by patching Spec.Etcd.Image")
+
+	assertPreSyncTaskCreated(ctx, t, cl, testNs, "presync-snapshot-update-0", timeout, pollingInterval)
+	t.Log("presync etcdopstask created")
+
+	task := &druidv1alpha1.EtcdOpsTask{}
+	g.Expect(cl.Get(ctx, client.ObjectKey{Name: "presync-snapshot-update-0", Namespace: testNs}, task)).To(Succeed())
+	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
+	g.Expect(task.OwnerReferences).To(ContainElement(druidv1alpha1.GetAsOwnerReference(etcdInstance.ObjectMeta)))
+	t.Log("presync etcdopstask has correct owner reference to etcd instance")
+
+	simulatePreSyncTaskCompletion(ctx, t, cl, testNs, "presync-snapshot-update-0", druidv1alpha1.TaskStateSucceeded)
+	t.Log("simulated presync task completion with Succeeded state")
+
+	assertEtcdContainerImage(ctx, t, cl, client.ObjectKeyFromObject(etcdInstance), newImage, timeout, pollingInterval)
+	t.Log("StatefulSet etcd container image successfully rolled to new tag")
+}
+
 // ------------------------------ reconcile status tests ------------------------------
 
 func TestEtcdStatusReconciliation(t *testing.T) {

--- a/test/it/controller/etcd/reconciler_test.go
+++ b/test/it/controller/etcd/reconciler_test.go
@@ -528,18 +528,21 @@ func testPreSyncHibernationSucceeds(t *testing.T, testNs string, reconcilerTestE
 	etcdInstance.Spec.Replicas = 0
 	etcdInstance.Annotations = map[string]string{druidv1alpha1.DruidOperationAnnotation: druidv1alpha1.DruidOperationReconcile}
 	g.Expect(cl.Update(ctx, etcdInstance)).To(Succeed())
+	// read the etcdInstance freshly to get the updated generation
+	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
+	presyncHibernationTaskName0 := fmt.Sprintf("presync-snapshot-hibernation-%d-0", etcdInstance.Generation)
 	t.Log("triggered hibernation by setting replicas to 0")
 
-	assertPreSyncTaskCreated(ctx, t, cl, testNs, "presync-snapshot-hibernation-0", timeout, pollingInterval)
+	assertPreSyncTaskCreated(ctx, t, cl, testNs, presyncHibernationTaskName0, timeout, pollingInterval)
 	t.Log("presync etcdopstask created")
 
 	task := &druidv1alpha1.EtcdOpsTask{}
-	g.Expect(cl.Get(ctx, client.ObjectKey{Name: "presync-snapshot-hibernation-0", Namespace: testNs}, task)).To(Succeed())
+	g.Expect(cl.Get(ctx, client.ObjectKey{Name: presyncHibernationTaskName0, Namespace: testNs}, task)).To(Succeed())
 	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
 	g.Expect(task.OwnerReferences).To(ContainElement(druidv1alpha1.GetAsOwnerReference(etcdInstance.ObjectMeta)))
 	t.Log("presync etcdopstask has correct owner reference to etcd instance")
 
-	simulatePreSyncTaskCompletion(ctx, t, cl, testNs, "presync-snapshot-hibernation-0", druidv1alpha1.TaskStateSucceeded)
+	simulatePreSyncTaskCompletion(ctx, t, cl, testNs, presyncHibernationTaskName0, druidv1alpha1.TaskStateSucceeded)
 	t.Log("simulated presync task completion with Succeeded state")
 
 	assertStatefulSetReplicas(ctx, t, cl, client.ObjectKeyFromObject(etcdInstance), 0, timeout, pollingInterval)
@@ -570,10 +573,12 @@ func testPreSyncHibernationProceedsAfterMaxRetries(t *testing.T, testNs string, 
 	etcdInstance.Spec.Replicas = 0
 	etcdInstance.Annotations = map[string]string{druidv1alpha1.DruidOperationAnnotation: druidv1alpha1.DruidOperationReconcile}
 	g.Expect(cl.Update(ctx, etcdInstance)).To(Succeed())
+	// read the etcdInstance freshly to get the updated generation
+	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
 	t.Log("triggered hibernation by setting replicas to 0")
 
 	for i := range 3 {
-		taskName := fmt.Sprintf("presync-snapshot-hibernation-%d", i)
+		taskName := fmt.Sprintf("presync-snapshot-hibernation-%d-%d", etcdInstance.Generation, i)
 		assertPreSyncTaskCreated(ctx, t, cl, testNs, taskName, timeout, pollingInterval)
 		t.Logf("presync etcdopstask  created")
 
@@ -653,18 +658,21 @@ func testPreSyncImageChangeSucceeds(t *testing.T, testNs string, reconcilerTestE
 	etcdInstance.Spec.Etcd.Image = &newImage
 	etcdInstance.Annotations = map[string]string{druidv1alpha1.DruidOperationAnnotation: druidv1alpha1.DruidOperationReconcile}
 	g.Expect(cl.Update(ctx, etcdInstance)).To(Succeed())
+	// read the etcdInstance freshly to get the updated generation
+	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
+	presyncUpdateTaskName0 := fmt.Sprintf("presync-snapshot-update-%d-0", etcdInstance.Generation)
 	t.Log("triggered image change by patching Spec.Etcd.Image")
 
-	assertPreSyncTaskCreated(ctx, t, cl, testNs, "presync-snapshot-update-0", timeout, pollingInterval)
+	assertPreSyncTaskCreated(ctx, t, cl, testNs, presyncUpdateTaskName0, timeout, pollingInterval)
 	t.Log("presync etcdopstask created")
 
 	task := &druidv1alpha1.EtcdOpsTask{}
-	g.Expect(cl.Get(ctx, client.ObjectKey{Name: "presync-snapshot-update-0", Namespace: testNs}, task)).To(Succeed())
+	g.Expect(cl.Get(ctx, client.ObjectKey{Name: presyncUpdateTaskName0, Namespace: testNs}, task)).To(Succeed())
 	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
 	g.Expect(task.OwnerReferences).To(ContainElement(druidv1alpha1.GetAsOwnerReference(etcdInstance.ObjectMeta)))
 	t.Log("presync etcdopstask has correct owner reference to etcd instance")
 
-	simulatePreSyncTaskCompletion(ctx, t, cl, testNs, "presync-snapshot-update-0", druidv1alpha1.TaskStateSucceeded)
+	simulatePreSyncTaskCompletion(ctx, t, cl, testNs, presyncUpdateTaskName0, druidv1alpha1.TaskStateSucceeded)
 	t.Log("simulated presync task completion with Succeeded state")
 
 	assertEtcdContainerImage(ctx, t, cl, client.ObjectKeyFromObject(etcdInstance), newImage, timeout, pollingInterval)
@@ -709,10 +717,12 @@ func testPreSyncImageChangeSkippedViaAnnotation(t *testing.T, testNs string, rec
 		druidv1alpha1.SkipSpecUpdateSnapshotAnnotation: "",
 	}
 	g.Expect(cl.Update(ctx, etcdInstance)).To(Succeed())
+	// read the etcdInstance freshly to get the updated generation
+	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
 	t.Log("triggered image change with skip-spec-update-snapshot annotation set")
 
 	// No pre-sync snapshot task should be created since the snapshot is skipped.
-	assertPreSyncTaskNotCreated(ctx, t, cl, testNs, "presync-snapshot-update-0", consistentlyDuration, pollingInterval)
+	assertPreSyncTaskNotCreated(ctx, t, cl, testNs, fmt.Sprintf("presync-snapshot-update-%d-0", etcdInstance.Generation), consistentlyDuration, pollingInterval)
 	t.Log("verified no presync etcdopstask created when skip annotation is present")
 
 	// The StatefulSet should still roll to the new image.
@@ -752,10 +762,12 @@ func testPreSyncImageChangeProceedsAfterMaxRetries(t *testing.T, testNs string, 
 	etcdInstance.Spec.Etcd.Image = &newImage
 	etcdInstance.Annotations = map[string]string{druidv1alpha1.DruidOperationAnnotation: druidv1alpha1.DruidOperationReconcile}
 	g.Expect(cl.Update(ctx, etcdInstance)).To(Succeed())
+	// read the etcdInstance freshly to get the updated generation
+	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
 	t.Log("triggered image change by patching Spec.Etcd.Image")
 
 	for i := range 3 {
-		taskName := fmt.Sprintf("presync-snapshot-update-%d", i)
+		taskName := fmt.Sprintf("presync-snapshot-update-%d-%d", etcdInstance.Generation, i)
 		assertPreSyncTaskCreated(ctx, t, cl, testNs, taskName, timeout, pollingInterval)
 		simulatePreSyncTaskCompletion(ctx, t, cl, testNs, taskName, druidv1alpha1.TaskStateFailed)
 		t.Logf("simulated presync task %s completion with Failed state", taskName)

--- a/test/it/controller/etcd/reconciler_test.go
+++ b/test/it/controller/etcd/reconciler_test.go
@@ -718,16 +718,6 @@ func testPreSyncImageChangeSkippedViaAnnotation(t *testing.T, testNs string, rec
 	// The StatefulSet should still roll to the new image.
 	assertEtcdContainerImage(ctx, t, cl, client.ObjectKeyFromObject(etcdInstance), newImage, timeout, pollingInterval)
 	t.Log("StatefulSet etcd container image rolled to new tag despite skipping the snapshot")
-
-	// etcd-druid must NOT remove the skip annotation; it persists on the resource.
-	g.Consistently(func() bool {
-		updated := &druidv1alpha1.Etcd{}
-		if err := cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), updated); err != nil {
-			return false
-		}
-		return druidv1alpha1.HasSkipSpecUpdateSnapshotAnnotation(updated.ObjectMeta)
-	}).Within(consistentlyDuration).WithPolling(pollingInterval).Should(BeTrue(), "expected skip-spec-update-snapshot annotation to be retained by druid")
-	t.Log("skip-spec-update-snapshot annotation retained by druid (persistent)")
 }
 
 func testPreSyncImageChangeProceedsAfterMaxRetries(t *testing.T, testNs string, reconcilerTestEnv ReconcilerTestEnv) {

--- a/test/it/controller/etcd/reconciler_test.go
+++ b/test/it/controller/etcd/reconciler_test.go
@@ -607,6 +607,8 @@ func TestPreSyncImageChange(t *testing.T) {
 		fn   func(t *testing.T, testNamespace string, reconcilerTestEnv ReconcilerTestEnv)
 	}{
 		{"should succeed with image change after presync task completes", testPreSyncImageChangeSucceeds},
+		{"should skip the presync snapshot when the skip annotation is present", testPreSyncImageChangeSkippedViaAnnotation},
+		{"should proceed with image change and surface the failure after max retries exceeded", testPreSyncImageChangeProceedsAfterMaxRetries},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -667,6 +669,115 @@ func testPreSyncImageChangeSucceeds(t *testing.T, testNs string, reconcilerTestE
 
 	assertEtcdContainerImage(ctx, t, cl, client.ObjectKeyFromObject(etcdInstance), newImage, timeout, pollingInterval)
 	t.Log("StatefulSet etcd container image successfully rolled to new tag")
+}
+
+func testPreSyncImageChangeSkippedViaAnnotation(t *testing.T, testNs string, reconcilerTestEnv ReconcilerTestEnv) {
+	const (
+		timeout         = time.Minute * 3
+		pollingInterval = time.Second * 2
+		// consistentlyDuration is how long we assert that no pre-sync task is created.
+		consistentlyDuration = time.Second * 10
+	)
+
+	g := NewWithT(t)
+	etcdInstance := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testNs).
+		WithClientTLS().
+		WithPeerTLS().
+		WithReplicas(3).
+		Build()
+	g.Expect(etcdInstance.Spec.Backup.Store).ToNot(BeNil())
+	g.Expect(etcdInstance.Spec.Backup.Store.SecretRef).ToNot(BeNil())
+	cl := reconcilerTestEnv.itTestEnv.GetClient()
+	ctx := context.Background()
+	g.Expect(testutils.CreateSecrets(ctx, cl, testNs, etcdInstance.Spec.Backup.Store.SecretRef.Name)).To(Succeed())
+	createAndAssertEtcdReconciliation(ctx, t, reconcilerTestEnv, etcdInstance)
+
+	// mark member leases as TLS-enabled so subsequent reconciles do not requeue on the peer-URL TLS check.
+	memberLeaseNames := druidv1alpha1.GetMemberLeaseNames(etcdInstance)
+	mlcs := []etcdMemberLeaseConfig{
+		{name: memberLeaseNames[0], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+		{name: memberLeaseNames[1], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+		{name: memberLeaseNames[2], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+	}
+	updateMemberLeases(ctx, t, cl, testNs, mlcs)
+
+	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
+	newImage := "europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:v0.6.99-test"
+	etcdInstance.Spec.Etcd.Image = &newImage
+	etcdInstance.Annotations = map[string]string{
+		druidv1alpha1.DruidOperationAnnotation:         druidv1alpha1.DruidOperationReconcile,
+		druidv1alpha1.SkipNextUpdateSnapshotAnnotation: "",
+	}
+	g.Expect(cl.Update(ctx, etcdInstance)).To(Succeed())
+	t.Log("triggered image change with skip-next-update-snapshot annotation set")
+
+	// No pre-sync snapshot task should be created since the snapshot is skipped.
+	assertPreSyncTaskNotCreated(ctx, t, cl, testNs, "presync-snapshot-update-0", consistentlyDuration, pollingInterval)
+	t.Log("verified no presync etcdopstask created when skip annotation is present")
+
+	// The StatefulSet should still roll to the new image.
+	assertEtcdContainerImage(ctx, t, cl, client.ObjectKeyFromObject(etcdInstance), newImage, timeout, pollingInterval)
+	t.Log("StatefulSet etcd container image rolled to new tag despite skipping the snapshot")
+
+	// The one-shot annotation must be removed by druid.
+	g.Eventually(func() bool {
+		updated := &druidv1alpha1.Etcd{}
+		if err := cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), updated); err != nil {
+			return true
+		}
+		return druidv1alpha1.HasSkipNextUpdateSnapshotAnnotation(updated.ObjectMeta)
+	}).Within(timeout).WithPolling(pollingInterval).Should(BeFalse(), "expected skip-next-update-snapshot annotation to be removed")
+	t.Log("skip-next-update-snapshot annotation removed by druid (one-shot)")
+}
+
+func testPreSyncImageChangeProceedsAfterMaxRetries(t *testing.T, testNs string, reconcilerTestEnv ReconcilerTestEnv) {
+	const (
+		timeout         = time.Minute * 5
+		pollingInterval = time.Second * 2
+	)
+
+	g := NewWithT(t)
+	etcdInstance := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testNs).
+		WithClientTLS().
+		WithPeerTLS().
+		WithReplicas(3).
+		Build()
+	g.Expect(etcdInstance.Spec.Backup.Store).ToNot(BeNil())
+	g.Expect(etcdInstance.Spec.Backup.Store.SecretRef).ToNot(BeNil())
+	cl := reconcilerTestEnv.itTestEnv.GetClient()
+	ctx := context.Background()
+	g.Expect(testutils.CreateSecrets(ctx, cl, testNs, etcdInstance.Spec.Backup.Store.SecretRef.Name)).To(Succeed())
+	createAndAssertEtcdReconciliation(ctx, t, reconcilerTestEnv, etcdInstance)
+
+	memberLeaseNames := druidv1alpha1.GetMemberLeaseNames(etcdInstance)
+	mlcs := []etcdMemberLeaseConfig{
+		{name: memberLeaseNames[0], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+		{name: memberLeaseNames[1], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+		{name: memberLeaseNames[2], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
+	}
+	updateMemberLeases(ctx, t, cl, testNs, mlcs)
+
+	g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), etcdInstance)).To(Succeed())
+	newImage := "europe-docker.pkg.dev/gardener-project/public/gardener/etcd-wrapper:v0.6.99-test"
+	etcdInstance.Spec.Etcd.Image = &newImage
+	etcdInstance.Annotations = map[string]string{druidv1alpha1.DruidOperationAnnotation: druidv1alpha1.DruidOperationReconcile}
+	g.Expect(cl.Update(ctx, etcdInstance)).To(Succeed())
+	t.Log("triggered image change by patching Spec.Etcd.Image")
+
+	for i := range 3 {
+		taskName := fmt.Sprintf("presync-snapshot-update-%d", i)
+		assertPreSyncTaskCreated(ctx, t, cl, testNs, taskName, timeout, pollingInterval)
+		simulatePreSyncTaskCompletion(ctx, t, cl, testNs, taskName, druidv1alpha1.TaskStateFailed)
+		t.Logf("simulated presync task %s completion with Failed state", taskName)
+	}
+
+	// Despite the snapshot failing, the StatefulSet must still roll to the new image.
+	assertEtcdContainerImage(ctx, t, cl, client.ObjectKeyFromObject(etcdInstance), newImage, timeout, pollingInterval)
+	t.Log("StatefulSet etcd container image rolled to new tag after max retries exceeded")
+
+	// The failure must be surfaced via a Warning event so operators are aware the update proceeded without a snapshot.
+	assertPreSyncSnapshotFailedEventRecorded(ctx, t, cl, client.ObjectKeyFromObject(etcdInstance), timeout, pollingInterval)
+	t.Log("PreSyncSnapshotFailed warning event recorded")
 }
 
 // ------------------------------ reconcile status tests ------------------------------

--- a/test/it/controller/etcd/reconciler_test.go
+++ b/test/it/controller/etcd/reconciler_test.go
@@ -706,10 +706,10 @@ func testPreSyncImageChangeSkippedViaAnnotation(t *testing.T, testNs string, rec
 	etcdInstance.Spec.Etcd.Image = &newImage
 	etcdInstance.Annotations = map[string]string{
 		druidv1alpha1.DruidOperationAnnotation:         druidv1alpha1.DruidOperationReconcile,
-		druidv1alpha1.SkipNextUpdateSnapshotAnnotation: "",
+		druidv1alpha1.SkipSpecUpdateSnapshotAnnotation: "",
 	}
 	g.Expect(cl.Update(ctx, etcdInstance)).To(Succeed())
-	t.Log("triggered image change with skip-next-update-snapshot annotation set")
+	t.Log("triggered image change with skip-spec-update-snapshot annotation set")
 
 	// No pre-sync snapshot task should be created since the snapshot is skipped.
 	assertPreSyncTaskNotCreated(ctx, t, cl, testNs, "presync-snapshot-update-0", consistentlyDuration, pollingInterval)
@@ -719,15 +719,15 @@ func testPreSyncImageChangeSkippedViaAnnotation(t *testing.T, testNs string, rec
 	assertEtcdContainerImage(ctx, t, cl, client.ObjectKeyFromObject(etcdInstance), newImage, timeout, pollingInterval)
 	t.Log("StatefulSet etcd container image rolled to new tag despite skipping the snapshot")
 
-	// The one-shot annotation must be removed by druid.
-	g.Eventually(func() bool {
+	// etcd-druid must NOT remove the skip annotation; it persists on the resource.
+	g.Consistently(func() bool {
 		updated := &druidv1alpha1.Etcd{}
 		if err := cl.Get(ctx, client.ObjectKeyFromObject(etcdInstance), updated); err != nil {
-			return true
+			return false
 		}
-		return druidv1alpha1.HasSkipNextUpdateSnapshotAnnotation(updated.ObjectMeta)
-	}).Within(timeout).WithPolling(pollingInterval).Should(BeFalse(), "expected skip-next-update-snapshot annotation to be removed")
-	t.Log("skip-next-update-snapshot annotation removed by druid (one-shot)")
+		return druidv1alpha1.HasSkipSpecUpdateSnapshotAnnotation(updated.ObjectMeta)
+	}).Within(consistentlyDuration).WithPolling(pollingInterval).Should(BeTrue(), "expected skip-spec-update-snapshot annotation to be retained by druid")
+	t.Log("skip-spec-update-snapshot annotation retained by druid (persistent)")
 }
 
 func testPreSyncImageChangeProceedsAfterMaxRetries(t *testing.T, testNs string, reconcilerTestEnv ReconcilerTestEnv) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
  /area backup
  /area disaster-recovery
  /kind enhancement

  **What this PR does / why we need it**:
  Triggers a full snapshot via `EtcdOpsTask` before the etcd `StatefulSet` is rolled due to a container image change or a replica count change, irrespective of HA / non-HA. Builds on the snapshot-before-rolling mechanism introduced in #1300, which previously covered only hibernation and the `UpgradeEtcdVersion` gated etcd-version-upgrade flow.

The pre-sync `EtcdOpsTask` name prefix has been renamed from `presync-snapshot-upgrade-` to `presync-snapshot-update-` to reflect the broader trigger. The `UpgradeEtcdVersion` feature gate itself is unchanged; it simply no longer gates the snapshot trigger.
  
Scope is intentionally limited to image and replica fields. Arbitrary `podTemplateSpec` mutations are out of scope because the StatefulSet pod-template-hash is computed by an internal, version-dependent algorithm in Kubernetes; pre-computing whether a roll will happen is not feasible without coupling druid to a specific Kubernetes version.

**Which issue(s) this PR fixes**:
Fixes #1359

**Checklist**:
- [x] Add tests that cover your changes (if applicable)
    - [x] Unit tests
    - [x] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:
During a druid version upgrade, an in-flight `presync-snapshot-upgrade-N` task created by the older operator will be ignored by the new code. The `etcdopstask` controller's FIFO + one-active-task-per-cluster guarantee means at most one extra full snapshot is taken across the upgrade boundary.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Take a full snapshot via `EtcdOpsTask` before the etcd `StatefulSet` is rolled due to any container image change or replica count change, in both HA and non-HA setups
```

```noteworthy operator
The pre-sync `EtcdOpsTask` name prefix is renamed from `presync-snapshot-upgrade-` to `presync-snapshot-update-`; in-flight tasks created by an older operator may result in at most one additional snapshot across the upgrade boundary.
```
