### PR TITLE
Introduce the `local` build tag to gate the `change-backup-bucket-permissions` initcontainer

### DIFF
--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -56,6 +56,11 @@ var (
 	defaultUpdateStrategy = appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType}
 )
 
+// localProviderInitContainer contains the init container that needs to run when local provider is chosen in e2e testing. No init container runs in normal deployments.
+var localProviderInitContainer = func(_ *druidv1alpha1.Etcd, _ *corev1.VolumeMount, _ string, _ *string) []corev1.Container {
+	return nil
+}
+
 type stsBuilder struct {
 	client                 client.Client
 	etcd                   *druidv1alpha1.Etcd
@@ -262,20 +267,8 @@ func (b *stsBuilder) getPodInitContainers() []corev1.Container {
 		return nil
 	}
 
-	return []corev1.Container{{
-		Name:            common.InitContainerNameChangeBackupBucketPermissions,
-		Image:           b.initContainerImage,
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{"sh", "-c", "--"},
-		Args:            []string{fmt.Sprintf("chown -R %d:%d %s", nonRootUser, nonRootUser, kubernetes.MountPathLocalStore(b.etcd, b.provider))},
-		VolumeMounts:    []corev1.VolumeMount{*etcdBackupVolumeMount},
-		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: ptr.To(false),
-			RunAsGroup:               ptr.To[int64](0),
-			RunAsNonRoot:             ptr.To(false),
-			RunAsUser:                ptr.To[int64](0),
-		},
-	}}
+	// Non-nil *only* when overriden to return the init container that chmod-s the backup directory to nonRootUser in e2e tests
+	return localProviderInitContainer(b.etcd, etcdBackupVolumeMount, b.initContainerImage, b.provider)
 }
 
 func (b *stsBuilder) getEtcdContainerVolumeMounts() []corev1.VolumeMount {

--- a/internal/component/statefulset/builder_local.go
+++ b/internal/component/statefulset/builder_local.go
@@ -1,0 +1,36 @@
+//go:build local
+
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package statefulset
+
+import (
+	"fmt"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	"github.com/gardener/etcd-druid/internal/common"
+	"github.com/gardener/etcd-druid/internal/utils/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+func init() {
+	localProviderInitContainer = func(etcd *druidv1alpha1.Etcd, etcdBackupVolumeMount *corev1.VolumeMount, initContainerImage string, provider *string) []corev1.Container {
+		return []corev1.Container{{
+			Name:            common.InitContainerNameChangeBackupBucketPermissions,
+			Image:           initContainerImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"sh", "-c", "--"},
+			Args:            []string{fmt.Sprintf("chown -R %d:%d %s", nonRootUser, nonRootUser, kubernetes.MountPathLocalStore(etcd, provider))},
+			VolumeMounts:    []corev1.VolumeMount{*etcdBackupVolumeMount},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.To(false),
+				RunAsGroup:               ptr.To[int64](0),
+				RunAsNonRoot:             ptr.To(false),
+				RunAsUser:                ptr.To[int64](0),
+			},
+		}}
+	}
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -16,6 +16,7 @@ build:
             - VERSION
         flags:
           - -v
+          - -tags=local
         ldflags:
           - '{{.LD_FLAGS}}'
         main: ./cmd
@@ -161,7 +162,7 @@ profiles:
                 - -c
                 - |
                   echo "Copying GCP service account json" &&
-                  touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" && 
+                  touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" &&
                   cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"
               os: [ darwin, linux ]
   # Profile to delete the GCP backup bucket from an e2e test.
@@ -177,8 +178,8 @@ profiles:
                 - sh
                 - -c
                 - |
-                  echo "Copying GCP service account json" && 
-                  touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" && 
+                  echo "Copying GCP service account json" &&
+                  touch "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json" &&
                   cp "$GCP_SERVICEACCOUNT_JSON_PATH" "hack/e2e-test/infrastructure/overlays/gcp/common/assets/serviceaccount.json"
               os: [ darwin, linux ]
   # Profile to create the required Local storage container for an e2e test.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area quality robustness
/kind cleanup

**What this PR does / why we need it**:


* `change-backup-bucket-permissions` is only included during compilation when the `local` build tag is used. This initcontainer performs a `chmod` on local directories used for etcd backups when the `Local` provider is configured. This init container only needs to run during e2e tests on the kind cluster, therefore this code can completely be gated behind this build tag.

* `local` tag is passed directly in `skaffold.yaml` to enable this feature locally.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**:
- [ ] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [ ] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [ ] Add tests that cover your changes (if applicable)
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:

We can confirm that this chmod init container will not be baked in by default by running:

```go
go tool nm ./bin/etcd-druid | rg "statefulset.init"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
N/A
```
