### PR TITLE
Add tolerations support to Etcd scheduling constraints

### DIFF
--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -904,7 +904,7 @@ spec:
                 description: |-
                   SchedulingConstraints defines the different scheduling constraints that must be applied to the
                   pod spec in the etcd statefulset.
-                  Currently supported constraints are Affinity and TopologySpreadConstraints.
+                  Currently supported constraints are Affinity, TopologySpreadConstraints and Tolerations.
                 properties:
                   affinity:
                     description: |-
@@ -1827,6 +1827,48 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                     type: object
+                  tolerations:
+                    description: |-
+                      Tolerations defines the pod tolerations that allow etcd pods to be scheduled
+                      onto nodes with matching taints, that are honoured by the kube-scheduler.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                   topologySpreadConstraints:
                     description: |-
                       TopologySpreadConstraints describes how a group of pods ought to spread across topology domains,

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
@@ -781,7 +781,7 @@ spec:
                   description: |-
                     SchedulingConstraints defines the different scheduling constraints that must be applied to the
                     pod spec in the etcd statefulset.
-                    Currently supported constraints are Affinity and TopologySpreadConstraints.
+                    Currently supported constraints are Affinity, TopologySpreadConstraints and Tolerations.
                   properties:
                     affinity:
                       description: |-
@@ -1658,6 +1658,48 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                       type: object
+                    tolerations:
+                      description: |-
+                        Tolerations defines the pod tolerations that allow etcd pods to be scheduled
+                        onto nodes with matching taints, that are honoured by the kube-scheduler.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
                     topologySpreadConstraints:
                       description: |-
                         TopologySpreadConstraints describes how a group of pods ought to spread across topology domains,

