### PR TITLE
Update doc with readiness and liveness probes configuration.

### DIFF
--- a/docs/concepts/etcd-cluster-components.md
+++ b/docs/concepts/etcd-cluster-components.md
@@ -49,7 +49,7 @@ To ensure that etcd pods are not evicted more than its failure tolerance, `etcd-
 
 ## Role & RoleBinding
 
-`etcd-backup-restore` container running as a side-car in every etcd-member, requires permissions to access resources like `Lease`, `StatefulSet` etc. A dedicated [Role]() and [RoleBinding]() is created and linked to the [ServiceAccount](https://kubernetes.io/docs/concepts/security/service-accounts/) created per `Etcd` cluster.
+`etcd-backup-restore` container running as a side-car in every etcd-member, requires permissions to access resources like `Lease`, `StatefulSet` etc. A dedicated [Role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) and [RoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) is created and linked to the [ServiceAccount](https://kubernetes.io/docs/concepts/security/service-accounts/) created per `Etcd` cluster.
 
 **Code reference:** [Role-Component](https://github.com/gardener/etcd-druid/tree/3383e0219a6c21c6ef1d5610db964cc3524807c8/internal/component/role) & [RoleBinding-Component](https://github.com/gardener/etcd-druid/tree/master/internal/component/rolebinding)
 
@@ -77,3 +77,19 @@ One of the responsibilities of `etcd-backup-restore` container is to take period
 > In future these leases will be replaced by [EtcdMember resource](https://github.com/gardener/etcd-druid/blob/3383e0219a6c21c6ef1d5610db964cc3524807c8/docs/proposals/04-etcd-member-custom-resource.md).
 
 **Code reference:** [Snapshot-Lease-Component](https://github.com/gardener/etcd-druid/tree/3383e0219a6c21c6ef1d5610db964cc3524807c8/internal/component/snapshotlease)
+
+## Probes
+
+### ReadinessProbe
+
+Currently a [/readyz](https://github.com/gardener/etcd-wrapper/blob/cf3be92fc03c78941a3275f6ac4b37f54fd9b59a/internal/app/readycheck.go#L143) endpoint provided by [etcd-wrapper](https://github.com/gardener/etcd-wrapper) is being used as readinessProbe. This endpoint performs a linearizable `GET` request, which effectively represents the readiness of the etcd cluster.
+
+### LivenessProbe
+
+Currently `etcd-druid` doesn't configure any [liveness probe](https://kubernetes.io/docs/concepts/workloads/pods/probes/#liveness-probe) for a etcd statefulset. Based on our observations, the introduction of livenessProbe can do more harm then being useful as liveness probe failure simply causes the kubelet to restart the etcd container, which is not helpful in most of the scenarios. Some examples of such scenarios:
+
+1. **Etcd cluster bootstrap**: Determining an appropriate value for `livenessProbe.initialDelaySeconds` is difficult as etcd member(s)may take longer than expected to start for various reasons. If the startup time exceeds initialDelaySeconds, the kubelet will prematurely kills and restart the etcd container.
+
+2. Even if `initialDelaySeconds` is set to some large value (say >200sec) or a startupProbe is introduced, still it won't solve all of the problems, for example: Consider a scenario when etcd cluster member are busy due to high load because of this if any etcd member unable to respond to livenessProbe within the configured time causing livenessProbe to fail, due to that kubelet will kills the etcd container in order to restart the container, this restarting of a member will only worsen the overall situation.
+
+more details can be found here: https://github.com/gardener/etcd-druid/issues/280#issuecomment-4505733020

--- a/docs/concepts/etcd-cluster-components.md
+++ b/docs/concepts/etcd-cluster-components.md
@@ -12,12 +12,12 @@ For every `Etcd` cluster that is provisioned by `etcd-druid` it deploys a set of
   * `etcd-wrapper` : This is the main container which runs an etcd process.
   
   * `etcd-backup-restore` : This is a side-container which does the following:
-    
+
     * Orchestrates the initialization of etcd. This includes validation of any existing etcd data directory, restoration in case of corrupt etcd data directory files for a single-member etcd cluster.
     * Periodically renews member lease.
     * Optionally takes schedule and threshold based delta and full snapshots and pushes them to a configured object store.
     * Orchestrates scheduled etcd-db defragmentation.
-    
+
     > NOTE: This is not a complete list of functionalities offered out of `etcd-backup-restore`. 
 
 **Code reference:** [StatefulSet-Component](https://github.com/gardener/etcd-druid/tree/480213808813c5282b19aff5f3fd6868529e779c/internal/component/statefulset)
@@ -34,7 +34,7 @@ Every `etcd` member requires [configuration](https://etcd.io/docs/v3.4/op-guide/
 
 An etcd cluster requires quorum for all write operations. Clients can additionally configure quorum based reads as well to ensure [linearizable](https://jepsen.io/consistency/models/linearizable) reads (kube-apiserver's etcd client is configured for linearizable reads and writes). In a cluster of size 3, only 1 member failure is tolerated. [Failure tolerance](https://etcd.io/docs/v3.3/faq/#what-is-failure-tolerance) for an etcd cluster with replicas `n` is computed as `(n-1)/2`.
 
-To ensure that etcd pods are not evicted more than its failure tolerance, `etcd-druid` creates a [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets). 
+To ensure that etcd pods are not evicted more than its failure tolerance, `etcd-druid` creates a [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets).
 
 !!! note
     For a single node etcd cluster a `PodDisruptionBudget` will be created, however `pdb.spec.minavailable` is set to 0 effectively disabling it.
@@ -43,13 +43,13 @@ To ensure that etcd pods are not evicted more than its failure tolerance, `etcd-
 
 ## ServiceAccount
 
