### PR TITLE
Validate backup store container name and harden chown init containers

### DIFF
--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcdcopybackupstasks.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcdcopybackupstasks.yaml
@@ -71,6 +71,8 @@ spec:
                   container:
                     description: Container is the name of the container the backup
                       is stored at.
+                    maxLength: 63
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]{1,61}[a-zA-Z0-9]$
                     type: string
                   endpointOverride:
                     description: EndpointOverride denotes the storage endpoint that
@@ -109,6 +111,8 @@ spec:
                   container:
                     description: Container is the name of the container the backup
                       is stored at.
+                    maxLength: 63
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]{1,61}[a-zA-Z0-9]$
                     type: string
                   endpointOverride:
                     description: EndpointOverride denotes the storage endpoint that

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -314,6 +314,8 @@ spec:
                       container:
                         description: Container is the name of the container the backup
                           is stored at.
+                        maxLength: 63
+                        pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]{1,61}[a-zA-Z0-9]$
                         type: string
                       endpointOverride:
                         description: EndpointOverride denotes the storage endpoint

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
@@ -293,6 +293,8 @@ spec:
                       properties:
                         container:
                           description: Container is the name of the container the backup is stored at.
+                          maxLength: 63
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]{1,61}[a-zA-Z0-9]$
                           type: string
                         endpointOverride:
                           description: EndpointOverride denotes the storage endpoint that will be used to override the storage provider's default endpoint.