--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -495,7 +495,7 @@ type SharedConfig struct {
 
 // SchedulingConstraints defines the different scheduling constraints that must be applied to the
 // pod spec in the etcd statefulset.
-// Currently supported constraints are Affinity and TopologySpreadConstraints.
+// Currently supported constraints are Affinity, TopologySpreadConstraints and Tolerations.
 type SchedulingConstraints struct {
 	// Affinity defines the various affinity and anti-affinity rules for a pod
 	// that are honoured by the kube-scheduler.
@@ -505,6 +505,10 @@ type SchedulingConstraints struct {
 	// that are honoured by the kube-scheduler.
 	// +optional
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+	// Tolerations defines the pod tolerations that allow etcd pods to be scheduled
+	// onto nodes with matching taints, that are honoured by the kube-scheduler.
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // EtcdSpec defines the desired state of Etcd

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -1051,6 +1051,13 @@ func (in *SchedulingConstraints) DeepCopyInto(out *SchedulingConstraints) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/charts/crds/druid.gardener.cloud_etcds.yaml
+++ b/charts/crds/druid.gardener.cloud_etcds.yaml
@@ -904,7 +904,7 @@ spec:
                 description: |-
                   SchedulingConstraints defines the different scheduling constraints that must be applied to the
                   pod spec in the etcd statefulset.
-                  Currently supported constraints are Affinity and TopologySpreadConstraints.
+                  Currently supported constraints are Affinity, TopologySpreadConstraints and Tolerations.
                 properties:
                   affinity:
                     description: |-
@@ -1827,6 +1827,48 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                     type: object
+                  tolerations:
+                    description: |-
+                      Tolerations defines the pod tolerations that allow etcd pods to be scheduled
+                      onto nodes with matching taints, that are honoured by the kube-scheduler.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                   topologySpreadConstraints:
                     description: |-
                       TopologySpreadConstraints describes how a group of pods ought to spread across topology domains,

--- a/docs/api-reference/etcd-druid-api.md
+++ b/docs/api-reference/etcd-druid-api.md
@@ -1167,7 +1167,7 @@ _Appears in:_
 
 SchedulingConstraints defines the different scheduling constraints that must be applied to the
 pod spec in the etcd statefulset.
-Currently supported constraints are Affinity and TopologySpreadConstraints.
+Currently supported constraints are Affinity, TopologySpreadConstraints and Tolerations.
 
 
 
@@ -1178,6 +1178,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#affinity-v1-core)_ | Affinity defines the various affinity and anti-affinity rules for a pod<br />that are honoured by the kube-scheduler. |  | Optional: \{\} <br /> |
 | `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#topologyspreadconstraint-v1-core) array_ | TopologySpreadConstraints describes how a group of pods ought to spread across topology domains,<br />that are honoured by the kube-scheduler. |  | Optional: \{\} <br /> |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#toleration-v1-core) array_ | Tolerations defines the pod tolerations that allow etcd pods to be scheduled<br />onto nodes with matching taints, that are honoured by the kube-scheduler. |  | Optional: \{\} <br /> |
 
 
 #### SecretReference

--- a/docs/deployment/production-setup-recommendations.md
+++ b/docs/deployment/production-setup-recommendations.md
@@ -99,7 +99,9 @@ To ensure that an `Etcd` cluster is highly available, following is recommended:
 ### Ensure that the `Etcd` cluster members are spread
 
 `Etcd` cluster members should always be spread across nodes. This provides you failure tolerance at the node level. For failure tolerance of a zone, it is recommended that you spread the `Etcd` cluster members across zones.
-We recommend that you use a combination of [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and [Pod Anti-Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). To set the scheduling constraints you can either specify these constraints using [SchedulingConstraints](https://github.com/gardener/etcd-druid/blob/55efca1c8f6c852b0a4e97f08488ffec2eed0e68/api/v1alpha1/etcd.go#L257-L265) in the `Etcd` custom resource or use a [MutatingWebhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) to dynamically inject these into pods.
+We recommend that you use a combination of [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and [Pod Anti-Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). To set the scheduling constraints you can either specify these constraints using [SchedulingConstraints](https://github.com/gardener/etcd-druid/blob/master/api/core/v1alpha1/etcd.go#L496-L512) in the `Etcd` custom resource or use a [MutatingWebhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) to dynamically inject these into pods.
+
+If you run `Etcd` clusters on dedicated, tainted node pools (to isolate them from general workloads), `SchedulingConstraints` also lets you set [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) so that `Etcd` pods can be scheduled onto those nodes.
 
 An example of scheduling constraints for a multi-node cluster with zone failure tolerance will be:
 ```yaml

--- a/examples/etcd/druid_v1alpha1_etcd.yaml
+++ b/examples/etcd/druid_v1alpha1_etcd.yaml
@@ -80,6 +80,11 @@ spec:
     #   labelSelector:
     #     matchLabels:
     #       app: etcd-statefulset
+    # tolerations:
+    # - key: dedicated
+    #   operator: Equal
+    #   value: etcd
+    #   effect: NoSchedule
 
   replicas: 3
   # priorityClassName: priority-class-name

--- a/examples/etcd/druid_v1alpha1_etcd_azurite.yaml
+++ b/examples/etcd/druid_v1alpha1_etcd_azurite.yaml
@@ -80,6 +80,11 @@ spec:
     #   labelSelector:
     #     matchLabels:
     #       app: etcd-statefulset
+    # tolerations:
+    # - key: dedicated
+    #   operator: Equal
+    #   value: etcd
+    #   effect: NoSchedule
   replicas: 3
   # priorityClassName: priority-class-name
   # storageClass: default

--- a/examples/etcd/druid_v1alpha1_etcd_fakegcs.yaml
+++ b/examples/etcd/druid_v1alpha1_etcd_fakegcs.yaml
@@ -80,6 +80,11 @@ spec:
     #   labelSelector:
     #     matchLabels:
     #       app: etcd-statefulset
+    # tolerations:
+    # - key: dedicated
+    #   operator: Equal
+    #   value: etcd
+    #   effect: NoSchedule
 
   replicas: 3
   # priorityClassName: priority-class-name

--- a/examples/etcd/druid_v1alpha1_etcd_localstack.yaml
+++ b/examples/etcd/druid_v1alpha1_etcd_localstack.yaml
@@ -80,6 +80,11 @@ spec:
     #   labelSelector:
     #     matchLabels:
     #       app: etcd-statefulset
+    # tolerations:
+    # - key: dedicated
+    #   operator: Equal
+    #   value: etcd
+    #   effect: NoSchedule
 
   replicas: 3
   # priorityClassName: priority-class-name

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -178,6 +178,7 @@ func (b *stsBuilder) createPodTemplateSpec(ctx component.OperatorContext) error 
 			SecurityContext:           b.getPodSecurityContext(),
 			Affinity:                  b.etcd.Spec.SchedulingConstraints.Affinity,
 			TopologySpreadConstraints: b.etcd.Spec.SchedulingConstraints.TopologySpreadConstraints,
+			Tolerations:               b.etcd.Spec.SchedulingConstraints.Tolerations,
 			Volumes:                   podVolumes,
 			PriorityClassName:         ptr.Deref(b.etcd.Spec.PriorityClassName, ""),
 		},

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -311,6 +311,7 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 		name                   string
 		replicas               int32
 		annotations            map[string]string
+		tolerations            []corev1.Toleration
 		createErr              *apierrors.StatusError
 		expectedErr            *druiderr.DruidError
 		expectedReplicas       *int32
@@ -325,6 +326,19 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 		{
 			name:             "creates multiple replica sts for a multi-node etcd cluster",
 			replicas:         3,
+			expectedReplicas: ptr.To[int32](3),
+		},
+		{
+			name:     "creates sts with tolerations propagated from schedulingConstraints",
+			replicas: 3,
+			tolerations: []corev1.Toleration{
+				{
+					Key:      "dedicated",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "etcd",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
 			expectedReplicas: ptr.To[int32](3),
 		},
 		{
@@ -360,6 +374,7 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 			etcd := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).
 				WithReplicas(tc.replicas).
 				WithAnnotations(tc.annotations).
+				WithTolerations(tc.tolerations).
 				Build()
 
 			cl := testutils.CreateTestFakeClientForObjects(nil, tc.createErr, nil, nil, []client.Object{buildBackupSecret()}, getObjectKey(etcd.ObjectMeta))

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -158,6 +158,7 @@ func (s StatefulSetMatcher) matchPodSpec() gomegatypes.GomegaMatcher {
 		"SecurityContext":       s.matchEtcdPodSecurityContext(),
 		"Volumes":               s.matchPodVolumes(),
 		"PriorityClassName":     Equal(ptr.Deref(s.etcd.Spec.PriorityClassName, "")),
+		"Tolerations":           Equal(s.etcd.Spec.SchedulingConstraints.Tolerations),
 	}
 	if !s.expectNoServiceAccount {
 		fields["ServiceAccountName"] = Equal(druidv1alpha1.GetServiceAccountName(s.etcd.ObjectMeta))

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -523,6 +523,15 @@ func (eb *EtcdBuilder) WithSpecLabels(labels map[string]string) *EtcdBuilder {
 	return eb
 }
 
+// WithTolerations sets the spec.schedulingConstraints.tolerations field on the Etcd resource.
+func (eb *EtcdBuilder) WithTolerations(tolerations []corev1.Toleration) *EtcdBuilder {
+	if eb == nil || eb.etcd == nil {
+		return nil
+	}
+	eb.etcd.Spec.SchedulingConstraints.Tolerations = tolerations
+	return eb
+}
+
 // WithGRPCGatewayEnabled enables the gRPC gateway on the Etcd resource.
 func (eb *EtcdBuilder) WithGRPCGatewayEnabled() *EtcdBuilder {
 	if eb == nil || eb.etcd == nil {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

/area high-availability
/kind api-change

**What this PR does / why we need it**:

Extends `spec.schedulingConstraints` on the `Etcd` resource with a `tolerations` field, alongside the existing `affinity` and `topologySpreadConstraints`. This lets `Etcd` pods be scheduled onto nodes with matching taints (e.g. dedicated/tainted node pools for stateful workloads) without needing a `MutatingWebhook` to inject tolerations after the fact.

The field is optional and additive; when unset, behaviour is unchanged. It is passed straight through to the etcd `StatefulSet` pod spec in the same way `affinity` and `topologySpreadConstraints` already are.

**Which issue(s) this PR fixes**:
Fixes# 
[issue-899](https://github.com/gardener/etcd-druid/issues/899)

**Checklist**:
- [x] Update documentation in the `/docs` folder (if applicable)
- [x] Add tests that cover your changes (if applicable)
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:

- Generated artifacts (`zz_generated.deepcopy.go`, both `druid.gardener.cloud_etcds*.yaml` CRDs, the copy under `charts/crds/`, and `docs/api-reference/etcd-druid-api.md`) were produced via `make --directory=api generate` and manually cross-checked for the `_without_cel.yaml` variant, since the generation script's md5-based change-detection relies on `md5sum`, which isn't present on macOS by default.
- `internal/component/statefulset/stsmatcher.go` previously had a `NOTE` explicitly opting out of asserting `affinity`/`topologySpreadConstraints` in tests. I added an explicit `Tolerations` assertion there rather than leaving it uncovered, since `MatchFields(IgnoreExtras, ...)` would otherwise silently pass regardless of the field's value.
- No changes were needed in `internal/webhook/**` (component-protection webhook doesn't inspect the spec), `api/validation/**` (covers backup-store only), or `client/**` (type-level codegen, regenerates identically).

**Release note**:
```feature operator
`spec.schedulingConstraints.tolerations` can now be set on the `Etcd` resource to schedule etcd pods onto tainted nodes.
```
