### PR TITLE
Changed `EtcdOpsTask` handler to refer `StatefulSet` volume mounted `Secret`.

### DIFF
--- a/internal/controller/etcdopstask/handler/ondemandsnapshot/ondemandsnapsnapshot_test.go
+++ b/internal/controller/etcdopstask/handler/ondemandsnapshot/ondemandsnapsnapshot_test.go
@@ -131,12 +131,13 @@ func TestOnDemandSnapshotTaskAdmit(t *testing.T) {
 func TestOnDemandSnapshotTaskExecute(t *testing.T) {
 	g := NewGomegaWithT(t)
 	tests := []struct {
-		name                string
-		etcdObject          *druidv1alpha1.Etcd
-		isSnapshotTypeDelta bool
-		FakeResponse        *utils.FakeResponse
-		expectedResult      taskhandler.Result
-		expectErr           bool
+		name                   string
+		etcdObject             *druidv1alpha1.Etcd
+		isSnapshotTypeDelta    bool
+		stsWithBackupRestoreCA bool
+		FakeResponse           *utils.FakeResponse
+		expectedResult         taskhandler.Result
+		expectErr              bool
 	}{
 		{
 			name:       "Should return error without requeue when Etcd object is not found",
@@ -220,8 +221,9 @@ func TestOnDemandSnapshotTaskExecute(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:       "Should return error without requeue when TLS is enabled but CA secret is not found",
-			etcdObject: createEtcd("test-etcd", "test-namespace", true, true, false, true),
+			name:                   "Should return error without requeue when TLS is enabled but CA secret is not found",
+			etcdObject:             createEtcd("test-etcd", "test-namespace", true, true, false, true),
+			stsWithBackupRestoreCA: true,
 			FakeResponse: &utils.FakeResponse{
 				Response: http.Response{},
 				Error:    nil,
@@ -278,6 +280,13 @@ func TestOnDemandSnapshotTaskExecute(t *testing.T) {
 			var objs []client.Object
 			if tc.etcdObject != nil {
 				objs = append(objs, tc.etcdObject)
+			}
+			if tc.stsWithBackupRestoreCA {
+				tc.etcdObject.UID = "test-etcd-uid"
+				objs = append(objs, utils.AddBackupRestoreCAVolume(
+					utils.CreateStatefulSet(tc.etcdObject.Name, tc.etcdObject.Namespace, tc.etcdObject.UID, 1),
+					utils.BackupRestoreTLSCASecretName,
+				))
 			}
 			cl := utils.NewTestClientBuilder().WithScheme(kubernetes.Scheme).WithObjects(objs...).Build()
 

--- a/internal/controller/etcdopstask/handler/utils/etcdbrclient.go
+++ b/internal/controller/etcdopstask/handler/utils/etcdbrclient.go
@@ -56,12 +56,12 @@ func ConfigureHTTPClientForEtcdBR(ctx context.Context, k8sClient client.Client, 
 		return
 	}
 
-	etcdbrCASecretName, ok := kutil.GetVolumeSecretName(sts, common.VolumeNameBackupRestoreCA)
+	etcdbrCASecretName, ok := kutil.GetSecretNameFromVolume(sts, common.VolumeNameBackupRestoreCA)
 	if !ok {
 		errResult = &taskhandler.Result{
 			Description: fmt.Sprintf("backup-restore CA volume %q not found on StatefulSet %s/%s", common.VolumeNameBackupRestoreCA, etcd.Namespace, etcd.Name),
 			Error:       druiderr.WrapError(fmt.Errorf("volume %q not found on StatefulSet %s/%s", common.VolumeNameBackupRestoreCA, etcd.Namespace, etcd.Name), taskhandler.ErrGetCASecret, string(phase), "resolve backup-restore CA secret from StatefulSet volumes"),
-			Requeue:     true,
+			Requeue:     false,
 		}
 		return
 	}

--- a/internal/controller/etcdopstask/handler/utils/etcdbrclient.go
+++ b/internal/controller/etcdopstask/handler/utils/etcdbrclient.go
@@ -38,7 +38,7 @@ func ConfigureHTTPClientForEtcdBR(ctx context.Context, k8sClient client.Client, 
 	etcdbrCASecret := &v1.Secret{}
 	dataKey := ptr.Deref(tlsConfig.TLSCASecretRef.DataKey, "bundle.crt")
 
-	// TODO @Shreyas-s14: revert this change once the gardener/gardener issue has been fixed.
+	// TODO @Shreyas-s14: revert this change once the gardener/gardener issue has been fixed: https://github.com/gardener/gardener/issues/15004
 	sts, err := kutil.GetStatefulSet(ctx, k8sClient, etcd)
 	if err != nil {
 		errResult = &taskhandler.Result{

--- a/internal/controller/etcdopstask/handler/utils/etcdbrclient.go
+++ b/internal/controller/etcdopstask/handler/utils/etcdbrclient.go
@@ -38,6 +38,7 @@ func ConfigureHTTPClientForEtcdBR(ctx context.Context, k8sClient client.Client, 
 	etcdbrCASecret := &v1.Secret{}
 	dataKey := ptr.Deref(tlsConfig.TLSCASecretRef.DataKey, "bundle.crt")
 
+	// TODO @Shreyas-s14: revert this change once the gardener/gardener issue has been fixed.
 	sts, err := kutil.GetStatefulSet(ctx, k8sClient, etcd)
 	if err != nil {
 		errResult = &taskhandler.Result{

--- a/internal/controller/etcdopstask/handler/utils/etcdbrclient.go
+++ b/internal/controller/etcdopstask/handler/utils/etcdbrclient.go
@@ -13,9 +13,11 @@ import (
 
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	"github.com/gardener/etcd-druid/internal/common"
 	taskhandler "github.com/gardener/etcd-druid/internal/controller/etcdopstask/handler"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,14 +37,44 @@ func ConfigureHTTPClientForEtcdBR(ctx context.Context, k8sClient client.Client, 
 	etcdbrCASecret := &v1.Secret{}
 	dataKey := ptr.Deref(tlsConfig.TLSCASecretRef.DataKey, "bundle.crt")
 
-	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: etcd.Namespace, Name: tlsConfig.TLSCASecretRef.Name}, etcdbrCASecret); err != nil {
+	sts := &appsv1.StatefulSet{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: etcd.Namespace, Name: etcd.Name}, sts); err != nil {
+		requeue := true
+		if apierrors.IsNotFound(err) {
+			requeue = false
+		}
+		errResult = &taskhandler.Result{
+			Description: "Failed to get StatefulSet for backup-restore CA resolution",
+			Error:       druiderr.WrapError(err, taskhandler.ErrGetCASecret, string(phase), fmt.Sprintf("failed to get StatefulSet %s/%s", etcd.Namespace, etcd.Name)),
+			Requeue:     requeue,
+		}
+		return
+	}
+
+	var caSecretName string
+	for _, vol := range sts.Spec.Template.Spec.Volumes {
+		if vol.Name == common.VolumeNameBackupRestoreCA && vol.Secret != nil {
+			caSecretName = vol.Secret.SecretName
+			break
+		}
+	}
+	if caSecretName == "" {
+		errResult = &taskhandler.Result{
+			Description: fmt.Sprintf("backup-restore CA volume %q not found on StatefulSet %s/%s", common.VolumeNameBackupRestoreCA, etcd.Namespace, etcd.Name),
+			Error:       druiderr.WrapError(fmt.Errorf("volume %q not found on StatefulSet %s/%s", common.VolumeNameBackupRestoreCA, etcd.Namespace, etcd.Name), taskhandler.ErrGetCASecret, string(phase), "resolve backup-restore CA secret from StatefulSet volumes"),
+			Requeue:     true,
+		}
+		return
+	}
+
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: etcd.Namespace, Name: caSecretName}, etcdbrCASecret); err != nil {
 		requeue := true
 		if apierrors.IsNotFound(err) {
 			requeue = false
 		}
 		errResult = &taskhandler.Result{
 			Description: "Failed to get etcdbr CA secret",
-			Error:       druiderr.WrapError(err, taskhandler.ErrGetCASecret, string(phase), fmt.Sprintf("failed to get etcdbr CA secret %s/%s", etcd.Namespace, tlsConfig.TLSCASecretRef.Name)),
+			Error:       druiderr.WrapError(err, taskhandler.ErrGetCASecret, string(phase), fmt.Sprintf("failed to get etcdbr CA secret %s/%s", etcd.Namespace, caSecretName)),
 			Requeue:     requeue,
 		}
 		return

--- a/internal/controller/etcdopstask/handler/utils/etcdbrclient.go
+++ b/internal/controller/etcdopstask/handler/utils/etcdbrclient.go
@@ -14,10 +14,11 @@ import (
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/common"
+	"github.com/gardener/etcd-druid/internal/component/statefulset"
 	taskhandler "github.com/gardener/etcd-druid/internal/controller/etcdopstask/handler"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
+	kutil "github.com/gardener/etcd-druid/internal/utils/kubernetes"
 
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,28 +38,26 @@ func ConfigureHTTPClientForEtcdBR(ctx context.Context, k8sClient client.Client, 
 	etcdbrCASecret := &v1.Secret{}
 	dataKey := ptr.Deref(tlsConfig.TLSCASecretRef.DataKey, "bundle.crt")
 
-	sts := &appsv1.StatefulSet{}
-	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: etcd.Namespace, Name: etcd.Name}, sts); err != nil {
-		requeue := true
-		if apierrors.IsNotFound(err) {
-			requeue = false
-		}
+	sts, err := kutil.GetStatefulSet(ctx, k8sClient, etcd)
+	if err != nil {
 		errResult = &taskhandler.Result{
 			Description: "Failed to get StatefulSet for backup-restore CA resolution",
-			Error:       druiderr.WrapError(err, taskhandler.ErrGetCASecret, string(phase), fmt.Sprintf("failed to get StatefulSet %s/%s", etcd.Namespace, etcd.Name)),
-			Requeue:     requeue,
+			Error:       druiderr.WrapError(err, statefulset.ErrGetStatefulSet, string(phase), fmt.Sprintf("failed to get StatefulSet for etcd %s/%s", etcd.Namespace, etcd.Name)),
+			Requeue:     true,
+		}
+		return
+	}
+	if sts == nil {
+		errResult = &taskhandler.Result{
+			Description: fmt.Sprintf("StatefulSet for etcd %s/%s not found or not owned by etcd", etcd.Namespace, etcd.Name),
+			Error:       druiderr.WrapError(fmt.Errorf("StatefulSet for etcd %s/%s not found or not owned", etcd.Namespace, etcd.Name), statefulset.ErrGetStatefulSet, string(phase), "resolve backup-restore CA secret from StatefulSet"),
+			Requeue:     false,
 		}
 		return
 	}
 
-	var caSecretName string
-	for _, vol := range sts.Spec.Template.Spec.Volumes {
-		if vol.Name == common.VolumeNameBackupRestoreCA && vol.Secret != nil {
-			caSecretName = vol.Secret.SecretName
-			break
-		}
-	}
-	if caSecretName == "" {
+	etcdbrCASecretName, ok := kutil.GetVolumeSecretName(sts, common.VolumeNameBackupRestoreCA)
+	if !ok {
 		errResult = &taskhandler.Result{
 			Description: fmt.Sprintf("backup-restore CA volume %q not found on StatefulSet %s/%s", common.VolumeNameBackupRestoreCA, etcd.Namespace, etcd.Name),
 			Error:       druiderr.WrapError(fmt.Errorf("volume %q not found on StatefulSet %s/%s", common.VolumeNameBackupRestoreCA, etcd.Namespace, etcd.Name), taskhandler.ErrGetCASecret, string(phase), "resolve backup-restore CA secret from StatefulSet volumes"),
@@ -67,14 +66,14 @@ func ConfigureHTTPClientForEtcdBR(ctx context.Context, k8sClient client.Client, 
 		return
 	}
 
-	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: etcd.Namespace, Name: caSecretName}, etcdbrCASecret); err != nil {
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: etcd.Namespace, Name: etcdbrCASecretName}, etcdbrCASecret); err != nil {
 		requeue := true
 		if apierrors.IsNotFound(err) {
 			requeue = false
 		}
 		errResult = &taskhandler.Result{
 			Description: "Failed to get etcdbr CA secret",
-			Error:       druiderr.WrapError(err, taskhandler.ErrGetCASecret, string(phase), fmt.Sprintf("failed to get etcdbr CA secret %s/%s", etcd.Namespace, caSecretName)),
+			Error:       druiderr.WrapError(err, taskhandler.ErrGetCASecret, string(phase), fmt.Sprintf("failed to get etcdbr CA secret %s/%s", etcd.Namespace, etcdbrCASecretName)),
 			Requeue:     requeue,
 		}
 		return

--- a/internal/controller/etcdopstask/handler/utils/etcdbrclient_test.go
+++ b/internal/controller/etcdopstask/handler/utils/etcdbrclient_test.go
@@ -13,13 +13,13 @@ import (
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/client/kubernetes"
+	"github.com/gardener/etcd-druid/internal/component/statefulset"
 	taskhandler "github.com/gardener/etcd-druid/internal/controller/etcdopstask/handler"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
@@ -31,6 +31,14 @@ func TestConfigureHTTPClientForEtcdBR(t *testing.T) {
 
 	caCert, err := testutils.GenerateCACert("test")
 	g.Expect(err).ToNot(HaveOccurred())
+
+	const (
+		etcdName  = "test-etcd"
+		namespace = "test-namespace"
+	)
+
+	tlsEnabledEtcd := testutils.EtcdBuilderWithoutDefaults(etcdName, namespace).WithBackupRestoreTLS().Build()
+	tlsEnabledEtcd.UID = "test-etcd-uid"
 
 	tests := []struct {
 		name            string
@@ -46,8 +54,8 @@ func TestConfigureHTTPClientForEtcdBR(t *testing.T) {
 			name: "Should return http scheme and default client when TLS is not configured",
 			etcd: &druidv1alpha1.Etcd{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-etcd",
-					Namespace: "test-namespace",
+					Name:      etcdName,
+					Namespace: namespace,
 				},
 				Spec: druidv1alpha1.EtcdSpec{
 					Backup: druidv1alpha1.BackupSpec{
@@ -63,29 +71,51 @@ func TestConfigureHTTPClientForEtcdBR(t *testing.T) {
 			validateTLS:     false,
 		},
 		{
-			name: "Should return error without requeue when CA secret is not found",
-			etcd: &druidv1alpha1.Etcd{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-etcd",
-					Namespace: "test-namespace",
-				},
-				Spec: druidv1alpha1.EtcdSpec{
-					Backup: druidv1alpha1.BackupSpec{
-						TLS: &druidv1alpha1.TLSConfig{
-							TLSCASecretRef: druidv1alpha1.SecretReference{
-								SecretReference: v1.SecretReference{
-									Name: "ca-secret",
-								},
-								DataKey: ptr.To("ca.crt"),
-							},
-						},
-					},
-				},
-			},
+			name:            "Should return error without requeue when StatefulSet is not found",
+			etcd:            tlsEnabledEtcd,
 			existingObjects: nil,
 			defaultClient:   http.Client{},
 			phase:           druidv1alpha1.LastOperationTypeExecution,
 			expectedScheme:  "",
+			expectedResult: taskhandler.Result{
+				Error: &druiderr.DruidError{
+					Code:      statefulset.ErrGetStatefulSet,
+					Operation: string(druidv1alpha1.LastOperationTypeExecution),
+				},
+				Requeue: false,
+			},
+			validateTLS: false,
+		},
+		{
+			name: "Should return error with requeue when backup-restore CA volume is missing from StatefulSet",
+			etcd: tlsEnabledEtcd,
+			existingObjects: []client.Object{
+				testutils.CreateStatefulSet(etcdName, namespace, tlsEnabledEtcd.UID, 1),
+			},
+			defaultClient:  http.Client{},
+			phase:          druidv1alpha1.LastOperationTypeExecution,
+			expectedScheme: "",
+			expectedResult: taskhandler.Result{
+				Error: &druiderr.DruidError{
+					Code:      taskhandler.ErrGetCASecret,
+					Operation: string(druidv1alpha1.LastOperationTypeExecution),
+				},
+				Requeue: true,
+			},
+			validateTLS: false,
+		},
+		{
+			name: "Should return error without requeue when CA secret is not found",
+			etcd: tlsEnabledEtcd,
+			existingObjects: []client.Object{
+				testutils.AddBackupRestoreCAVolume(
+					testutils.CreateStatefulSet(etcdName, namespace, tlsEnabledEtcd.UID, 1),
+					testutils.BackupRestoreTLSCASecretName,
+				),
+			},
+			defaultClient:  http.Client{},
+			phase:          druidv1alpha1.LastOperationTypeExecution,
+			expectedScheme: "",
 			expectedResult: taskhandler.Result{
 				Error: &druiderr.DruidError{
 					Code:      taskhandler.ErrGetCASecret,
@@ -97,29 +127,16 @@ func TestConfigureHTTPClientForEtcdBR(t *testing.T) {
 		},
 		{
 			name: "Should return error without requeue when CA cert data key is not found in secret",
-			etcd: &druidv1alpha1.Etcd{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-etcd",
-					Namespace: "test-namespace",
-				},
-				Spec: druidv1alpha1.EtcdSpec{
-					Backup: druidv1alpha1.BackupSpec{
-						TLS: &druidv1alpha1.TLSConfig{
-							TLSCASecretRef: druidv1alpha1.SecretReference{
-								SecretReference: v1.SecretReference{
-									Name: "ca-secret",
-								},
-								DataKey: ptr.To("ca.crt"),
-							},
-						},
-					},
-				},
-			},
+			etcd: tlsEnabledEtcd,
 			existingObjects: []client.Object{
+				testutils.AddBackupRestoreCAVolume(
+					testutils.CreateStatefulSet(etcdName, namespace, tlsEnabledEtcd.UID, 1),
+					testutils.BackupRestoreTLSCASecretName,
+				),
 				&v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "ca-secret",
-						Namespace: "test-namespace",
+						Name:      testutils.BackupRestoreTLSCASecretName,
+						Namespace: namespace,
 					},
 					Data: map[string][]byte{
 						"wrong-key": []byte("some-data"),
@@ -140,29 +157,16 @@ func TestConfigureHTTPClientForEtcdBR(t *testing.T) {
 		},
 		{
 			name: "Should return error without requeue when CA cert data is invalid",
-			etcd: &druidv1alpha1.Etcd{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-etcd",
-					Namespace: "test-namespace",
-				},
-				Spec: druidv1alpha1.EtcdSpec{
-					Backup: druidv1alpha1.BackupSpec{
-						TLS: &druidv1alpha1.TLSConfig{
-							TLSCASecretRef: druidv1alpha1.SecretReference{
-								SecretReference: v1.SecretReference{
-									Name: "ca-secret",
-								},
-								DataKey: ptr.To("ca.crt"),
-							},
-						},
-					},
-				},
-			},
+			etcd: tlsEnabledEtcd,
 			existingObjects: []client.Object{
+				testutils.AddBackupRestoreCAVolume(
+					testutils.CreateStatefulSet(etcdName, namespace, tlsEnabledEtcd.UID, 1),
+					testutils.BackupRestoreTLSCASecretName,
+				),
 				&v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "ca-secret",
-						Namespace: "test-namespace",
+						Name:      testutils.BackupRestoreTLSCASecretName,
+						Namespace: namespace,
 					},
 					Data: map[string][]byte{
 						"ca.crt": []byte("invalid-cert-data"),
@@ -183,29 +187,16 @@ func TestConfigureHTTPClientForEtcdBR(t *testing.T) {
 		},
 		{
 			name: "Should successfully configure HTTPS client with valid CA cert",
-			etcd: &druidv1alpha1.Etcd{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-etcd",
-					Namespace: "test-namespace",
-				},
-				Spec: druidv1alpha1.EtcdSpec{
-					Backup: druidv1alpha1.BackupSpec{
-						TLS: &druidv1alpha1.TLSConfig{
-							TLSCASecretRef: druidv1alpha1.SecretReference{
-								SecretReference: v1.SecretReference{
-									Name: "ca-secret",
-								},
-								DataKey: ptr.To("ca.crt"),
-							},
-						},
-					},
-				},
-			},
+			etcd: tlsEnabledEtcd,
 			existingObjects: []client.Object{
+				testutils.AddBackupRestoreCAVolume(
+					testutils.CreateStatefulSet(etcdName, namespace, tlsEnabledEtcd.UID, 1),
+					testutils.BackupRestoreTLSCASecretName,
+				),
 				&v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "ca-secret",
-						Namespace: "test-namespace",
+						Name:      testutils.BackupRestoreTLSCASecretName,
+						Namespace: namespace,
 					},
 					Data: map[string][]byte{
 						"ca.crt": caCert,

--- a/internal/controller/etcdopstask/handler/utils/etcdbrclient_test.go
+++ b/internal/controller/etcdopstask/handler/utils/etcdbrclient_test.go
@@ -87,7 +87,7 @@ func TestConfigureHTTPClientForEtcdBR(t *testing.T) {
 			validateTLS: false,
 		},
 		{
-			name: "Should return error with requeue when backup-restore CA volume is missing from StatefulSet",
+			name: "Should return error without requeue when backup-restore CA volume is missing from StatefulSet",
 			etcd: tlsEnabledEtcd,
 			existingObjects: []client.Object{
 				testutils.CreateStatefulSet(etcdName, namespace, tlsEnabledEtcd.UID, 1),
@@ -100,7 +100,7 @@ func TestConfigureHTTPClientForEtcdBR(t *testing.T) {
 					Code:      taskhandler.ErrGetCASecret,
 					Operation: string(druidv1alpha1.LastOperationTypeExecution),
 				},
-				Requeue: true,
+				Requeue: false,
 			},
 			validateTLS: false,
 		},

--- a/internal/utils/kubernetes/statefulset.go
+++ b/internal/utils/kubernetes/statefulset.go
@@ -156,8 +156,8 @@ func filterTLSVolumeMounts(containerName string, allVolumeMounts []corev1.Volume
 	return filteredVolMounts
 }
 
-// GetVolumeSecretName returns the SecretName of the named Secret-typed volume in the StatefulSet's pod template.
-func GetVolumeSecretName(sts *appsv1.StatefulSet, volumeName string) (string, bool) {
+// GetSecretNameFromVolume returns the SecretName of the named Secret-typed volume in the StatefulSet's pod template.
+func GetSecretNameFromVolume(sts *appsv1.StatefulSet, volumeName string) (string, bool) {
 	if sts == nil {
 		return "", false
 	}

--- a/internal/utils/kubernetes/statefulset.go
+++ b/internal/utils/kubernetes/statefulset.go
@@ -156,7 +156,10 @@ func filterTLSVolumeMounts(containerName string, allVolumeMounts []corev1.Volume
 	return filteredVolMounts
 }
 
-// GetSecretNameFromVolume returns the SecretName of the named Secret-typed volume in the StatefulSet's pod template.
+// GetSecretNameFromVolume looks up a Secret-typed volume by name in the StatefulSet's pod template.
+// It returns the volume's SecretName and true if a volume with the given name exists and has a
+// Secret volume source; otherwise it returns "" and false (when sts is nil, no volume matches the
+// name, or the matching volume's source is not a Secret).
 func GetSecretNameFromVolume(sts *appsv1.StatefulSet, volumeName string) (string, bool) {
 	if sts == nil {
 		return "", false

--- a/internal/utils/kubernetes/statefulset.go
+++ b/internal/utils/kubernetes/statefulset.go
@@ -155,3 +155,16 @@ func filterTLSVolumeMounts(containerName string, allVolumeMounts []corev1.Volume
 	}
 	return filteredVolMounts
 }
+
+// GetVolumeSecretName returns the SecretName of the named Secret-typed volume in the StatefulSet's pod template.
+func GetVolumeSecretName(sts *appsv1.StatefulSet, volumeName string) (string, bool) {
+	if sts == nil {
+		return "", false
+	}
+	for _, vol := range sts.Spec.Template.Spec.Volumes {
+		if vol.Name == volumeName && vol.Secret != nil {
+			return vol.Secret.SecretName, true
+		}
+	}
+	return "", false
+}

--- a/internal/utils/kubernetes/statefulset_test.go
+++ b/internal/utils/kubernetes/statefulset_test.go
@@ -399,3 +399,71 @@ func TestGetStatefulSetContainerTLSVolumeMounts(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSecretNameFromVolume(t *testing.T) {
+	const etcdbrCASecretName = "ca-etcdbr"
+	stsWithCAVolume := testutils.AddBackupRestoreCAVolume(
+		testutils.CreateStatefulSet("test-sts", "test-ns", uuid.NewUUID(), 1),
+		etcdbrCASecretName,
+	)
+	stsWithoutCAVolume := testutils.CreateStatefulSet("test-sts", "test-ns", uuid.NewUUID(), 1)
+	stsWithEmptyDirNamedAsCAVolume := testutils.AddEmptyDirVolume(
+		testutils.CreateStatefulSet("test-sts", "test-ns", uuid.NewUUID(), 1),
+		common.VolumeNameBackupRestoreCA,
+	)
+
+	testCases := []struct {
+		name          string
+		sts           *appsv1.StatefulSet
+		volumeName    string
+		expectedName  string
+		expectedFound bool
+	}{
+		{
+			name:          "sts is nil",
+			sts:           nil,
+			volumeName:    common.VolumeNameBackupRestoreCA,
+			expectedName:  "",
+			expectedFound: false,
+		},
+		{
+			name:          "volume not present on sts",
+			sts:           stsWithoutCAVolume,
+			volumeName:    common.VolumeNameBackupRestoreCA,
+			expectedName:  "",
+			expectedFound: false,
+		},
+		{
+			name:          "secret-typed volume found, returns secret name",
+			sts:           stsWithCAVolume,
+			volumeName:    common.VolumeNameBackupRestoreCA,
+			expectedName:  etcdbrCASecretName,
+			expectedFound: true,
+		},
+		{
+			name:          "volume name matches but volume source is not a secret",
+			sts:           stsWithEmptyDirNamedAsCAVolume,
+			volumeName:    common.VolumeNameBackupRestoreCA,
+			expectedName:  "",
+			expectedFound: false,
+		},
+		{
+			name:          "different volume name queried",
+			sts:           stsWithCAVolume,
+			volumeName:    "nonexistent",
+			expectedName:  "",
+			expectedFound: false,
+		},
+	}
+
+	g := NewWithT(t)
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			name, found := GetSecretNameFromVolume(tc.sts, tc.volumeName)
+			g.Expect(found).To(Equal(tc.expectedFound))
+			g.Expect(name).To(Equal(tc.expectedName))
+		})
+	}
+}

--- a/test/utils/statefulset.go
+++ b/test/utils/statefulset.go
@@ -86,12 +86,22 @@ func CreateStatefulSet(name, namespace string, etcdUID types.UID, replicas int32
 
 // AddBackupRestoreCAVolume appends the backup-restore-ca volume to the StatefulSet's pod
 // template, pointing at the named secret. Returns the StatefulSet for chaining.
-func AddBackupRestoreCAVolume(sts *appsv1.StatefulSet, caSecretName string) *appsv1.StatefulSet {
+func AddBackupRestoreCAVolume(sts *appsv1.StatefulSet, etcdbrCASecretName string) *appsv1.StatefulSet {
 	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, corev1.Volume{
 		Name: common.VolumeNameBackupRestoreCA,
 		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{SecretName: caSecretName},
+			Secret: &corev1.SecretVolumeSource{SecretName: etcdbrCASecretName},
 		},
+	})
+	return sts
+}
+
+// AddEmptyDirVolume appends an EmptyDir volume with the given name to the StatefulSet's
+// pod template. Returns the StatefulSet for chaining.
+func AddEmptyDirVolume(sts *appsv1.StatefulSet, volumeName string) *appsv1.StatefulSet {
+	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name:         volumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 	})
 	return sts
 }

--- a/test/utils/statefulset.go
+++ b/test/utils/statefulset.go
@@ -83,3 +83,15 @@ func CreateStatefulSet(name, namespace string, etcdUID types.UID, replicas int32
 		},
 	}
 }
+
+// AddBackupRestoreCAVolume appends the backup-restore-ca volume to the StatefulSet's pod
+// template, pointing at the named secret. Returns the StatefulSet for chaining.
+func AddBackupRestoreCAVolume(sts *appsv1.StatefulSet, caSecretName string) *appsv1.StatefulSet {
+	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: common.VolumeNameBackupRestoreCA,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{SecretName: caSecretName},
+		},
+	})
+	return sts
+}


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
* Previously the EtcdOpstask handler would refer to the Secret referenced in the Etcd Resource ie in `etcd.spec.backup.tls.serverTLSSecretRef`. 
* There was an issue as described in #1362 which required a change. Since in this issue, the Etcd refers to the newly generated secret and the sts hasn't updated its Secret Ref in its `sts.Spec.Template.Spec.Volumes[i].Secret.SecretName` (where `Volumes[i].Name ==
  common.VolumeNameBackupRestoreCA`), this PR changes the source of the Secret used by OnDemand Snapshot handler to that of the StatefulSet.

**Which issue(s) this PR fixes**:
Fixes Partially #1362 

**Checklist**:
- [ ] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [ ] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [ ] Add tests that cover your changes (if applicable)
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
changed `EtcdOpsTask` OnDemandSnapshot  handler to refer `StatefulSet` volume mounted `Secret`.
```