-`etcd-backup-restore` container running as a side-car in every etcd-member, requires permissions to access resources like `Lease`, `StatefulSet` etc. A dedicated [ServiceAccount](https://kubernetes.io/docs/concepts/security/service-accounts/) is created per `Etcd` cluster for this purpose.
+`etcd-backup-restore` container running as a side-car in every etcd-member, requires permissions to access kubernetes resources like [Lease](https://kubernetes.io/docs/concepts/architecture/leases/), [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) etc. A dedicated [ServiceAccount](https://kubernetes.io/docs/concepts/security/service-accounts/) is created per `Etcd` cluster for this purpose.
 
 **Code reference:** [ServiceAccount-Component](https://github.com/gardener/etcd-druid/tree/3383e0219a6c21c6ef1d5610db964cc3524807c8/internal/component/serviceaccount)
 
 ## Role & RoleBinding
 
-`etcd-backup-restore` container running as a side-car in every etcd-member, requires permissions to access resources like `Lease`, `StatefulSet` etc. A dedicated [Role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) and [RoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) is created and linked to the [ServiceAccount](https://kubernetes.io/docs/concepts/security/service-accounts/) created per `Etcd` cluster.
+`etcd-backup-restore` container running as a side-car in every etcd-member, requires permissions to access kubernetes resources like `Lease`, `StatefulSet` etc. A dedicated [Role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) and [RoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding) is created and linked to the [ServiceAccount](https://kubernetes.io/docs/concepts/security/service-accounts/) created per `Etcd` cluster.
 
 **Code reference:** [Role-Component](https://github.com/gardener/etcd-druid/tree/3383e0219a6c21c6ef1d5610db964cc3524807c8/internal/component/role) & [RoleBinding-Component](https://github.com/gardener/etcd-druid/tree/master/internal/component/rolebinding)
 
@@ -63,8 +63,8 @@ To enable clients to connect to an etcd cluster a ClusterIP `Client` [Service](h
 
 Every member in an `Etcd` cluster has a dedicated [Lease](https://kubernetes.io/docs/concepts/architecture/leases/) that gets created which signifies that the member is alive. It is the responsibility of the `etcd-backup-store` side-car container to periodically renew the lease.
 
-!!! note 
-    Today the lease object is also used to indicate the member-ID and the role of the member in an etcd cluster. Possible roles are `Leader`, `Member`(which denotes that this is a member but not a leader). This will change in the future with [EtcdMember resource](https://github.com/gardener/etcd-druid/blob/3383e0219a6c21c6ef1d5610db964cc3524807c8/docs/proposals/04-etcd-member-custom-resource.md).
+[!NOTE]
+Today the lease object is used to hold the memberID, clusterID and the role of the member in an etcd cluster information. Possible roles are `Leader`, `Member`(which denotes that this is a member but not a leader). This will change in the future with [EtcdMember resource](https://github.com/gardener/etcd-druid/blob/3383e0219a6c21c6ef1d5610db964cc3524807c8/docs/proposals/04-etcd-member-custom-resource.md).
 
 **Code reference:** [Member-Lease-Component](https://github.com/gardener/etcd-druid/tree/3383e0219a6c21c6ef1d5610db964cc3524807c8/internal/component/memberlease)
 
@@ -82,7 +82,7 @@ One of the responsibilities of `etcd-backup-restore` container is to take period
 
 ### ReadinessProbe
 
-Currently a [/readyz](https://github.com/gardener/etcd-wrapper/blob/cf3be92fc03c78941a3275f6ac4b37f54fd9b59a/internal/app/readycheck.go#L143) endpoint provided by [etcd-wrapper](https://github.com/gardener/etcd-wrapper) is being used as readinessProbe. This endpoint performs a linearizable `GET` request, which effectively represents the readiness of the etcd cluster.
+Currently a [/readyz](https://github.com/gardener/etcd-wrapper/blob/cf3be92fc03c78941a3275f6ac4b37f54fd9b59a/internal/app/readycheck.go#L143) endpoint provided by [etcd-wrapper](https://github.com/gardener/etcd-wrapper) is being used as readinessProbe. This endpoint performs a linearizable `GET` request, which effectively represents the readiness of the etcd cluster as linearizable call expects strong consistency which requires quorum among the members.
 
 ### LivenessProbe
 
@@ -90,6 +90,7 @@ Currently `etcd-druid` doesn't configure any [liveness probe](https://kubernetes
 
 1. **Etcd cluster bootstrap**: Determining an appropriate value for `livenessProbe.initialDelaySeconds` is difficult as etcd member(s)may take longer than expected to start for various reasons. If the startup time exceeds initialDelaySeconds, the kubelet will prematurely kills and restart the etcd container.
 
-2. Even if `initialDelaySeconds` is set to some large value (say >200sec) or a startupProbe is introduced, still it won't solve all of the problems, for example: Consider a scenario when etcd cluster member are busy due to high load because of this if any etcd member unable to respond to livenessProbe within the configured time causing livenessProbe to fail, due to that kubelet will kills the etcd container in order to restart the container, this restarting of a member will only worsen the overall situation.
+
+2. Even if `livenessProbe.initialDelaySeconds` is set to some large value (say >200sec) or a startupProbe is introduced, still it won't solve all of the problems, for example: Consider a scenario where etcd cluster member are busy due to high load, now because of this if any etcd member is unable to respond to livenessProbe within the configured time causing livenessProbe to fail, due to that kubelet will kill the etcd container in order to restart the container, this restarting of a member will only worsen the overall situation.
 
 more details can be found here: https://github.com/gardener/etcd-druid/issues/280#issuecomment-4505733020

--- a/docs/concepts/etcd-cluster-components.md
+++ b/docs/concepts/etcd-cluster-components.md
@@ -88,8 +88,7 @@ Currently a [/readyz](https://github.com/gardener/etcd-wrapper/blob/cf3be92fc03c
 
 Currently `etcd-druid` doesn't configure any [liveness probe](https://kubernetes.io/docs/concepts/workloads/pods/probes/#liveness-probe) for a etcd statefulset. Based on our observations, the introduction of livenessProbe can do more harm then being useful as liveness probe failure simply causes the kubelet to restart the etcd container, which is not helpful in most of the scenarios. Some examples of such scenarios:
 
-1. **Etcd cluster bootstrap**: Determining an appropriate value for `livenessProbe.initialDelaySeconds` is difficult as etcd member(s)may take longer than expected to start for various reasons. If the startup time exceeds initialDelaySeconds, the kubelet will prematurely kills and restart the etcd container.
-
+1. **Etcd cluster bootstrap**: Determining an appropriate value for `livenessProbe.initialDelaySeconds` is difficult as etcd member(s)may take longer than expected to start for various reasons such as network related issue among others etc. If the startup time exceeds initialDelaySeconds, the kubelet will prematurely kills and restart the etcd container.
 
 2. Even if `livenessProbe.initialDelaySeconds` is set to some large value (say >200sec) or a startupProbe is introduced, still it won't solve all of the problems, for example: Consider a scenario where etcd cluster member are busy due to high load, now because of this if any etcd member is unable to respond to livenessProbe within the configured time causing livenessProbe to fail, due to that kubelet will kill the etcd container in order to restart the container, this restarting of a member will only worsen the overall situation.
 

--- a/docs/concepts/etcd-cluster-components.md
+++ b/docs/concepts/etcd-cluster-components.md
@@ -86,10 +86,10 @@ Currently a [/readyz](https://github.com/gardener/etcd-wrapper/blob/cf3be92fc03c
 
 ### LivenessProbe
 
-Currently `etcd-druid` doesn't configure any [liveness probe](https://kubernetes.io/docs/concepts/workloads/pods/probes/#liveness-probe) for a etcd statefulset. Based on our observations, the introduction of livenessProbe can do more harm then being useful as liveness probe failure simply causes the kubelet to restart the etcd container, which is not helpful in most of the scenarios. Some examples of such scenarios:
+Currently `etcd-druid` doesn't configure any [liveness probe](https://kubernetes.io/docs/concepts/workloads/pods/probes/#liveness-probe) for a etcd statefulset. Based on our observations, the introduction of livenessProbe can do more harm than being useful as liveness probe failure simply causes the kubelet to restart the etcd container, which is not helpful in most of the scenarios. Some examples of such scenarios:
 
 1. **Etcd cluster bootstrap**: Determining an appropriate value for `livenessProbe.initialDelaySeconds` is difficult as etcd member(s)may take longer than expected to start for various reasons such as network related issue among others etc. If the startup time exceeds initialDelaySeconds, the kubelet will prematurely kills and restart the etcd container.
 
-2. Even if `livenessProbe.initialDelaySeconds` is set to some large value (say >200sec) or a startupProbe is introduced, still it won't solve all of the problems, for example: Consider a scenario where etcd cluster member are busy due to high load, now because of this if any etcd member is unable to respond to livenessProbe within the configured time causing livenessProbe to fail, due to that kubelet will kill the etcd container in order to restart the container, this restarting of a member will only worsen the overall situation.
+2. Even if `livenessProbe.initialDelaySeconds` is set to some large value (say >200sec) or a [startupProbe](https://kubernetes.io/docs/concepts/workloads/pods/probes/#startup-probe) is introduced, it still won't solve all of the problems. For example, consider a scenario where etcd cluster member(s) are busy due to high load. Because of this, if any etcd member is unable to respond to the livenessProbe within the configured time, the livenessProbe fails, due to which kubelet will kill the etcd container in order to restart the container. This restarting of a member will only worsen the overall situation.
 
 more details can be found here: https://github.com/gardener/etcd-druid/issues/280#issuecomment-4505733020


### PR DESCRIPTION

/area documentation

**What this PR does / why we need it**:
This PR documents the current readiness and liveness probes configuration set on etcd statefulset deployed by etcd-druid.


**Which issue(s) this PR fixes**:
Fixes #

**Checklist**:
- [x] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.

**Special notes for your reviewer**:
I'm capturing this info in this doc `docs/concepts/etcd-cluster-components.md` but open for change.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
