### PR TITLE
docs: escape angle bracket placeholders to fix VitePress build

### DIFF
--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -729,7 +729,7 @@ spec:
                 type: object
               memberNamePrefix:
                 description: |-
-                  MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be "<prefix>-<pod-name>", otherwise it defaults to the "pod-name".
+                  MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be `<prefix>-<pod-name>`, otherwise it defaults to the `pod-name`.
                   The combined length of the member-prefix, pod-name, and separator must not exceed 253 characters (DNS subdomain limit for lease names).
                 maxLength: 63
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2150,7 +2150,7 @@ spec:
                     name:
                       description: |-
                         Name is the name of the etcd member. It matches the member lease name.
-                        When EtcdSpec.MemberNamePrefix is set, it is "<prefix>-<pod-name>" otherwise it is the name of the backing `Pod`.
+                        When EtcdSpec.MemberNamePrefix is set, it is `<prefix>-<pod-name>` otherwise it is the name of the backing `Pod`.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
@@ -651,7 +651,7 @@ spec:
                   type: object
                 memberNamePrefix:
                   description: |-
-                    MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be "<prefix>-<pod-name>", otherwise it defaults to the "pod-name".
+                    MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be `<prefix>-<pod-name>`, otherwise it defaults to the `pod-name`.
                     The combined length of the member-prefix, pod-name, and separator must not exceed 253 characters (DNS subdomain limit for lease names).
                   maxLength: 63
                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1979,7 +1979,7 @@ spec:
                       name:
                         description: |-
                           Name is the name of the etcd member. It matches the member lease name.
-                          When EtcdSpec.MemberNamePrefix is set, it is "<prefix>-<pod-name>" otherwise it is the name of the backing `Pod`.
+                          When EtcdSpec.MemberNamePrefix is set, it is `<prefix>-<pod-name>` otherwise it is the name of the backing `Pod`.
                         type: string
                       reason:
                         description: The reason for the condition's last transition.

--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -351,7 +351,7 @@ type SchedulingConstraints struct {
 // +kubebuilder:validation:XValidation:message="etcd.spec.volumeClaimTemplate is an immutable field.",rule="has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)"
 // +kubebuilder:validation:XValidation:message="etcd.spec.memberNamePrefix is an immutable field.",rule="has(oldSelf.memberNamePrefix) == has(self.memberNamePrefix)"
 type EtcdSpec struct {
-	// MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be "<prefix>-<pod-name>", otherwise it defaults to the "pod-name".
+	// MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be `<prefix>-<pod-name>`, otherwise it defaults to the `pod-name`.
 	// The combined length of the member-prefix, pod-name, and separator must not exceed 253 characters (DNS subdomain limit for lease names).
 	// +optional
 	// +kubebuilder:validation:MaxLength=63
@@ -463,7 +463,7 @@ const (
 // EtcdMemberStatus holds information about etcd cluster membership.
 type EtcdMemberStatus struct {
 	// Name is the name of the etcd member. It matches the member lease name.
-	// When EtcdSpec.MemberNamePrefix is set, it is "<prefix>-<pod-name>" otherwise it is the name of the backing `Pod`.
+	// When EtcdSpec.MemberNamePrefix is set, it is `<prefix>-<pod-name>` otherwise it is the name of the backing `Pod`.
 	Name string `json:"name"`
 	// ID is the ID of the etcd member.
 	// +optional

--- a/charts/crds/druid.gardener.cloud_etcds.yaml
+++ b/charts/crds/druid.gardener.cloud_etcds.yaml
@@ -729,7 +729,7 @@ spec:
                 type: object
               memberNamePrefix:
                 description: |-
-                  MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be "<prefix>-<pod-name>", otherwise it defaults to the "pod-name".
+                  MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be `<prefix>-<pod-name>`, otherwise it defaults to the `pod-name`.
                   The combined length of the member-prefix, pod-name, and separator must not exceed 253 characters (DNS subdomain limit for lease names).
                 maxLength: 63
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -2150,7 +2150,7 @@ spec:
                     name:
                       description: |-
                         Name is the name of the etcd member. It matches the member lease name.
-                        When EtcdSpec.MemberNamePrefix is set, it is "<prefix>-<pod-name>" otherwise it is the name of the backing `Pod`.
+                        When EtcdSpec.MemberNamePrefix is set, it is `<prefix>-<pod-name>` otherwise it is the name of the backing `Pod`.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.

--- a/docs/api-reference/etcd-druid-api.md
+++ b/docs/api-reference/etcd-druid-api.md
@@ -769,7 +769,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the etcd member. It matches the member lease name.<br />When EtcdSpec.MemberNamePrefix is set, it is "<prefix>-<pod-name>" otherwise it is the name of the backing `Pod`. |  |  |
+| `name` _string_ | Name is the name of the etcd member. It matches the member lease name.<br />When EtcdSpec.MemberNamePrefix is set, it is `<prefix>-<pod-name>` otherwise it is the name of the backing `Pod`. |  |  |
 | `id` _string_ | ID is the ID of the etcd member. |  |  |
 | `role` _[EtcdRole](#etcdrole)_ | Role is the role in the etcd cluster, either `Leader` or `Member`. |  |  |
 | `status` _[EtcdMemberConditionStatus](#etcdmemberconditionstatus)_ | Status of the condition, one of True, False, Unknown. |  |  |
@@ -884,7 +884,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `memberNamePrefix` _string_ | MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be "<prefix>-<pod-name>", otherwise it defaults to the "pod-name".<br />The combined length of the member-prefix, pod-name, and separator must not exceed 253 characters (DNS subdomain limit for lease names). |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br /> |
+| `memberNamePrefix` _string_ | MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be `<prefix>-<pod-name>`, otherwise it defaults to the `pod-name`.<br />The combined length of the member-prefix, pod-name, and separator must not exceed 253 characters (DNS subdomain limit for lease names). |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br /> |
 | `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | selector is a label query over pods that should match the replica count.<br />It must match the pod template's labels.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors<br />Deprecated: this field will be removed in the future. |  |  |
 | `labels` _object (keys:string, values:string)_ | Labels defines the labels to be applied to the etcd pods backing the etcd cluster. |  |  |
 | `annotations` _object (keys:string, values:string)_ | Annotations defines the annotations to be applied to the etcd pods backing the etcd cluster. |  |  |


### PR DESCRIPTION
/area documentation
/kind bug

**What this PR does / why we need it**:
Fixes a VitePress build error in `gardener/documentation` caused by unescaped
angle brackets in Go comments. `<prefix>` and `<pod-name>` in two comment lines
in `etcd.go` propagate into the generated CRD YAML files and the API reference
markdown, where VitePress/Vue parses them as invalid HTML tags without closing
tags, breaking the build with:
  [vite:vue] Element is missing end tag — etcd-druid-api.md:1550:141

Fix: replace double-quoted `"<prefix>-<pod-name>"` with backtick-quoted
`<prefix>-<pod-name>` in etcd.go and regenerate all derived files via `make generate`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**:
- [x] Update documentation in the `/docs` folder (if applicable)

- [ ] Add tests that cover your changes (if applicable)

**Special notes for your reviewer**:
Only two comment lines changed in `etcd.go` (lines 354 and 466).
All other modified files (`crds/*.yaml`, `charts/crds/*.yaml`, `docs/api-reference/etcd-druid-api.md`)
are auto-generated via `make generate` from the `api/` directory.

**Release note**:
```doc developer
Escaped angle bracket placeholders in etcd.go comments to fix VitePress build error in gardener/documentation.
```