### PR TITLE
feat: make backup store secretRef optional to support ambient cloud credentials

### DIFF
--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -339,21 +339,17 @@ func (b *stsBuilder) getEtcdBackupVolumeMount() *corev1.VolumeMount {
 				MountPath: kubernetes.MountPathLocalStore(b.etcd, b.provider),
 			}
 		}
-	case druidstore.GCS:
+	case druidstore.GCS, druidstore.S3, druidstore.ABS, druidstore.OSS, druidstore.Swift, druidstore.OCS:
 		if b.etcd.Spec.Backup.Store.SecretRef == nil {
 			return nil
 		}
-		return &corev1.VolumeMount{
-			Name:      common.VolumeNameProviderBackupSecret,
-			MountPath: common.VolumeMountPathGCSBackupSecret,
-		}
-	case druidstore.S3, druidstore.ABS, druidstore.OSS, druidstore.Swift, druidstore.OCS:
-		if b.etcd.Spec.Backup.Store.SecretRef == nil {
-			return nil
+		mountPath := common.VolumeMountPathNonGCSProviderBackupSecret
+		if *b.provider == druidstore.GCS {
+			mountPath = common.VolumeMountPathGCSBackupSecret
 		}
 		return &corev1.VolumeMount{
 			Name:      common.VolumeNameProviderBackupSecret,
-			MountPath: common.VolumeMountPathNonGCSProviderBackupSecret,
+			MountPath: mountPath,
 		}
 	}
 	return nil

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -340,11 +340,17 @@ func (b *stsBuilder) getEtcdBackupVolumeMount() *corev1.VolumeMount {
 			}
 		}
 	case druidstore.GCS:
+		if b.etcd.Spec.Backup.Store.SecretRef == nil {
+			return nil
+		}
 		return &corev1.VolumeMount{
 			Name:      common.VolumeNameProviderBackupSecret,
 			MountPath: common.VolumeMountPathGCSBackupSecret,
 		}
 	case druidstore.S3, druidstore.ABS, druidstore.OSS, druidstore.Swift, druidstore.OCS:
+		if b.etcd.Spec.Backup.Store.SecretRef == nil {
+			return nil
+		}
 		return &corev1.VolumeMount{
 			Name:      common.VolumeNameProviderBackupSecret,
 			MountPath: common.VolumeMountPathNonGCSProviderBackupSecret,
@@ -860,7 +866,11 @@ func (b *stsBuilder) getBackupVolume(ctx component.OperatorContext) (*corev1.Vol
 		}, nil
 	case druidstore.GCS, druidstore.S3, druidstore.OSS, druidstore.ABS, druidstore.Swift, druidstore.OCS:
 		if store.SecretRef == nil {
-			return nil, fmt.Errorf("etcd: %v, no secretRef configured for backup store", druidv1alpha1.GetNamespaceName(b.etcd.ObjectMeta))
+			// SecretRef is optional when the pod has ambient credentials (e.g. GKE
+			// Workload Identity, EKS IRSA, AKS Workload Identity). In that case the
+			// cloud SDK's Application Default Credentials chain will pick up the
+			// pod-level identity without a mounted secret.
+			return nil, nil
 		}
 
 		return &corev1.Volume{


### PR DESCRIPTION
/area backup
/kind enhancement

**What this PR does / why we need it**:

When a pod runs on a managed Kubernetes cluster with workload identity (GKE Workload Identity, EKS IRSA, AKS Workload Identity), the cloud SDK can mint short-lived credentials without a mounted Kubernetes Secret.

Previously, etcd-druid required a non-nil `secretRef` for all cloud backup providers (GCS, S3, ABS, OSS, Swift, OCS), returning an error when it was absent. This forced users on managed Kubernetes to create and rotate a Kubernetes Secret even when workload identity already grants the necessary cloud storage permissions.

Changes:
- `getBackupVolume`: return `nil, nil` instead of an error when `store.SecretRef == nil` for cloud providers
- `getEtcdBackupVolumeMount`: return `nil` when `store.SecretRef == nil`

When `secretRef` is absent, no credential volume or mount is injected into the StatefulSet. The `backup-restore` container's cloud storage client falls back to the cloud SDK's default credential chain and picks up the workload identity automatically.

`secretRef` remains fully supported — existing deployments that provide one are completely unaffected.

**Which issue(s) this PR fixes**:
N/A — no tracking issue

**Checklist**:
- [ ] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [ ] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [ ] Add tests that cover your changes (if applicable)
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:

Validated on GKE with Workload Identity enabled:
- Removed `secretRef` from an `Etcd` CR backed by GCS
- etcd-druid successfully created the StatefulSet without injecting a credential volume
- `etcd-backup-restore` authenticated to GCS via the GKE metadata server and took snapshots successfully without any Kubernetes Secret

**Release note**:
```feature operator
`spec.backup.store.secretRef` is now not necessary for taking backups to cloud backup providers (GCS, S3, ABS, OSS, Swift, OCS). When omitted & workload identity is enabled, no credential volume is mounted into the StatefulSet, and the backup-restore container falls back to workload identity (e.g. GKE Workload Identity, EKS IRSA, AKS Workload Identity) via each cloud SDK's default credential chain.
```
