### PR TITLE
Escape angular brackets

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -18,6 +18,8 @@ check-generate:
 .PHONY: generate-api-docs
 generate-api-docs: $(CRD_REF_DOCS)
 	@crd-ref-docs --source-path "$(REPO_ROOT)/api" --config "$(HACK_DIR)/api-reference/config.yaml" --output-path "$(REPO_ROOT)/docs/api-reference/etcd-druid-api.md" --renderer markdown
+	@# crd-ref-docs emits stray "<nil>" strings for empty template fields (e.g., XValidation messageExpression).
+	@sed -i.bak -E 's/[[:space:]]*<nil>//g' "$(REPO_ROOT)/docs/api-reference/etcd-druid-api.md" && rm -f "$(REPO_ROOT)/docs/api-reference/etcd-druid-api.md.bak"
 
 .PHONY: check-apidiff
 check-apidiff: $(GO_APIDIFF)

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -417,7 +417,7 @@ spec:
                       additional URLs. The member name must follow the pattern {etcd-name}-{index}
                       where index is 0 to (replicas-1) (e.g., etcd-main-0, etcd-main-1 etc).
                       When spec.memberNamePrefix is set, member names become
-                      "<memberNamePrefix>-<podName>".
+                      `<memberNamePrefix>-<podName>`.
                       Updating this field on a running cluster triggers a ConfigMap update
                       and a rolling restart of the StatefulSet.
                     items:
@@ -429,7 +429,7 @@ spec:
                             MemberName is the etcd member name.
                             Must match the etcd member name of the cluster (e.g., etcd-main-0).
                             When spec.memberNamePrefix is set, the member name becomes
-                            "<memberNamePrefix>-<podName>". The top-level CEL rules on
+                            `<memberNamePrefix>-<podName>`. The top-level CEL rules on
                             Etcd already incorporate the prefix when validating these names.
                           maxLength: 253
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?-[0-9]+$

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
@@ -375,7 +375,7 @@ spec:
                         additional URLs. The member name must follow the pattern {etcd-name}-{index}
                         where index is 0 to (replicas-1) (e.g., etcd-main-0, etcd-main-1 etc).
                         When spec.memberNamePrefix is set, member names become
-                        "<memberNamePrefix>-<podName>".
+                        `<memberNamePrefix>-<podName>`.
                         Updating this field on a running cluster triggers a ConfigMap update
                         and a rolling restart of the StatefulSet.
                       items:
@@ -386,7 +386,7 @@ spec:
                               MemberName is the etcd member name.
                               Must match the etcd member name of the cluster (e.g., etcd-main-0).
                               When spec.memberNamePrefix is set, the member name becomes
-                              "<memberNamePrefix>-<podName>". The top-level CEL rules on
+                              `<memberNamePrefix>-<podName>`. The top-level CEL rules on
                               Etcd already incorporate the prefix when validating these names.
                             maxLength: 253
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?-[0-9]+$