--- a/api/core/v1alpha1/store.go
+++ b/api/core/v1alpha1/store.go
@@ -13,6 +13,8 @@ type StorageProvider string
 type StoreSpec struct {
 	// Container is the name of the container the backup is stored at.
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9][a-zA-Z0-9._-]{1,61}[a-zA-Z0-9]$`
 	Container *string `json:"container,omitempty"`
 	// EndpointOverride denotes the storage endpoint that will be used to override the storage provider's default endpoint.
 	// +optional

--- a/charts/crds/druid.gardener.cloud_etcdcopybackupstasks.yaml
+++ b/charts/crds/druid.gardener.cloud_etcdcopybackupstasks.yaml
@@ -71,6 +71,8 @@ spec:
                   container:
                     description: Container is the name of the container the backup
                       is stored at.
+                    maxLength: 63
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]{1,61}[a-zA-Z0-9]$
                     type: string
                   endpointOverride:
                     description: EndpointOverride denotes the storage endpoint that
@@ -109,6 +111,8 @@ spec:
                   container:
                     description: Container is the name of the container the backup
                       is stored at.
+                    maxLength: 63
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]{1,61}[a-zA-Z0-9]$
                     type: string
                   endpointOverride:
                     description: EndpointOverride denotes the storage endpoint that

--- a/charts/crds/druid.gardener.cloud_etcds.yaml
+++ b/charts/crds/druid.gardener.cloud_etcds.yaml
@@ -314,6 +314,8 @@ spec:
                       container:
                         description: Container is the name of the container the backup
                           is stored at.
+                        maxLength: 63
+                        pattern: ^[a-zA-Z0-9][a-zA-Z0-9._-]{1,61}[a-zA-Z0-9]$
                         type: string
                       endpointOverride:
                         description: EndpointOverride denotes the storage endpoint

--- a/docs/api-reference/etcd-druid-api.md
+++ b/docs/api-reference/etcd-druid-api.md
@@ -1261,7 +1261,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `container` _string_ | Container is the name of the container the backup is stored at. |  | Optional: \{\} <br /> |
+| `container` _string_ | Container is the name of the container the backup is stored at. |  | MaxLength: 63 <br />Pattern: `^[a-zA-Z0-9][a-zA-Z0-9._-]\{1,61\}[a-zA-Z0-9]$` <br />Optional: \{\} <br /> |
 | `endpointOverride` _string_ | EndpointOverride denotes the storage endpoint that will be used to override the storage provider's default endpoint. |  | Optional: \{\} <br /> |
 | `prefix` _string_ | Prefix is the prefix used for the store. |  | Required: \{\} <br /> |
 | `provider` _[StorageProvider](#storageprovider)_ | Provider is the name of the backup provider. |  | Optional: \{\} <br /> |

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -266,8 +266,7 @@ func (b *stsBuilder) getPodInitContainers() []corev1.Container {
 		Name:            common.InitContainerNameChangeBackupBucketPermissions,
 		Image:           b.initContainerImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{"sh", "-c", "--"},
-		Args:            []string{fmt.Sprintf("chown -R %d:%d %s", nonRootUser, nonRootUser, kubernetes.MountPathLocalStore(b.etcd, b.provider))},
+		Command:         []string{"chown", "-R", fmt.Sprintf("%d:%d", nonRootUser, nonRootUser), kubernetes.MountPathLocalStore(b.etcd, b.provider)},
 		VolumeMounts:    []corev1.VolumeMount{*etcdBackupVolumeMount},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.To(false),

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -179,8 +179,7 @@ func (s StatefulSetMatcher) matchPodInitContainers() gomegatypes.GomegaMatcher {
 			"Name":            Equal(common.InitContainerNameChangeBackupBucketPermissions),
 			"Image":           Equal(s.initContainerImage),
 			"ImagePullPolicy": Equal(corev1.PullIfNotPresent),
-			"Command":         HaveExactElements("sh", "-c", "--"),
-			"Args":            HaveExactElements(fmt.Sprintf("chown -R 65532:65532 /home/nonroot/%s", *s.etcd.Spec.Backup.Store.Container)),
+			"Command":         HaveExactElements("chown", "-R", "65532:65532", fmt.Sprintf("/home/nonroot/%s", *s.etcd.Spec.Backup.Store.Container)),
 			"VolumeMounts":    ConsistOf(s.getEtcdBackupVolumeMountMatcher()),
 			"SecurityContext": matchPodInitContainerSecurityContext(),
 		})

--- a/internal/controller/etcdcopybackupstask/reconciler.go
+++ b/internal/controller/etcdcopybackupstask/reconciler.go
@@ -362,8 +362,7 @@ func (r *Reconciler) createJobObject(ctx context.Context, task *druidv1alpha1.Et
 			{
 				Name:         "change-backup-bucket-permissions",
 				Image:        *initContainerImage,
-				Command:      []string{"sh", "-c", "--"},
-				Args:         []string{fmt.Sprintf("%s%s%s%s", "chown -R 65532:65532 /home/nonroot/", *targetStore.Container, " /home/nonroot/", *sourceStore.Container)},
+				Command:      []string{"chown", "-R", "65532:65532", fmt.Sprintf("/home/nonroot/%s", *targetStore.Container), fmt.Sprintf("/home/nonroot/%s", *sourceStore.Container)},
 				VolumeMounts: volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
 					AllowPrivilegeEscalation: ptr.To(false),

--- a/internal/controller/etcdcopybackupstask/reconciler_test.go
+++ b/internal/controller/etcdcopybackupstask/reconciler_test.go
@@ -864,6 +864,31 @@ func matchJobWithProviders(task *druidv1alpha1.EtcdCopyBackupsTask, sourceProvid
 		})
 		return And(matcher, volumeMatcher)
 	}
+	if targetProvider == druidstore.Local {
+		// With a Local target, druid adds a change-backup-bucket-permissions init container that
+		// chowns the source and target backup dirs. It must use the exec (argv) form, not sh -c,
+		// so that the container names cannot inject shell commands.
+		initContainerMatcher := MatchFields(IgnoreExtras, Fields{
+			"Spec": MatchFields(IgnoreExtras, Fields{
+				"Template": MatchFields(IgnoreExtras, Fields{
+					"Spec": MatchFields(IgnoreExtras, Fields{
+						"InitContainers": MatchAllElements(testutils.ContainerIterator, Elements{
+							"change-backup-bucket-permissions": MatchFields(IgnoreExtras, Fields{
+								"Name": Equal("change-backup-bucket-permissions"),
+								"Command": HaveExactElements(
+									"chown", "-R", "65532:65532",
+									fmt.Sprintf("/home/nonroot/%s", *task.Spec.TargetStore.Container),
+									fmt.Sprintf("/home/nonroot/%s", *task.Spec.SourceStore.Container),
+								),
+								"Args": BeEmpty(),
+							}),
+						}),
+					}),
+				}),
+			}),
+		})
+		return And(matcher, initContainerMatcher)
+	}
 	return matcher
 }
 

--- a/test/it/crdvalidation/etcd/specbackup_test.go
+++ b/test/it/crdvalidation/etcd/specbackup_test.go
@@ -90,6 +90,44 @@ func TestValidateSpecBackupCompressionPolicy(t *testing.T) {
 	}
 }
 
+// TestValidateSpecBackupStoreContainer validates the pattern/maxLength constraints on the
+// etcd.spec.backup.store.container field. The field flows into a root chown init container, so
+// it must reject shell metacharacters and path separators.
+func TestValidateSpecBackupStoreContainer(t *testing.T) {
+	tests := []struct {
+		name      string
+		etcdName  string
+		container string
+		expectErr bool
+	}{
+		{"valid: simple name", "etcd-c-1", "etcd-bucket", false},
+		{"valid: with dot", "etcd-c-2", "default.bkp", false},
+		{"valid: with hyphens", "etcd-c-3", "object-storage-container-name", false},
+		{"valid: three-char minimum", "etcd-c-4", "foo", false},
+		{"invalid: shell injection", "etcd-c-5", "x; id > /tmp/pwned; #", true},
+		{"invalid: contains space", "etcd-c-6", "a b", true},
+		{"invalid: leading hyphen", "etcd-c-7", "-rf", true},
+		{"invalid: path traversal", "etcd-c-8", "../etc", true},
+		{"invalid: command substitution", "etcd-c-9", "$(whoami)", true},
+		{"invalid: trailing hyphen", "etcd-c-10", "foo-", true},
+		{"invalid: trailing dot", "etcd-c-11", "foo.", true},
+		{"invalid: below minimum length", "etcd-c-12", "ab", true},
+	}
+
+	testNs, g := setupTestEnvironment(t)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).WithReplicas(3).Build()
+			etcd.Spec.Backup.Store = &druidv1alpha1.StoreSpec{
+				Prefix:    test.etcdName,
+				Container: &test.container,
+			}
+			validateEtcdCreation(g, etcd, test.expectErr)
+		})
+	}
+}
+
 // validates the duration passed into the etcd.spec.backup.deltaSnapshotRetentionPeriod field.
 func TestValidateSpecBackupDeltaSnapshotRetentionPeriod(t *testing.T) {
 	testNs, g := setupTestEnvironment(t)


### PR DESCRIPTION
**How to categorize this PR?**

/area security
/area backup
/kind bug

**What this PR does / why we need it**:

The `spec.backup.store.container` field (`StoreSpec.Container`, shared by `Etcd` and `EtcdCopyBackupsTask`) was string-formatted, without validation, into a `sh -c` command in the root-privileged `change-backup-bucket-permissions` init container. For `provider: Local`, a user able to create/update these resources could inject arbitrary shell that runs as root in the generated pod/job (CWE-77, OS command injection).

This PR closes the issue with two layered fixes:

1. **Input validation (primary).** Adds `Pattern` (`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`) and `MaxLength=63` validation to `StoreSpec.Container`, so shell metacharacters, spaces, path separators, and hostile leading characters are rejected at admission. A `pattern` marker is used rather than a CEL rule because this is a single-scalar character-set constraint; a CEL rule would be the same regex wrapped in `self.matches(...)` with no added value. Being part of the structural schema, the pattern also applies to the CEL-less CRD variant.

2. **Defense in depth.** Rewrites both `chown` init containers (statefulset builder and EtcdCopyBackupsTask reconciler) from `sh -c "chown ..."` to the exec/argv form `["chown","-R","65532:65532",<path>...]`. Neither relied on any shell feature, so this is behaviour-preserving while removing the injection primitive entirely.

The init container continues to run as root (uid 0) intentionally: it fixes ownership of the root-created Local backup hostPath so the non-root (uid 65532) etcd and backup-restore containers can write to it. Removing root is not viable and root itself is not the vulnerability — the shell plus unvalidated input was.

**Which issue(s) this PR fixes**:

Addresses a privately reported security submission (no public issue).

**Checklist**:
- [x] Add tests that cover your changes (if applicable)
    - [x] Unit tests
    - [x] Integration tests

**Special notes for your reviewer**:

- `StoreSpec` is shared, so the single field marker protects `Etcd.spec.backup.store.container` and `EtcdCopyBackupsTask.spec.{sourceStore,targetStore}.container`.
- `maxLength: 63` is the common maximum bucket/container-name length across AWS S3, GCS, Azure Blob, and Alibaba OSS. It keeps druid's validation aligned with the downstream object-store limits so a value that druid accepts is not later rejected by the provider.
- The leading-alphanumeric rule matches the bucket-naming rules of S3, GCS, Azure, and OSS (all require a letter or digit first); only OpenStack Swift is more permissive, and no etcd-druid usage relies on a leading `.`/`-`/`_`.
- Verified manually on a KIND cluster: injection payloads are rejected at admission, valid bucket names are accepted, and the `chown` init container (argv form) still correctly chowns the Local hostPath so backup-restore writes full snapshots as uid 65532.

/cc @renormalize

**Release note**:
```other operator
The `spec.backup.store.container` field is now validated (allowed characters `[a-zA-Z0-9._-]`, must start and end with an alphanumeric character, min length 3, max length 63). The init container that adjusts permissions for local backups no longer uses a shell, closing a potential command-injection vector.
```