--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -314,7 +314,7 @@ type EtcdConfig struct {
 	// additional URLs. The member name must follow the pattern {etcd-name}-{index}
 	// where index is 0 to (replicas-1) (e.g., etcd-main-0, etcd-main-1 etc).
 	// When spec.memberNamePrefix is set, member names become
-	// "<memberNamePrefix>-<podName>".
+	// `<memberNamePrefix>-<podName>`.
 	// Updating this field on a running cluster triggers a ConfigMap update
 	// and a rolling restart of the StatefulSet.
 	// +optional
@@ -373,7 +373,7 @@ type MemberPeerURLs struct {
 	// MemberName is the etcd member name.
 	// Must match the etcd member name of the cluster (e.g., etcd-main-0).
 	// When spec.memberNamePrefix is set, the member name becomes
-	// "<memberNamePrefix>-<podName>". The top-level CEL rules on
+	// `<memberNamePrefix>-<podName>`. The top-level CEL rules on
 	// Etcd already incorporate the prefix when validating these names.
 	// +required
 	// +kubebuilder:validation:Required

--- a/api/hack/tools.mk
+++ b/api/hack/tools.mk
@@ -17,7 +17,7 @@ YQ                         := $(TOOLS_BIN_DIR)/yq
 CONTROLLER_GEN_VERSION ?= $(call version_gomod,sigs.k8s.io/controller-tools)
 GOLANGCI_LINT_VERSION ?= v2.8.0
 GOIMPORTS_REVISER_VERSION ?= v3.9.1
-CRD_REF_DOCS_VERSION ?= v0.2.0
+CRD_REF_DOCS_VERSION ?= v0.3.0
 GO_APIDIFF_VERSION ?= v0.8.2
 YQ_VERSION ?= v4.45.1
 

--- a/charts/crds/druid.gardener.cloud_etcds.yaml
+++ b/charts/crds/druid.gardener.cloud_etcds.yaml
@@ -417,7 +417,7 @@ spec:
                       additional URLs. The member name must follow the pattern {etcd-name}-{index}
                       where index is 0 to (replicas-1) (e.g., etcd-main-0, etcd-main-1 etc).
                       When spec.memberNamePrefix is set, member names become
-                      "<memberNamePrefix>-<podName>".
+                      `<memberNamePrefix>-<podName>`.
                       Updating this field on a running cluster triggers a ConfigMap update
                       and a rolling restart of the StatefulSet.
                     items:
@@ -429,7 +429,7 @@ spec:
                             MemberName is the etcd member name.
                             Must match the etcd member name of the cluster (e.g., etcd-main-0).
                             When spec.memberNamePrefix is set, the member name becomes
-                            "<memberNamePrefix>-<podName>". The top-level CEL rules on
+                            `<memberNamePrefix>-<podName>`. The top-level CEL rules on
                             Etcd already incorporate the prefix when validating these names.
                           maxLength: 253
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?-[0-9]+$

--- a/docs/api-reference/etcd-druid-api.md
+++ b/docs/api-reference/etcd-druid-api.md
@@ -44,7 +44,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Enabled specifies whether backup compaction should be enabled. |  |  |
-| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
+| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  | Optional: \{\} <br /> |
 | `eventsThreshold` _integer_ | EventsThreshold denotes total number of etcd events to be reached upon which a backup compaction job is triggered. |  |  |
 | `triggerFullSnapshotThreshold` _integer_ | TriggerFullSnapshotThreshold denotes the upper threshold for the number of etcd events before giving up on compaction job and triggering a full snapshot. |  |  |
 | `activeDeadlineDuration` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | ActiveDeadlineDuration is the duration after which a running compaction job will be killed. |  |  |
@@ -64,7 +64,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `disableLeaseCache` _boolean_ | DisableLeaseCache disables the cache for lease.coordination.k8s.io resources.<br />Deprecated: This field will be eventually removed. It is recommended to not use this.<br />It has only been introduced to allow for backward compatibility with the old CLI flags. |  |  |
+| `disableLeaseCache` _boolean_ | DisableLeaseCache disables the cache for lease.coordination.k8s.io resources.<br />Deprecated: This field will be eventually removed. It is recommended to not use this.<br />It has only been introduced to allow for backward compatibility with the old CLI flags. |  | Optional: \{\} <br /> |
 | `etcd` _[EtcdControllerConfiguration](#etcdcontrollerconfiguration)_ | Etcd is the configuration for the Etcd controller. |  |  |
 | `compaction` _[CompactionControllerConfiguration](#compactioncontrollerconfiguration)_ | Compaction is the configuration for the compaction controller. |  |  |
 | `etcdCopyBackupsTask` _[EtcdCopyBackupsTaskControllerConfiguration](#etcdcopybackupstaskcontrollerconfiguration)_ | EtcdCopyBackupsTask is the configuration for the EtcdCopyBackupsTask controller. |  |  |
@@ -105,7 +105,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
+| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  | Optional: \{\} <br /> |
 | `enableEtcdSpecAutoReconcile` _boolean_ | EnableEtcdSpecAutoReconcile controls how the Etcd Spec is reconciled. If set to true, then any change in Etcd spec<br />will automatically trigger a reconciliation of the Etcd resource. If set to false, then an operator needs to<br />explicitly set gardener.cloud/operation=reconcile annotation on the Etcd resource to trigger reconciliation<br />of the Etcd spec.<br />NOTE: Decision to enable it should be carefully taken as spec updates could potentially result in rolling update<br />of the StatefulSet which will cause a minor downtime for a single node etcd cluster and can potentially cause a<br />downtime for a multi-node etcd cluster. |  |  |
 | `disableEtcdServiceAccountAutomount` _boolean_ | DisableEtcdServiceAccountAutomount controls the auto-mounting of service account token for etcd StatefulSets. |  |  |
 | `etcdStatusSyncPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | EtcdStatusSyncPeriod is the duration after which an event will be re-queued ensuring etcd status synchronization. |  |  |
@@ -159,8 +159,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
-| `requeueInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | RequeueInterval is the duration to wait before re-queuing a reconcile request for EtcdOpsTask. |  |  |
+| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  | Optional: \{\} <br /> |
+| `requeueInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | RequeueInterval is the duration to wait before re-queuing a reconcile request for EtcdOpsTask. |  | Optional: \{\} <br /> |
 
 
 #### LeaderElectionConfiguration
@@ -253,7 +253,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  |  |
+| `concurrentSyncs` _integer_ | ConcurrentSyncs is the max number of concurrent workers that can be run, each worker servicing a reconcile request. |  | Optional: \{\} <br /> |
 
 
 #### Server
@@ -287,8 +287,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `webhooks` _[TLSServer](#tlsserver)_ | Webhooks is the configuration for the TLS webhook server. |  |  |
-| `metrics` _[Server](#server)_ | Metrics is the configuration for serving the metrics endpoint. |  |  |
+| `webhooks` _[TLSServer](#tlsserver)_ | Webhooks is the configuration for the TLS webhook server. |  | Optional: \{\} <br /> |
+| `metrics` _[Server](#server)_ | Metrics is the configuration for serving the metrics endpoint. |  | Optional: \{\} <br /> |
 
 
 #### ServiceAccountInfo
@@ -453,23 +453,23 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `port` _integer_ | Port define the port on which etcd-backup-restore server will be exposed. |  |  |
-| `tls` _[TLSConfig](#tlsconfig)_ |  |  |  |
-| `image` _string_ | Image defines the etcd container image and tag |  |  |
-| `store` _[StoreSpec](#storespec)_ | Store defines the specification of object store provider for storing backups. |  |  |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#resourcerequirements-v1-core)_ | Resources defines compute Resources required by backup-restore container.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ |  |  |
-| `snapshotCompaction` _[SnapshotCompactionSpec](#snapshotcompactionspec)_ | SnapshotCompaction defines the specification for compaction of backups. |  |  |
-| `fullSnapshotSchedule` _string_ | FullSnapshotSchedule defines the cron standard schedule for full snapshots. |  | Pattern: `^(\*\|[1-5]?[0-9]\|[1-5]?[0-9]-[1-5]?[0-9]\|(?:[1-9]\|[1-4][0-9]\|5[0-9])\/(?:[1-9]\|[1-4][0-9]\|5[0-9]\|60)\|\*\/(?:[1-9]\|[1-4][0-9]\|5[0-9]\|60))\s+(\*\|[0-9]\|1[0-9]\|2[0-3]\|[0-9]-(?:[0-9]\|1[0-9]\|2[0-3])\|1[0-9]-(?:1[0-9]\|2[0-3])\|2[0-3]-2[0-3]\|(?:[1-9]\|1[0-9]\|2[0-3])\/(?:[1-9]\|1[0-9]\|2[0-4])\|\*\/(?:[1-9]\|1[0-9]\|2[0-4]))\s+(\*\|[1-9]\|[12][0-9]\|3[01]\|[1-9]-(?:[1-9]\|[12][0-9]\|3[01])\|[12][0-9]-(?:[12][0-9]\|3[01])\|3[01]-3[01]\|(?:[1-9]\|[12][0-9]\|30)\/(?:[1-9]\|[12][0-9]\|3[01])\|\*\/(?:[1-9]\|[12][0-9]\|3[01]))\s+(\*\|[1-9]\|1[0-2]\|[1-9]-(?:[1-9]\|1[0-2])\|1[0-2]-1[0-2]\|(?:[1-9]\|1[0-2])\/(?:[1-9]\|1[0-2])\|\*\/(?:[1-9]\|1[0-2]))\s+(\*\|[1-7]\|[1-6]-[1-7]\|[1-6]\/[1-7]\|\*\/[1-7])$` <br /> |
-| `garbageCollectionPolicy` _[GarbageCollectionPolicy](#garbagecollectionpolicy)_ | GarbageCollectionPolicy defines the policy for garbage collecting old backups |  | Enum: [Exponential LimitBased] <br /> |
-| `maxBackupsLimitBasedGC` _integer_ | MaxBackupsLimitBasedGC defines the maximum number of Full snapshots to retain in Limit Based GarbageCollectionPolicy<br />All full snapshots beyond this limit will be garbage collected. |  |  |
-| `garbageCollectionPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | GarbageCollectionPeriod defines the period for garbage collecting old backups |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br /> |
-| `deltaSnapshotPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | DeltaSnapshotPeriod defines the period after which delta snapshots will be taken |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br /> |
-| `deltaSnapshotMemoryLimit` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#quantity-resource-api)_ | DeltaSnapshotMemoryLimit defines the memory limit after which delta snapshots will be taken |  |  |
-| `deltaSnapshotRetentionPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | DeltaSnapshotRetentionPeriod defines the duration for which delta snapshots will be retained, excluding the latest snapshot set.<br />The value should be a string formatted as a duration (e.g., '1s', '2m', '3h', '4d') |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br /> |
-| `compression` _[CompressionSpec](#compressionspec)_ | SnapshotCompression defines the specification for compression of Snapshots. |  |  |
-| `enableProfiling` _boolean_ | EnableProfiling defines if profiling should be enabled for the etcd-backup-restore-sidecar |  |  |
-| `etcdSnapshotTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | EtcdSnapshotTimeout defines the timeout duration for etcd FullSnapshot operation |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br /> |
-| `leaderElection` _[LeaderElectionSpec](#leaderelectionspec)_ | LeaderElection defines parameters related to the LeaderElection configuration. |  |  |
+| `port` _integer_ | Port define the port on which etcd-backup-restore server will be exposed. |  | Optional: \{\} <br /> |
+| `tls` _[TLSConfig](#tlsconfig)_ |  |  | Optional: \{\} <br /> |
+| `image` _string_ | Image defines the etcd container image and tag |  | Optional: \{\} <br /> |
+| `store` _[StoreSpec](#storespec)_ | Store defines the specification of object store provider for storing backups. |  | Optional: \{\} <br /> |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#resourcerequirements-v1-core)_ | Resources defines compute Resources required by backup-restore container.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ |  | Optional: \{\} <br /> |
+| `snapshotCompaction` _[SnapshotCompactionSpec](#snapshotcompactionspec)_ | SnapshotCompaction defines the specification for compaction of backups. |  | Optional: \{\} <br /> |
+| `fullSnapshotSchedule` _string_ | FullSnapshotSchedule defines the cron standard schedule for full snapshots. |  | Pattern: `^(\*\|[1-5]?[0-9]\|[1-5]?[0-9]-[1-5]?[0-9]\|(?:[1-9]\|[1-4][0-9]\|5[0-9])\/(?:[1-9]\|[1-4][0-9]\|5[0-9]\|60)\|\*\/(?:[1-9]\|[1-4][0-9]\|5[0-9]\|60))\s+(\*\|[0-9]\|1[0-9]\|2[0-3]\|[0-9]-(?:[0-9]\|1[0-9]\|2[0-3])\|1[0-9]-(?:1[0-9]\|2[0-3])\|2[0-3]-2[0-3]\|(?:[1-9]\|1[0-9]\|2[0-3])\/(?:[1-9]\|1[0-9]\|2[0-4])\|\*\/(?:[1-9]\|1[0-9]\|2[0-4]))\s+(\*\|[1-9]\|[12][0-9]\|3[01]\|[1-9]-(?:[1-9]\|[12][0-9]\|3[01])\|[12][0-9]-(?:[12][0-9]\|3[01])\|3[01]-3[01]\|(?:[1-9]\|[12][0-9]\|30)\/(?:[1-9]\|[12][0-9]\|3[01])\|\*\/(?:[1-9]\|[12][0-9]\|3[01]))\s+(\*\|[1-9]\|1[0-2]\|[1-9]-(?:[1-9]\|1[0-2])\|1[0-2]-1[0-2]\|(?:[1-9]\|1[0-2])\/(?:[1-9]\|1[0-2])\|\*\/(?:[1-9]\|1[0-2]))\s+(\*\|[1-7]\|[1-6]-[1-7]\|[1-6]\/[1-7]\|\*\/[1-7])$` <br />Optional: \{\} <br /> |
+| `garbageCollectionPolicy` _[GarbageCollectionPolicy](#garbagecollectionpolicy)_ | GarbageCollectionPolicy defines the policy for garbage collecting old backups |  | Enum: [Exponential LimitBased] <br />Optional: \{\} <br /> |
+| `maxBackupsLimitBasedGC` _integer_ | MaxBackupsLimitBasedGC defines the maximum number of Full snapshots to retain in Limit Based GarbageCollectionPolicy<br />All full snapshots beyond this limit will be garbage collected. |  | Optional: \{\} <br /> |
+| `garbageCollectionPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | GarbageCollectionPeriod defines the period for garbage collecting old backups |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br />Optional: \{\} <br /> |
+| `deltaSnapshotPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | DeltaSnapshotPeriod defines the period after which delta snapshots will be taken |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br />Optional: \{\} <br /> |
+| `deltaSnapshotMemoryLimit` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#quantity-resource-api)_ | DeltaSnapshotMemoryLimit defines the memory limit after which delta snapshots will be taken |  | Optional: \{\} <br /> |
+| `deltaSnapshotRetentionPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | DeltaSnapshotRetentionPeriod defines the duration for which delta snapshots will be retained, excluding the latest snapshot set.<br />The value should be a string formatted as a duration (e.g., '1s', '2m', '3h', '4d') |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br />Optional: \{\} <br /> |
+| `compression` _[CompressionSpec](#compressionspec)_ | SnapshotCompression defines the specification for compression of Snapshots. |  | Optional: \{\} <br /> |
+| `enableProfiling` _boolean_ | EnableProfiling defines if profiling should be enabled for the etcd-backup-restore-sidecar |  | Optional: \{\} <br /> |
+| `etcdSnapshotTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | EtcdSnapshotTimeout defines the timeout duration for etcd FullSnapshot operation |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br />Optional: \{\} <br /> |
+| `leaderElection` _[LeaderElectionSpec](#leaderelectionspec)_ | LeaderElection defines parameters related to the LeaderElection configuration. |  | Optional: \{\} <br /> |
 
 
 #### BboltFreelistType
@@ -503,8 +503,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `name` _string_ | Name is the etcd member name in the source cluster. |  | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br />Required: \{\} <br /> |
-| `peerUrls` _string array_ | PeerURLs are the peer URLs of this member.<br />Must be valid HTTP or HTTPS URLs with scheme and host; port is optional<br />(e.g., https://10.0.0.1:2380).<br />A maximum of 5 peer URLs can be specified per member (constrained by CEL validation cost budget). |  | MaxItems: 5 <br />MinItems: 1 <br />Required: \{\} <br />items:MaxLength: 2048 <br />items:XValidation: \{(self.startsWith('http://') \|\| self.startsWith('https://')) && isURL(self) must be a valid http:// or https:// URL (e.g., https://10.0.0.1:2380)    <nil>\} <br /> |
+| `name` _string_ | Name is the etcd member name in the source cluster. |  | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br />Required: \{\} <br />Required: \{\} <br /> |
+| `peerUrls` _string array_ | PeerURLs are the peer URLs of this member.<br />Must be valid HTTP or HTTPS URLs with scheme and host; port is optional<br />(e.g., https://10.0.0.1:2380).<br />A maximum of 5 peer URLs can be specified per member (constrained by CEL validation cost budget). |  | MaxItems: 5 <br />MinItems: 1 <br />Required: \{\} <br />items:MaxLength: 2048 <br />items:XValidation: \{(self.startsWith('http://') \|\| self.startsWith('https://')) && isURL(self) must be a valid http:// or https:// URL (e.g., https://10.0.0.1:2380)\} <br />Required: \{\} <br /> |
 
 
 #### BootstrapJoinedMember
@@ -522,8 +522,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `name` _string_ | Name is the source-cluster member's name. |  |  |
-| `peerUrls` _string array_ | PeerURLs are the source member's peer URLs, copied from<br />spec.etcd.bootstrapWithExistingCluster.members at the time the<br />snapshot was recorded. |  |  |
+| `name` _string_ | Name is the source-cluster member's name. |  | Required: \{\} <br /> |
+| `peerUrls` _string array_ | PeerURLs are the source member's peer URLs, copied from<br />spec.etcd.bootstrapWithExistingCluster.members at the time the<br />snapshot was recorded. |  | Required: \{\} <br /> |
 
 
 #### BootstrapWithExistingCluster
@@ -550,8 +550,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `members` _[BootstrapExistingMember](#bootstrapexistingmember) array_ | Members are the existing etcd members of the source cluster.<br />A maximum of 10 members can be specified (constrained by CEL validation cost budget). |  | MaxItems: 10 <br />MinItems: 1 <br />Required: \{\} <br /> |
-| `clientEndpoints` _string array_ | ClientEndpoints are the client endpoints of the source cluster for member management.<br />Must be valid HTTP or HTTPS URLs with scheme and host; port is optional<br />(e.g., https://etcd-source-client.source-ns.svc:2379).<br />A maximum of 10 client endpoints can be specified (constrained by CEL validation cost budget). |  | MaxItems: 10 <br />MinItems: 1 <br />Required: \{\} <br />items:MaxLength: 2048 <br />items:XValidation: \{(self.startsWith('http://') \|\| self.startsWith('https://')) && isURL(self) must be a valid http:// or https:// URL (e.g., https://etcd-source-client.source-ns.svc:2379)    <nil>\} <br /> |
+| `members` _[BootstrapExistingMember](#bootstrapexistingmember) array_ | Members are the existing etcd members of the source cluster.<br />A maximum of 10 members can be specified (constrained by CEL validation cost budget). |  | MaxItems: 10 <br />MinItems: 1 <br />Required: \{\} <br />Required: \{\} <br /> |
+| `clientEndpoints` _string array_ | ClientEndpoints are the client endpoints of the source cluster for member management.<br />Must be valid HTTP or HTTPS URLs with scheme and host; port is optional<br />(e.g., https://etcd-source-client.source-ns.svc:2379).<br />A maximum of 10 client endpoints can be specified (constrained by CEL validation cost budget). |  | MaxItems: 10 <br />MinItems: 1 <br />Required: \{\} <br />items:MaxLength: 2048 <br />items:XValidation: \{(self.startsWith('http://') \|\| self.startsWith('https://')) && isURL(self) must be a valid http:// or https:// URL (e.g., https://etcd-source-client.source-ns.svc:2379)\} <br />Required: \{\} <br /> |
 
 
 #### BootstrapWithExistingClusterStatus
@@ -570,8 +570,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `joinedAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)_ | JoinedAt is the time at which the snapshot was recorded. |  |  |
-| `members` _[BootstrapJoinedMember](#bootstrapjoinedmember) array_ | Members are the source-cluster members observed at the time the<br />snapshot was recorded. |  |  |
+| `joinedAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)_ | JoinedAt is the time at which the snapshot was recorded. |  | Required: \{\} <br /> |
+| `members` _[BootstrapJoinedMember](#bootstrapjoinedmember) array_ | Members are the source-cluster members observed at the time the<br />snapshot was recorded. |  | Required: \{\} <br /> |
 
 
 #### ClientService
@@ -587,9 +587,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `annotations` _object (keys:string, values:string)_ | Annotations specify the annotations that should be added to the client service |  |  |
-| `labels` _object (keys:string, values:string)_ | Labels specify the labels that should be added to the client service |  |  |
-| `trafficDistribution` _string_ | TrafficDistribution defines the traffic distribution preference that should be added to the client service.<br />More info: https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution |  | Enum: [PreferSameZone PreferSameNode PreferClose] <br /> |
+| `annotations` _object (keys:string, values:string)_ | Annotations specify the annotations that should be added to the client service |  | Optional: \{\} <br /> |
+| `labels` _object (keys:string, values:string)_ | Labels specify the labels that should be added to the client service |  | Optional: \{\} <br /> |
+| `trafficDistribution` _string_ | TrafficDistribution defines the traffic distribution preference that should be added to the client service.<br />More info: https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution |  | Enum: [PreferSameZone PreferSameNode PreferClose] <br />Optional: \{\} <br /> |
 
 
 #### CompactionMode
@@ -643,8 +643,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `enabled` _boolean_ |  |  |  |
-| `policy` _[CompressionPolicy](#compressionpolicy)_ |  |  | Enum: [gzip lzw zlib] <br /> |
+| `enabled` _boolean_ |  |  | Optional: \{\} <br /> |
+| `policy` _[CompressionPolicy](#compressionpolicy)_ |  |  | Enum: [gzip lzw zlib] <br />Optional: \{\} <br /> |
 
 
 #### Condition
@@ -727,9 +727,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `kind` _string_ | Kind of the referent |  |  |
-| `name` _string_ | Name of the referent |  |  |
-| `apiVersion` _string_ | API version of the referent |  |  |
+| `kind` _string_ | Kind of the referent |  | Required: \{\} <br /> |
+| `name` _string_ | Name of the referent |  | Required: \{\} <br /> |
+| `apiVersion` _string_ | API version of the referent |  | Optional: \{\} <br /> |
 
 
 #### Etcd
@@ -764,25 +764,25 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `quota` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#quantity-resource-api)_ | Quota defines the etcd DB quota. |  |  |
-| `snapshotCount` _integer_ | SnapshotCount defines the number of applied Raft entries to hold in-memory before compaction.<br />More info: https://etcd.io/docs/v3.5/op-guide/maintenance/#raft-log-retention |  |  |
-| `enableGRPCGateway` _boolean_ | EnableGRPCGateway enables the gRPC-Gateway proxy for etcd. |  |  |
-| `defragmentationSchedule` _string_ | DefragmentationSchedule defines the cron standard schedule for defragmentation of etcd. |  | Pattern: `^(\*\|[1-5]?[0-9]\|[1-5]?[0-9]-[1-5]?[0-9]\|(?:[1-9]\|[1-4][0-9]\|5[0-9])\/(?:[1-9]\|[1-4][0-9]\|5[0-9]\|60)\|\*\/(?:[1-9]\|[1-4][0-9]\|5[0-9]\|60))\s+(\*\|[0-9]\|1[0-9]\|2[0-3]\|[0-9]-(?:[0-9]\|1[0-9]\|2[0-3])\|1[0-9]-(?:1[0-9]\|2[0-3])\|2[0-3]-2[0-3]\|(?:[1-9]\|1[0-9]\|2[0-3])\/(?:[1-9]\|1[0-9]\|2[0-4])\|\*\/(?:[1-9]\|1[0-9]\|2[0-4]))\s+(\*\|[1-9]\|[12][0-9]\|3[01]\|[1-9]-(?:[1-9]\|[12][0-9]\|3[01])\|[12][0-9]-(?:[12][0-9]\|3[01])\|3[01]-3[01]\|(?:[1-9]\|[12][0-9]\|30)\/(?:[1-9]\|[12][0-9]\|3[01])\|\*\/(?:[1-9]\|[12][0-9]\|3[01]))\s+(\*\|[1-9]\|1[0-2]\|[1-9]-(?:[1-9]\|1[0-2])\|1[0-2]-1[0-2]\|(?:[1-9]\|1[0-2])\/(?:[1-9]\|1[0-2])\|\*\/(?:[1-9]\|1[0-2]))\s+(\*\|[1-7]\|[1-6]-[1-7]\|[1-6]\/[1-7]\|\*\/[1-7])$` <br /> |
-| `serverPort` _integer_ |  |  |  |
-| `clientPort` _integer_ |  |  |  |
-| `wrapperPort` _integer_ |  |  |  |
-| `image` _string_ | Image defines the etcd container image and tag |  |  |
-| `authSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  |  |
-| `metrics` _[MetricsLevel](#metricslevel)_ | Metrics defines the level of detail for exported metrics of etcd, specify 'extensive' to include histogram metrics. |  | Enum: [basic extensive] <br /> |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#resourcerequirements-v1-core)_ | Resources defines the compute Resources required by etcd container.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ |  |  |
-| `clientUrlTls` _[TLSConfig](#tlsconfig)_ | ClientUrlTLS contains the ca, server TLS and client TLS secrets for client communication to ETCD cluster |  |  |
-| `additionalAdvertisePeerURLs` _[MemberPeerURLs](#memberpeerurls) array_ | AdditionalAdvertisePeerURLs contains extra per-member peer URLs to append<br />to initial-advertise-peer-urls. Each entry maps a member name to its<br />additional URLs. The member name must follow the pattern \{etcd-name\}-\{index\}<br />where index is 0 to (replicas-1) (e.g., etcd-main-0, etcd-main-1 etc).<br />When spec.memberNamePrefix is set, member names become<br />"<memberNamePrefix>-<podName>".<br />Updating this field on a running cluster triggers a ConfigMap update<br />and a rolling restart of the StatefulSet. |  | MaxItems: 10 <br /> |
-| `peerUrlTls` _[PeerTLSConfig](#peertlsconfig)_ | PeerUrlTLS contains the ca and server TLS secrets for peer communication within ETCD cluster.<br />Currently, PeerUrlTLS does not require client TLS secrets for gardener implementation of ETCD cluster.<br />In addition to the base TLSConfig fields it also exposes the peer-only<br />SkipClientSANVerification knob (see PeerTLSConfig). |  |  |
-| `etcdDefragTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | EtcdDefragTimeout defines the timeout duration for etcd defrag call |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br /> |
-| `heartbeatDuration` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | HeartbeatDuration defines the duration for members to send heartbeats. The default value is 10s. |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br /> |
-| `clientService` _[ClientService](#clientservice)_ | ClientService defines the parameters of the client service that a user can specify |  |  |
-| `backendBboltFreelistType` _[BboltFreelistType](#bboltfreelisttype)_ | BackendBboltFreelistType specifies the freelist-type used by the bbolt backend storage engine of etcd.<br />Supported values are 'array' (default) and 'map'.<br />It corresponds to the etcd's flag --backend-bbolt-freelist-type which available only from etcd version 3.5.x<br />Note: Although etcd v3.5.x defaults `--backend-bbolt-freelist-type` to "map", etcd-druid default to "array"<br />because for "map", it has been observed to cause significant increase in total database size.<br />The "array" freelist type is more space-efficient for the small databases (a few GBs) clusters.<br />Please refer to this issue for more info: https://github.com/gardener/etcd-druid/issues/1373 |  | Enum: [array map] <br /> |
-| `bootstrapWithExistingCluster` _[BootstrapWithExistingCluster](#bootstrapwithexistingcluster)_ | BootstrapWithExistingCluster configures this etcd to join an existing cluster. |  |  |
+| `quota` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#quantity-resource-api)_ | Quota defines the etcd DB quota. |  | Optional: \{\} <br /> |
+| `snapshotCount` _integer_ | SnapshotCount defines the number of applied Raft entries to hold in-memory before compaction.<br />More info: https://etcd.io/docs/v3.5/op-guide/maintenance/#raft-log-retention |  | Optional: \{\} <br /> |
+| `enableGRPCGateway` _boolean_ | EnableGRPCGateway enables the gRPC-Gateway proxy for etcd. |  | Optional: \{\} <br /> |
+| `defragmentationSchedule` _string_ | DefragmentationSchedule defines the cron standard schedule for defragmentation of etcd. |  | Pattern: `^(\*\|[1-5]?[0-9]\|[1-5]?[0-9]-[1-5]?[0-9]\|(?:[1-9]\|[1-4][0-9]\|5[0-9])\/(?:[1-9]\|[1-4][0-9]\|5[0-9]\|60)\|\*\/(?:[1-9]\|[1-4][0-9]\|5[0-9]\|60))\s+(\*\|[0-9]\|1[0-9]\|2[0-3]\|[0-9]-(?:[0-9]\|1[0-9]\|2[0-3])\|1[0-9]-(?:1[0-9]\|2[0-3])\|2[0-3]-2[0-3]\|(?:[1-9]\|1[0-9]\|2[0-3])\/(?:[1-9]\|1[0-9]\|2[0-4])\|\*\/(?:[1-9]\|1[0-9]\|2[0-4]))\s+(\*\|[1-9]\|[12][0-9]\|3[01]\|[1-9]-(?:[1-9]\|[12][0-9]\|3[01])\|[12][0-9]-(?:[12][0-9]\|3[01])\|3[01]-3[01]\|(?:[1-9]\|[12][0-9]\|30)\/(?:[1-9]\|[12][0-9]\|3[01])\|\*\/(?:[1-9]\|[12][0-9]\|3[01]))\s+(\*\|[1-9]\|1[0-2]\|[1-9]-(?:[1-9]\|1[0-2])\|1[0-2]-1[0-2]\|(?:[1-9]\|1[0-2])\/(?:[1-9]\|1[0-2])\|\*\/(?:[1-9]\|1[0-2]))\s+(\*\|[1-7]\|[1-6]-[1-7]\|[1-6]\/[1-7]\|\*\/[1-7])$` <br />Optional: \{\} <br /> |
+| `serverPort` _integer_ |  |  | Optional: \{\} <br /> |
+| `clientPort` _integer_ |  |  | Optional: \{\} <br /> |
+| `wrapperPort` _integer_ |  |  | Optional: \{\} <br /> |
+| `image` _string_ | Image defines the etcd container image and tag |  | Optional: \{\} <br /> |
+| `authSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  | Optional: \{\} <br /> |
+| `metrics` _[MetricsLevel](#metricslevel)_ | Metrics defines the level of detail for exported metrics of etcd, specify 'extensive' to include histogram metrics. |  | Enum: [basic extensive] <br />Optional: \{\} <br /> |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#resourcerequirements-v1-core)_ | Resources defines the compute Resources required by etcd container.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ |  | Optional: \{\} <br /> |
+| `clientUrlTls` _[TLSConfig](#tlsconfig)_ | ClientUrlTLS contains the ca, server TLS and client TLS secrets for client communication to ETCD cluster |  | Optional: \{\} <br /> |
+| `additionalAdvertisePeerURLs` _[MemberPeerURLs](#memberpeerurls) array_ | AdditionalAdvertisePeerURLs contains extra per-member peer URLs to append<br />to initial-advertise-peer-urls. Each entry maps a member name to its<br />additional URLs. The member name must follow the pattern \{etcd-name\}-\{index\}<br />where index is 0 to (replicas-1) (e.g., etcd-main-0, etcd-main-1 etc).<br />When spec.memberNamePrefix is set, member names become<br />`<memberNamePrefix>-<podName>`.<br />Updating this field on a running cluster triggers a ConfigMap update<br />and a rolling restart of the StatefulSet. |  | MaxItems: 10 <br />Optional: \{\} <br /> |
+| `peerUrlTls` _[PeerTLSConfig](#peertlsconfig)_ | PeerUrlTLS contains the ca and server TLS secrets for peer communication within ETCD cluster.<br />Currently, PeerUrlTLS does not require client TLS secrets for gardener implementation of ETCD cluster.<br />In addition to the base TLSConfig fields it also exposes the peer-only<br />SkipClientSANVerification knob (see PeerTLSConfig). |  | Optional: \{\} <br /> |
+| `etcdDefragTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | EtcdDefragTimeout defines the timeout duration for etcd defrag call |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br />Optional: \{\} <br /> |
+| `heartbeatDuration` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | HeartbeatDuration defines the duration for members to send heartbeats. The default value is 10s. |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br />Optional: \{\} <br /> |
+| `clientService` _[ClientService](#clientservice)_ | ClientService defines the parameters of the client service that a user can specify |  | Optional: \{\} <br /> |
+| `backendBboltFreelistType` _[BboltFreelistType](#bboltfreelisttype)_ | BackendBboltFreelistType specifies the freelist-type used by the bbolt backend storage engine of etcd.<br />Supported values are 'array' (default) and 'map'.<br />It corresponds to the etcd's flag --backend-bbolt-freelist-type which available only from etcd version 3.5.x<br />Note: Although etcd v3.5.x defaults `--backend-bbolt-freelist-type` to "map", etcd-druid default to "array"<br />because for "map", it has been observed to cause significant increase in total database size.<br />The "array" freelist type is more space-efficient for the small databases (a few GBs) clusters.<br />Please refer to this issue for more info: https://github.com/gardener/etcd-druid/issues/1373 |  | Enum: [array map] <br />Optional: \{\} <br /> |
+| `bootstrapWithExistingCluster` _[BootstrapWithExistingCluster](#bootstrapwithexistingcluster)_ | BootstrapWithExistingCluster configures this etcd to join an existing cluster. |  | Optional: \{\} <br /> |
 
 
 #### EtcdCopyBackupsTask
@@ -817,12 +817,12 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `podLabels` _object (keys:string, values:string)_ | PodLabels is a set of labels that will be added to pod(s) created by the copy backups task. |  |  |
+| `podLabels` _object (keys:string, values:string)_ | PodLabels is a set of labels that will be added to pod(s) created by the copy backups task. |  | Optional: \{\} <br /> |
 | `sourceStore` _[StoreSpec](#storespec)_ | SourceStore defines the specification of the source object store provider for storing backups. |  |  |
 | `targetStore` _[StoreSpec](#storespec)_ | TargetStore defines the specification of the target object store provider for storing backups. |  |  |
-| `maxBackupAge` _integer_ | MaxBackupAge is the maximum age in days that a backup must have in order to be copied.<br />By default, all backups will be copied. |  | Minimum: 0 <br /> |
-| `maxBackups` _integer_ | MaxBackups is the maximum number of backups that will be copied starting with the most recent ones. |  | Minimum: 0 <br /> |
-| `waitForFinalSnapshot` _[WaitForFinalSnapshotSpec](#waitforfinalsnapshotspec)_ | WaitForFinalSnapshot defines the parameters for waiting for a final full snapshot before copying backups. |  |  |
+| `maxBackupAge` _integer_ | MaxBackupAge is the maximum age in days that a backup must have in order to be copied.<br />By default, all backups will be copied. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `maxBackups` _integer_ | MaxBackups is the maximum number of backups that will be copied starting with the most recent ones. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `waitForFinalSnapshot` _[WaitForFinalSnapshotSpec](#waitforfinalsnapshotspec)_ | WaitForFinalSnapshot defines the parameters for waiting for a final full snapshot before copying backups. |  | Optional: \{\} <br /> |
 
 
 #### EtcdCopyBackupsTaskStatus
@@ -838,9 +838,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `conditions` _[Condition](#condition) array_ | Conditions represents the latest available observations of an object's current state. |  |  |
-| `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this resource. |  |  |
-| `lastError` _string_ | LastError represents the last occurred error. |  |  |
+| `conditions` _[Condition](#condition) array_ | Conditions represents the latest available observations of an object's current state. |  | Optional: \{\} <br /> |
+| `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this resource. |  | Optional: \{\} <br /> |
+| `lastError` _string_ | LastError represents the last occurred error. |  | Optional: \{\} <br /> |
 
 
 #### EtcdMemberConditionStatus
@@ -875,8 +875,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `name` _string_ | Name is the name of the etcd member. It matches the member lease name.<br />When EtcdSpec.MemberNamePrefix is set, it is `<prefix>-<pod-name>` otherwise it is the name of the backing `Pod`. |  |  |
-| `id` _string_ | ID is the ID of the etcd member. |  |  |
-| `role` _[EtcdRole](#etcdrole)_ | Role is the role in the etcd cluster, either `Leader` or `Member`. |  |  |
+| `id` _string_ | ID is the ID of the etcd member. |  | Optional: \{\} <br /> |
+| `role` _[EtcdRole](#etcdrole)_ | Role is the role in the etcd cluster, either `Leader` or `Member`. |  | Optional: \{\} <br /> |
 | `status` _[EtcdMemberConditionStatus](#etcdmemberconditionstatus)_ | Status of the condition, one of True, False, Unknown. |  |  |
 | `reason` _string_ | The reason for the condition's last transition. |  |  |
 | `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)_ | LastTransitionTime is the last time the condition's status changed. |  |  |
@@ -899,7 +899,7 @@ It defines the desired configuration in Spec and tracks the observed state in St
 | `kind` _string_ | `EtcdOpsTask` | | |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
 | `spec` _[EtcdOpsTaskSpec](#etcdopstaskspec)_ | Spec defines the desired specification of the EtcdOpsTask. |  | Required: \{\} <br /> |
-| `status` _[EtcdOpsTaskStatus](#etcdopstaskstatus)_ | Status defines the observed state of the EtcdOpsTask. |  |  |
+| `status` _[EtcdOpsTaskStatus](#etcdopstaskstatus)_ | Status defines the observed state of the EtcdOpsTask. |  | Optional: \{\} <br /> |
 
 
 #### EtcdOpsTaskConfig
@@ -918,7 +918,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `onDemandSnapshot` _[OnDemandSnapshotConfig](#ondemandsnapshotconfig)_ | OnDemandSnapshot defines the configuration for an on-demand snapshot task. |  |  |
+| `onDemandSnapshot` _[OnDemandSnapshotConfig](#ondemandsnapshotconfig)_ | OnDemandSnapshot defines the configuration for an on-demand snapshot task. |  | Optional: \{\} <br /> |
 
 
 #### EtcdOpsTaskSpec
@@ -935,8 +935,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `config` _[EtcdOpsTaskConfig](#etcdopstaskconfig)_ | Config specifies the configuration for the operation to be performed.<br />Exactly one of the members of EtcdOpsTaskConfig must be set. |  | MaxProperties: 1 <br />MinProperties: 1 <br />Required: \{\} <br /> |
-| `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished is the duration in seconds after which a finished task (status.state == Succeeded\|Failed\|Rejected) will be garbage-collected. | 3600 | Minimum: 1 <br /> |
-| `etcdName` _string_ | EtcdName refers to the name of the Etcd resource that this task will operate on. |  |  |
+| `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished is the duration in seconds after which a finished task (status.state == Succeeded\|Failed\|Rejected) will be garbage-collected. | 3600 | Minimum: 1 <br />Optional: \{\} <br /> |
+| `etcdName` _string_ | EtcdName refers to the name of the Etcd resource that this task will operate on. |  | Optional: \{\} <br /> |
 
 
 #### EtcdOpsTaskStatus
@@ -952,11 +952,11 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `state` _[TaskState](#taskstate)_ | State represents the current state of the task. |  | Enum: [Pending InProgress Succeeded Failed Rejected] <br /> |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)_ | LastTransitionTime is the last time the state transitioned from one value to another. |  |  |
-| `startedAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)_ | StartedAt is the time at which the task transitioned from Pending to InProgress. |  |  |
-| `lastErrors` _[LastError](#lasterror) array_ | LastErrors is a list of the most recent errors observed during the task's execution.<br />A maximum of 10 latest errors will be recorded. |  | MaxItems: 10 <br /> |
-| `lastOperation` _[LastOperation](#lastoperation)_ | LastOperation tracks the fine-grained progress of the task's execution.<br />The controller initializes this field when processing the task. |  |  |
+| `state` _[TaskState](#taskstate)_ | State represents the current state of the task. |  | Enum: [Pending InProgress Succeeded Failed Rejected] <br />Optional: \{\} <br /> |
+| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)_ | LastTransitionTime is the last time the state transitioned from one value to another. |  | Optional: \{\} <br /> |
+| `startedAt` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#time-v1-meta)_ | StartedAt is the time at which the task transitioned from Pending to InProgress. |  | Optional: \{\} <br /> |
+| `lastErrors` _[LastError](#lasterror) array_ | LastErrors is a list of the most recent errors observed during the task's execution.<br />A maximum of 10 latest errors will be recorded. |  | MaxItems: 10 <br />Optional: \{\} <br /> |
+| `lastOperation` _[LastOperation](#lastoperation)_ | LastOperation tracks the fine-grained progress of the task's execution.<br />The controller initializes this field when processing the task. |  | Optional: \{\} <br /> |
 
 
 #### EtcdRole
@@ -989,20 +989,20 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `memberNamePrefix` _string_ | MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be `<prefix>-<pod-name>`, otherwise it defaults to the `pod-name`.<br />The combined length of the member-prefix, pod-name, and separator must not exceed 253 characters (DNS subdomain limit for lease names). |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br /> |
-| `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | selector is a label query over pods that should match the replica count.<br />It must match the pod template's labels.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors<br />Deprecated: this field will be removed in the future. |  |  |
-| `labels` _object (keys:string, values:string)_ | Labels defines the labels to be applied to the etcd pods backing the etcd cluster. |  |  |
-| `annotations` _object (keys:string, values:string)_ | Annotations defines the annotations to be applied to the etcd pods backing the etcd cluster. |  |  |
-| `etcd` _[EtcdConfig](#etcdconfig)_ |  |  |  |
-| `backup` _[BackupSpec](#backupspec)_ |  |  |  |
-| `sharedConfig` _[SharedConfig](#sharedconfig)_ |  |  |  |
-| `schedulingConstraints` _[SchedulingConstraints](#schedulingconstraints)_ |  |  |  |
-| `replicas` _integer_ | Replicas defines the number of etcd pods to be deployed, subsequently defining the etcd cluster size.<br />If set to 0, the etcd cluster will be scaled down, i.e., it will cease to run.<br />It can be scaled back up to the previously set value to continue running the etcd cluster. |  |  |
-| `priorityClassName` _string_ | PriorityClassName is the name of a priority class that shall be used for the etcd pods. |  |  |
-| `storageClass` _string_ | StorageClass defines the name of the StorageClass required by the claim.<br />More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1 |  |  |
-| `storageCapacity` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#quantity-resource-api)_ | StorageCapacity defines the size of persistent volume. |  |  |
-| `volumeClaimTemplate` _string_ | VolumeClaimTemplate defines the volume claim template to be created |  |  |
-| `runAsRoot` _boolean_ | RunAsRoot defines whether the securityContext of the pod specification should indicate that the containers shall<br />run as root. By default, they run as non-root with user 'nobody'. |  |  |
+| `memberNamePrefix` _string_ | MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be `<prefix>-<pod-name>`, otherwise it defaults to the `pod-name`.<br />The combined length of the member-prefix, pod-name, and separator must not exceed 253 characters (DNS subdomain limit for lease names). |  | MaxLength: 63 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` <br />Optional: \{\} <br /> |
+| `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | selector is a label query over pods that should match the replica count.<br />It must match the pod template's labels.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors<br />Deprecated: this field will be removed in the future. |  | Optional: \{\} <br /> |
+| `labels` _object (keys:string, values:string)_ | Labels defines the labels to be applied to the etcd pods backing the etcd cluster. |  | Required: \{\} <br /> |
+| `annotations` _object (keys:string, values:string)_ | Annotations defines the annotations to be applied to the etcd pods backing the etcd cluster. |  | Optional: \{\} <br /> |
+| `etcd` _[EtcdConfig](#etcdconfig)_ |  |  | Required: \{\} <br /> |
+| `backup` _[BackupSpec](#backupspec)_ |  |  | Required: \{\} <br /> |
+| `sharedConfig` _[SharedConfig](#sharedconfig)_ |  |  | Optional: \{\} <br /> |
+| `schedulingConstraints` _[SchedulingConstraints](#schedulingconstraints)_ |  |  | Optional: \{\} <br /> |
+| `replicas` _integer_ | Replicas defines the number of etcd pods to be deployed, subsequently defining the etcd cluster size.<br />If set to 0, the etcd cluster will be scaled down, i.e., it will cease to run.<br />It can be scaled back up to the previously set value to continue running the etcd cluster. |  | Required: \{\} <br /> |
+| `priorityClassName` _string_ | PriorityClassName is the name of a priority class that shall be used for the etcd pods. |  | Optional: \{\} <br /> |
+| `storageClass` _string_ | StorageClass defines the name of the StorageClass required by the claim.<br />More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1 |  | Optional: \{\} <br /> |
+| `storageCapacity` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#quantity-resource-api)_ | StorageCapacity defines the size of persistent volume. |  | Optional: \{\} <br /> |
+| `volumeClaimTemplate` _string_ | VolumeClaimTemplate defines the volume claim template to be created |  | Optional: \{\} <br /> |
+| `runAsRoot` _boolean_ | RunAsRoot defines whether the securityContext of the pod specification should indicate that the containers shall<br />run as root. By default, they run as non-root with user 'nobody'. |  | Optional: \{\} <br /> |
 
 
 #### EtcdStatus
@@ -1018,20 +1018,20 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this resource. |  |  |
-| `etcd` _[CrossVersionObjectReference](#crossversionobjectreference)_ |  |  |  |
-| `conditions` _[Condition](#condition) array_ | Conditions represents the latest available observations of an etcd's current state. |  |  |
-| `lastErrors` _[LastError](#lasterror) array_ | LastErrors captures errors that occurred during the last operation. |  |  |
-| `lastOperation` _[LastOperation](#lastoperation)_ | LastOperation indicates the last operation performed on this resource. |  |  |
-| `currentReplicas` _integer_ | CurrentReplicas is the current replica count for the etcd cluster. |  |  |
-| `replicas` _integer_ | Replicas is the replica count of the etcd cluster. |  |  |
-| `readyReplicas` _integer_ | ReadyReplicas is the count of replicas being ready in the etcd cluster. |  |  |
-| `ready` _boolean_ | Ready is `true` if all etcd replicas are ready. |  |  |
-| `labelSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | LabelSelector is a label query over pods that should match the replica count.<br />It must match the pod template's labels.<br />Deprecated: this field will be removed in the future. |  |  |
-| `members` _[EtcdMemberStatus](#etcdmemberstatus) array_ | Members represents the members of the etcd cluster |  |  |
-| `peerUrlTLSEnabled` _boolean_ | PeerUrlTLSEnabled captures the state of peer url TLS being enabled for the etcd member(s) |  |  |
-| `selector` _string_ | Selector is a label query over pods that should match the replica count.<br />It must match the pod template's labels. |  |  |
-| `bootstrapWithExistingCluster` _[BootstrapWithExistingClusterStatus](#bootstrapwithexistingclusterstatus)_ | BootstrapWithExistingCluster is the snapshot of the source cluster the<br />target joined. It is set once when the BootstrappedWithExistingCluster<br />condition first transitions to True, and is not updated thereafter. |  |  |
+| `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed for this resource. |  | Optional: \{\} <br /> |
+| `etcd` _[CrossVersionObjectReference](#crossversionobjectreference)_ |  |  | Optional: \{\} <br /> |
+| `conditions` _[Condition](#condition) array_ | Conditions represents the latest available observations of an etcd's current state. |  | Optional: \{\} <br /> |
+| `lastErrors` _[LastError](#lasterror) array_ | LastErrors captures errors that occurred during the last operation. |  | Optional: \{\} <br /> |
+| `lastOperation` _[LastOperation](#lastoperation)_ | LastOperation indicates the last operation performed on this resource. |  | Optional: \{\} <br /> |
+| `currentReplicas` _integer_ | CurrentReplicas is the current replica count for the etcd cluster. |  | Optional: \{\} <br /> |
+| `replicas` _integer_ | Replicas is the replica count of the etcd cluster. |  | Optional: \{\} <br /> |
+| `readyReplicas` _integer_ | ReadyReplicas is the count of replicas being ready in the etcd cluster. |  | Optional: \{\} <br /> |
+| `ready` _boolean_ | Ready is `true` if all etcd replicas are ready. |  | Optional: \{\} <br /> |
+| `labelSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#labelselector-v1-meta)_ | LabelSelector is a label query over pods that should match the replica count.<br />It must match the pod template's labels.<br />Deprecated: this field will be removed in the future. |  | Optional: \{\} <br /> |
+| `members` _[EtcdMemberStatus](#etcdmemberstatus) array_ | Members represents the members of the etcd cluster |  | Optional: \{\} <br /> |
+| `peerUrlTLSEnabled` _boolean_ | PeerUrlTLSEnabled captures the state of peer url TLS being enabled for the etcd member(s) |  | Optional: \{\} <br /> |
+| `selector` _string_ | Selector is a label query over pods that should match the replica count.<br />It must match the pod template's labels. |  | Optional: \{\} <br /> |
+| `bootstrapWithExistingCluster` _[BootstrapWithExistingClusterStatus](#bootstrapwithexistingclusterstatus)_ | BootstrapWithExistingCluster is the snapshot of the source cluster the<br />target joined. It is set once when the BootstrappedWithExistingCluster<br />condition first transitions to True, and is not updated thereafter. |  | Optional: \{\} <br /> |
 
 
 #### GarbageCollectionPolicy
@@ -1061,8 +1061,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `reelectionPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | ReelectionPeriod defines the Period after which leadership status of corresponding etcd is checked. |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br /> |
-| `etcdConnectionTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | EtcdConnectionTimeout defines the timeout duration for etcd client connection during leader election. |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br /> |
+| `reelectionPeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | ReelectionPeriod defines the Period after which leadership status of corresponding etcd is checked. |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br />Optional: \{\} <br /> |
+| `etcdConnectionTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | EtcdConnectionTimeout defines the timeout duration for etcd client connection during leader election. |  | Pattern: `^([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+$` <br />Type: string <br />Optional: \{\} <br /> |
 
 
 #### MemberPeerURLs
@@ -1078,8 +1078,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `memberName` _string_ | MemberName is the etcd member name.<br />Must match the etcd member name of the cluster (e.g., etcd-main-0).<br />When spec.memberNamePrefix is set, the member name becomes<br />"<memberNamePrefix>-<podName>". The top-level CEL rules on<br />Etcd already incorporate the prefix when validating these names. |  | MaxLength: 253 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?-[0-9]+$` <br />Required: \{\} <br /> |
-| `urls` _string array_ | URLs is a list of additional peer URLs for this member.<br />These will be appended to the default internal service URL.<br />A maximum of 5 URLs can be specified per member (constrained by CEL validation cost budget).<br />Must be valid HTTP(S) URLs with scheme and host; port is optional (e.g., https://10.0.0.1:2380). |  | MaxItems: 5 <br />MinItems: 1 <br />Required: \{\} <br />items:MaxLength: 2048 <br />items:XValidation: \{(self.startsWith('http://') \|\| self.startsWith('https://')) && isURL(self) must be a valid http:// or https:// URL (e.g., https://10.0.0.1:2380)    <nil>\} <br /> |
+| `memberName` _string_ | MemberName is the etcd member name.<br />Must match the etcd member name of the cluster (e.g., etcd-main-0).<br />When spec.memberNamePrefix is set, the member name becomes<br />`<memberNamePrefix>-<podName>`. The top-level CEL rules on<br />Etcd already incorporate the prefix when validating these names. |  | MaxLength: 253 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?-[0-9]+$` <br />Required: \{\} <br />Required: \{\} <br /> |
+| `urls` _string array_ | URLs is a list of additional peer URLs for this member.<br />These will be appended to the default internal service URL.<br />A maximum of 5 URLs can be specified per member (constrained by CEL validation cost budget).<br />Must be valid HTTP(S) URLs with scheme and host; port is optional (e.g., https://10.0.0.1:2380). |  | MaxItems: 5 <br />MinItems: 1 <br />Required: \{\} <br />items:MaxLength: 2048 <br />items:XValidation: \{(self.startsWith('http://') \|\| self.startsWith('https://')) && isURL(self) must be a valid http:// or https:// URL (e.g., https://10.0.0.1:2380)\} <br />Required: \{\} <br /> |
 
 
 #### MetricsLevel
@@ -1114,9 +1114,9 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `type` _[OnDemandSnapshotType](#ondemandsnapshottype)_ | Type specifies whether the snapshot is a 'full' or 'delta' snapshot.<br />Use 'full' for a complete backup of the etcd database, or 'delta' for incremental changes since the last snapshot. |  | Enum: [full delta] <br />Required: \{\} <br /> |
-| `isFinal` _boolean_ | IsFinal indicates whether the snapshot of type: full is marked as final. This is subject to change. |  |  |
-| `timeoutSecondsDelta` _integer_ | TimeoutSeconds is the timeout for the delta snapshot operation.<br />Defaults to 60 seconds. | 60 | Minimum: 10 <br /> |
-| `timeoutSecondsFull` _integer_ | TimeoutSecondsFull is the timeout for full snapshot operations.<br />Defaults to 900 seconds (15 minutes). | 900 | Minimum: 120 <br /> |
+| `isFinal` _boolean_ | IsFinal indicates whether the snapshot of type: full is marked as final. This is subject to change. |  | Optional: \{\} <br /> |
+| `timeoutSecondsDelta` _integer_ | TimeoutSeconds is the timeout for the delta snapshot operation.<br />Defaults to 60 seconds. | 60 | Minimum: 10 <br />Optional: \{\} <br /> |
+| `timeoutSecondsFull` _integer_ | TimeoutSecondsFull is the timeout for full snapshot operations.<br />Defaults to 900 seconds (15 minutes). | 900 | Minimum: 120 <br />Optional: \{\} <br /> |
 
 
 #### OnDemandSnapshotType
@@ -1155,10 +1155,10 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `tlsCASecretRef` _[SecretReference](#secretreference)_ |  |  |  |
-| `serverTLSSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  |  |
-| `clientTLSSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  |  |
-| `skipClientSANVerification` _boolean_ | SkipClientSANVerification, when true, skips verification of Subject<br />Alternative Names on the client certificate during peer mTLS<br />handshakes. The CA-based identity check still applies — any<br />certificate signed by the configured peer CA is accepted regardless<br />of its SAN. Only effective when peerUrlTls is configured (which is<br />structurally required: this field cannot be set without setting<br />peerUrlTls itself).<br />Mirrors etcd's config.PeerTLSInfo.SkipClientSANVerification;<br />rendered under peer-transport-security in the etcd config ConfigMap.<br />Behavior across etcd versions:<br />  - etcd v3.6+: the YAML key skip-client-san-verification under<br />    peer-transport-security is honored natively — see<br />    https://github.com/etcd-io/etcd/blob/release-3.6/server/embed/config.go#L485<br />    and https://github.com/etcd-io/etcd/blob/release-3.6/server/etcdmain/config.go#L122<br />    (the experimental CLI flag is deprecated in v3.6).<br />  - etcd v3.4 / v3.5: the YAML key is not honored natively; etcd-wrapper<br />    translates this field into the<br />    --experimental-peer-skip-client-san-verification CLI flag — see<br />    https://github.com/etcd-io/etcd/blob/release-3.5/server/etcdmain/config.go#L302<br />    and the bridge in https://github.com/gardener/etcd-wrapper/pull/92. |  |  |
+| `tlsCASecretRef` _[SecretReference](#secretreference)_ |  |  | Required: \{\} <br /> |
+| `serverTLSSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  | Required: \{\} <br /> |
+| `clientTLSSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  | Optional: \{\} <br /> |
+| `skipClientSANVerification` _boolean_ | SkipClientSANVerification, when true, skips verification of Subject<br />Alternative Names on the client certificate during peer mTLS<br />handshakes. The CA-based identity check still applies — any<br />certificate signed by the configured peer CA is accepted regardless<br />of its SAN. Only effective when peerUrlTls is configured (which is<br />structurally required: this field cannot be set without setting<br />peerUrlTls itself).<br />Mirrors etcd's config.PeerTLSInfo.SkipClientSANVerification;<br />rendered under peer-transport-security in the etcd config ConfigMap.<br />Behavior across etcd versions:<br />  - etcd v3.6+: the YAML key skip-client-san-verification under<br />    peer-transport-security is honored natively — see<br />    https://github.com/etcd-io/etcd/blob/release-3.6/server/embed/config.go#L485<br />    and https://github.com/etcd-io/etcd/blob/release-3.6/server/etcdmain/config.go#L122<br />    (the experimental CLI flag is deprecated in v3.6).<br />  - etcd v3.4 / v3.5: the YAML key is not honored natively; etcd-wrapper<br />    translates this field into the<br />    --experimental-peer-skip-client-san-verification CLI flag — see<br />    https://github.com/etcd-io/etcd/blob/release-3.5/server/etcdmain/config.go#L302<br />    and the bridge in https://github.com/gardener/etcd-wrapper/pull/92. |  | Optional: \{\} <br /> |
 
 
 #### SchedulingConstraints
@@ -1176,8 +1176,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#affinity-v1-core)_ | Affinity defines the various affinity and anti-affinity rules for a pod<br />that are honoured by the kube-scheduler. |  |  |
-| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#topologyspreadconstraint-v1-core) array_ | TopologySpreadConstraints describes how a group of pods ought to spread across topology domains,<br />that are honoured by the kube-scheduler. |  |  |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#affinity-v1-core)_ | Affinity defines the various affinity and anti-affinity rules for a pod<br />that are honoured by the kube-scheduler. |  | Optional: \{\} <br /> |
+| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#topologyspreadconstraint-v1-core) array_ | TopologySpreadConstraints describes how a group of pods ought to spread across topology domains,<br />that are honoured by the kube-scheduler. |  | Optional: \{\} <br /> |
 
 
 #### SecretReference
@@ -1194,9 +1194,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `name` _string_ | name is unique within a namespace to reference a secret resource. |  |  |
-| `namespace` _string_ | namespace defines the space within which the secret name must be unique. |  |  |
-| `dataKey` _string_ | DataKey is the name of the key in the data map containing the credentials. |  |  |
+| `name` _string_ | name is unique within a namespace to reference a secret resource. |  | Optional: \{\} <br /> |
+| `namespace` _string_ | namespace defines the space within which the secret name must be unique. |  | Optional: \{\} <br /> |
+| `dataKey` _string_ | DataKey is the name of the key in the data map containing the credentials. |  | Optional: \{\} <br /> |
 
 
 #### SharedConfig
@@ -1212,8 +1212,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `autoCompactionMode` _[CompactionMode](#compactionmode)_ | AutoCompactionMode defines the auto-compaction-mode:'periodic' mode or 'revision' mode for etcd and embedded-etcd of backup-restore sidecar. |  | Enum: [periodic revision] <br /> |
-| `autoCompactionRetention` _string_ | AutoCompactionRetention defines the auto-compaction-retention length for etcd as well as for embedded-etcd of backup-restore sidecar. |  |  |
+| `autoCompactionMode` _[CompactionMode](#compactionmode)_ | AutoCompactionMode defines the auto-compaction-mode:'periodic' mode or 'revision' mode for etcd and embedded-etcd of backup-restore sidecar. |  | Enum: [periodic revision] <br />Optional: \{\} <br /> |
+| `autoCompactionRetention` _string_ | AutoCompactionRetention defines the auto-compaction-retention length for etcd as well as for embedded-etcd of backup-restore sidecar. |  | Optional: \{\} <br /> |
 
 
 #### SnapshotCompactionSpec
@@ -1229,9 +1229,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#resourcerequirements-v1-core)_ | Resources defines compute Resources required by compaction job.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ |  |  |
-| `eventsThreshold` _integer_ | EventsThreshold defines the threshold for the number of etcd events before triggering a compaction job |  |  |
-| `triggerFullSnapshotThreshold` _integer_ | TriggerFullSnapshotThreshold defines the upper threshold for the number of etcd events before giving up on compaction job and triggering a full snapshot. |  |  |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#resourcerequirements-v1-core)_ | Resources defines compute Resources required by compaction job.<br />More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ |  | Optional: \{\} <br /> |
+| `eventsThreshold` _integer_ | EventsThreshold defines the threshold for the number of etcd events before triggering a compaction job |  | Optional: \{\} <br /> |
+| `triggerFullSnapshotThreshold` _integer_ | TriggerFullSnapshotThreshold defines the upper threshold for the number of etcd events before giving up on compaction job and triggering a full snapshot. |  | Optional: \{\} <br /> |
 
 
 #### StorageProvider
@@ -1261,11 +1261,11 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `container` _string_ | Container is the name of the container the backup is stored at. |  |  |
-| `endpointOverride` _string_ | EndpointOverride denotes the storage endpoint that will be used to override the storage provider's default endpoint. |  |  |
-| `prefix` _string_ | Prefix is the prefix used for the store. |  |  |
-| `provider` _[StorageProvider](#storageprovider)_ | Provider is the name of the backup provider. |  |  |
-| `secretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ | SecretRef is the reference to the secret which used to connect to the backup store. |  |  |
+| `container` _string_ | Container is the name of the container the backup is stored at. |  | Optional: \{\} <br /> |
+| `endpointOverride` _string_ | EndpointOverride denotes the storage endpoint that will be used to override the storage provider's default endpoint. |  | Optional: \{\} <br /> |
+| `prefix` _string_ | Prefix is the prefix used for the store. |  | Required: \{\} <br /> |
+| `provider` _[StorageProvider](#storageprovider)_ | Provider is the name of the backup provider. |  | Optional: \{\} <br /> |
+| `secretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ | SecretRef is the reference to the secret which used to connect to the backup store. |  | Optional: \{\} <br /> |
 
 
 #### TLSConfig
@@ -1283,9 +1283,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `tlsCASecretRef` _[SecretReference](#secretreference)_ |  |  |  |
-| `serverTLSSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  |  |
-| `clientTLSSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  |  |
+| `tlsCASecretRef` _[SecretReference](#secretreference)_ |  |  | Required: \{\} <br /> |
+| `serverTLSSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  | Required: \{\} <br /> |
+| `clientTLSSecretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#secretreference-v1-core)_ |  |  | Optional: \{\} <br /> |
 
 
 #### TaskState
@@ -1329,6 +1329,6 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Enabled specifies whether to wait for a final full snapshot before copying backups. |  |  |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | Timeout is the timeout for waiting for a final full snapshot. When this timeout expires, the copying of backups<br />will be performed anyway. No timeout or 0 means wait forever. |  | Pattern: `^(0\|([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+)$` <br />Type: string <br /> |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#duration-v1-meta)_ | Timeout is the timeout for waiting for a final full snapshot. When this timeout expires, the copying of backups<br />will be performed anyway. No timeout or 0 means wait forever. |  | Pattern: `^(0\|([0-9]+(\.[0-9]+)?(ns\|us\|µs\|ms\|s\|m\|h))+)$` <br />Type: string <br />Optional: \{\} <br /> |
 
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:

* Escapes angular brackets with backticks in docstrings
* Updates crd-ref-docs to v0.3.0
* Ran `make generate`

**Which issue(s) this PR fixes**:

The build of Gardener's website is failing due to unespaced angular brackets in the documentation source content that Docforge is pulling ing.

**Checklist**:
- [ ] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [ ] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [ ] Add tests that cover your changes (if applicable)
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:

Similar to:
* https://github.com/gardener/etcd-druid/pull/1365
* https://github.com/gardener/etcd-druid/pull/1383

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
