### PR TITLE
Add support for externally managed members

### DIFF
--- a/api/core/v1alpha1/constants.go
+++ b/api/core/v1alpha1/constants.go
@@ -39,9 +39,6 @@ const (
 	// This value will only be effective if etcd-druid is not configured with auto-reconciliation of Etcd resource specification via
 	// --enable-etcd-spec-auto-reconcile CLI flag.
 	DruidOperationReconcile = "reconcile"
-	// DisableEtcdRuntimeComponentCreationAnnotation is an annotation set by an operator to disable the creation and management of
-	// runtime components of the etcd cluster such as pods, PVCs, leases, RBAC resources, PDBs, services, etc.
-	DisableEtcdRuntimeComponentCreationAnnotation = "druid.gardener.cloud/disable-etcd-runtime-component-creation"
 )
 
 // Compaction Job/Pod reasons that are used to set the reason for a pod condition in the status of an Etcd resource.

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -2159,8 +2159,8 @@ spec:
             - message: etcd.spec.volumeClaimTemplate field cannot be added or removed
                 dynamically.
               rule: has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)
-            - message: etcd.spec.replicas must be equal to length of etcd.spec.externallyManagedMemberAddresses
-                when etcd.spec.externallyManagedMemberAddresses is specified.
+            - message: etcd.spec.externallyManagedMemberAddresses length must equal
+                to etcd.spec.replicas.
               rule: 'has(self.externallyManagedMemberAddresses) ? self.replicas ==
                 self.externallyManagedMemberAddresses.size() : true'
             - message: etcd.spec.externallyManagedMemberAddresses field cannot be

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -2163,8 +2163,8 @@ spec:
                 to etcd.spec.replicas.
               rule: 'has(self.externallyManagedMemberAddresses) ? self.replicas ==
                 self.externallyManagedMemberAddresses.size() : true'
-            - message: etcd.spec.externallyManagedMemberAddresses field cannot be
-                added or removed dynamically.
+            - message: etcd.spec.externallyManagedMemberAddresses field must only
+                be set during creation.
               rule: has(oldSelf.externallyManagedMemberAddresses) == has(self.externallyManagedMemberAddresses)
           status:
             description: EtcdStatus defines the observed state of Etcd.

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds.yaml
@@ -865,6 +865,15 @@ spec:
                 - message: etcd.spec.etcd.bootstrapWithExistingCluster cannot be added
                     after the Etcd resource has been created
                   rule: '!has(self.bootstrapWithExistingCluster) || has(oldSelf.bootstrapWithExistingCluster)'
+              externallyManagedMemberAddresses:
+                description: |-
+                  ExternallyManagedMemberAddresses defines the list of addresses of externally managed etcd members. Specifying this
+                  will disable components that are involved in management of etcd members like Pods, Services and PDBs.
+                  Allowed values include: IPv4/IPv6 addresses and hostnames. Protocol or port shall not be specified.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
               labels:
                 additionalProperties:
                   type: string
@@ -2143,12 +2152,20 @@ spec:
             - replicas
             type: object
             x-kubernetes-validations:
-            - message: etcd.spec.storageClass is an immutable field.
-              rule: has(oldSelf.storageClass) ==  has(self.storageClass)
-            - message: etcd.spec.volumeClaimTemplate is an immutable field.
-              rule: has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)
             - message: etcd.spec.memberNamePrefix is an immutable field.
               rule: has(oldSelf.memberNamePrefix) == has(self.memberNamePrefix)
+            - message: etcd.spec.storageClass field cannot be added or removed dynamically.
+              rule: has(oldSelf.storageClass) ==  has(self.storageClass)
+            - message: etcd.spec.volumeClaimTemplate field cannot be added or removed
+                dynamically.
+              rule: has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)
+            - message: etcd.spec.replicas must be equal to length of etcd.spec.externallyManagedMemberAddresses
+                when etcd.spec.externallyManagedMemberAddresses is specified.
+              rule: 'has(self.externallyManagedMemberAddresses) ? self.replicas ==
+                self.externallyManagedMemberAddresses.size() : true'
+            - message: etcd.spec.externallyManagedMemberAddresses field cannot be
+                added or removed dynamically.
+              rule: has(oldSelf.externallyManagedMemberAddresses) == has(self.externallyManagedMemberAddresses)
           status:
             description: EtcdStatus defines the observed state of Etcd.
             properties:

--- a/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
+++ b/api/core/v1alpha1/crds/druid.gardener.cloud_etcds_without_cel.yaml
@@ -750,6 +750,15 @@ spec:
                       format: int32
                       type: integer
                   type: object
+                externallyManagedMemberAddresses:
+                  description: |-
+                    ExternallyManagedMemberAddresses defines the list of addresses of externally managed etcd members. Specifying this
+                    will disable components that are involved in management of etcd members like Pods, Services and PDBs.
+                    Allowed values include: IPv4/IPv6 addresses and hostnames. Protocol or port shall not be specified.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
                 labels:
                   additionalProperties:
                     type: string

--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -512,9 +512,11 @@ type SchedulingConstraints struct {
 }
 
 // EtcdSpec defines the desired state of Etcd
-// +kubebuilder:validation:XValidation:message="etcd.spec.storageClass is an immutable field.",rule="has(oldSelf.storageClass) ==  has(self.storageClass)"
-// +kubebuilder:validation:XValidation:message="etcd.spec.volumeClaimTemplate is an immutable field.",rule="has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)"
 // +kubebuilder:validation:XValidation:message="etcd.spec.memberNamePrefix is an immutable field.",rule="has(oldSelf.memberNamePrefix) == has(self.memberNamePrefix)"
+// +kubebuilder:validation:XValidation:message="etcd.spec.storageClass field cannot be added or removed dynamically.",rule="has(oldSelf.storageClass) ==  has(self.storageClass)"
+// +kubebuilder:validation:XValidation:message="etcd.spec.volumeClaimTemplate field cannot be added or removed dynamically.",rule="has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)"
+// +kubebuilder:validation:XValidation:message="etcd.spec.replicas must be equal to length of etcd.spec.externallyManagedMemberAddresses when etcd.spec.externallyManagedMemberAddresses is specified.",rule="has(self.externallyManagedMemberAddresses) ? self.replicas == self.externallyManagedMemberAddresses.size() : true"
+// +kubebuilder:validation:XValidation:message="etcd.spec.externallyManagedMemberAddresses field cannot be added or removed dynamically.",rule="has(oldSelf.externallyManagedMemberAddresses) == has(self.externallyManagedMemberAddresses)"
 type EtcdSpec struct {
 	// MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be `<prefix>-<pod-name>`, otherwise it defaults to the `pod-name`.
 	// The combined length of the member-prefix, pod-name, and separator must not exceed 253 characters (DNS subdomain limit for lease names).
@@ -568,6 +570,12 @@ type EtcdSpec struct {
 	// run as root. By default, they run as non-root with user 'nobody'.
 	// +optional
 	RunAsRoot *bool `json:"runAsRoot,omitempty"`
+	// ExternallyManagedMemberAddresses defines the list of addresses of externally managed etcd members. Specifying this
+	// will disable components that are involved in management of etcd members like Pods, Services and PDBs.
+	// Allowed values include: IPv4/IPv6 addresses and hostnames. Protocol or port shall not be specified.
+	// +optional
+	// +listType=set
+	ExternallyManagedMemberAddresses []string `json:"externallyManagedMemberAddresses,omitempty"`
 }
 
 // CrossVersionObjectReference contains enough information to let you identify the referred resource.

--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -515,7 +515,7 @@ type SchedulingConstraints struct {
 // +kubebuilder:validation:XValidation:message="etcd.spec.memberNamePrefix is an immutable field.",rule="has(oldSelf.memberNamePrefix) == has(self.memberNamePrefix)"
 // +kubebuilder:validation:XValidation:message="etcd.spec.storageClass field cannot be added or removed dynamically.",rule="has(oldSelf.storageClass) ==  has(self.storageClass)"
 // +kubebuilder:validation:XValidation:message="etcd.spec.volumeClaimTemplate field cannot be added or removed dynamically.",rule="has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)"
-// +kubebuilder:validation:XValidation:message="etcd.spec.replicas must be equal to length of etcd.spec.externallyManagedMemberAddresses when etcd.spec.externallyManagedMemberAddresses is specified.",rule="has(self.externallyManagedMemberAddresses) ? self.replicas == self.externallyManagedMemberAddresses.size() : true"
+// +kubebuilder:validation:XValidation:message="etcd.spec.externallyManagedMemberAddresses length must equal to etcd.spec.replicas.",rule="has(self.externallyManagedMemberAddresses) ? self.replicas == self.externallyManagedMemberAddresses.size() : true"
 // +kubebuilder:validation:XValidation:message="etcd.spec.externallyManagedMemberAddresses field cannot be added or removed dynamically.",rule="has(oldSelf.externallyManagedMemberAddresses) == has(self.externallyManagedMemberAddresses)"
 type EtcdSpec struct {
 	// MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be `<prefix>-<pod-name>`, otherwise it defaults to the `pod-name`.

--- a/api/core/v1alpha1/etcd.go
+++ b/api/core/v1alpha1/etcd.go
@@ -516,7 +516,7 @@ type SchedulingConstraints struct {
 // +kubebuilder:validation:XValidation:message="etcd.spec.storageClass field cannot be added or removed dynamically.",rule="has(oldSelf.storageClass) ==  has(self.storageClass)"
 // +kubebuilder:validation:XValidation:message="etcd.spec.volumeClaimTemplate field cannot be added or removed dynamically.",rule="has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)"
 // +kubebuilder:validation:XValidation:message="etcd.spec.externallyManagedMemberAddresses length must equal to etcd.spec.replicas.",rule="has(self.externallyManagedMemberAddresses) ? self.replicas == self.externallyManagedMemberAddresses.size() : true"
-// +kubebuilder:validation:XValidation:message="etcd.spec.externallyManagedMemberAddresses field cannot be added or removed dynamically.",rule="has(oldSelf.externallyManagedMemberAddresses) == has(self.externallyManagedMemberAddresses)"
+// +kubebuilder:validation:XValidation:message="etcd.spec.externallyManagedMemberAddresses field must only be set during creation.",rule="has(oldSelf.externallyManagedMemberAddresses) == has(self.externallyManagedMemberAddresses)"
 type EtcdSpec struct {
 	// MemberNamePrefix defines the prefix for the name of each etcd cluster member. When set, the member name would be `<prefix>-<pod-name>`, otherwise it defaults to the `pod-name`.
 	// The combined length of the member-prefix, pod-name, and separator must not exceed 253 characters (DNS subdomain limit for lease names).

--- a/api/core/v1alpha1/helper.go
+++ b/api/core/v1alpha1/helper.go
@@ -5,7 +5,9 @@
 package v1alpha1
 
 import (
+	"crypto/rand"
 	"fmt"
+	"math/big"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,6 +24,22 @@ func GetPeerServiceName(etcdObjMeta metav1.ObjectMeta) string {
 // GetClientServiceName returns the client service name for the Etcd cluster reachable by external clients.
 func GetClientServiceName(etcdObjMeta metav1.ObjectMeta) string {
 	return fmt.Sprintf("%s-client", etcdObjMeta.Name)
+}
+
+// GetClientHostname returns the hostname of the client endpoint for the Etcd cluster. This is the client service hostname when the Etcd members
+// are managed by etcd-druid, else it is a randomly selected member address out of the externally managed member addresses.
+func GetClientHostname(etcd *Etcd) string {
+	if ArePodsManagedByEtcdDruid(etcd) {
+		return fmt.Sprintf("%s.%s.svc", GetClientServiceName(etcd.ObjectMeta), etcd.Namespace)
+	} else {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(etcd.Spec.ExternallyManagedMemberAddresses))))
+		if err != nil {
+			// Fallback to first member address in case of an error
+			return etcd.Spec.ExternallyManagedMemberAddresses[0]
+		}
+		randomIndex := int(n.Int64())
+		return etcd.Spec.ExternallyManagedMemberAddresses[randomIndex]
+	}
 }
 
 // GetServiceAccountName returns the service account name for the Etcd.
@@ -54,6 +72,11 @@ func GetMemberName(memberNamePrefix *string, podName string) string {
 	return podName
 }
 
+// GetMemberNameFromAddress returns the name of the etcd member based on the address.
+func GetMemberNameFromAddress(etcd *Etcd, memberAddress string) string {
+	return GetMemberName(etcd.Spec.MemberNamePrefix, fmt.Sprintf("%s-%s", etcd.Name, memberAddress))
+}
+
 // GetAllPodNames returns the names of all pods for the Etcd.
 func GetAllPodNames(etcdObjMeta metav1.ObjectMeta, replicas int32) []string {
 	podNames := make([]string, replicas)
@@ -65,12 +88,21 @@ func GetAllPodNames(etcdObjMeta metav1.ObjectMeta, replicas int32) []string {
 
 // GetMemberLeaseNames returns the name of member leases for the Etcd.
 func GetMemberLeaseNames(etcd *Etcd) []string {
-	leaseNames := make([]string, etcd.Spec.Replicas)
-	for i := range int(etcd.Spec.Replicas) {
-		podName := GetOrdinalPodName(etcd.ObjectMeta, i)
-		leaseNames[i] = GetMemberName(etcd.Spec.MemberNamePrefix, podName)
+	if ArePodsManagedByEtcdDruid(etcd) {
+		leaseNames := make([]string, etcd.Spec.Replicas)
+		for i := range int(etcd.Spec.Replicas) {
+			podName := GetOrdinalPodName(etcd.ObjectMeta, i)
+			leaseNames[i] = GetMemberName(etcd.Spec.MemberNamePrefix, podName)
+		}
+		return leaseNames
+	} else {
+		memberAddresses := etcd.Spec.ExternallyManagedMemberAddresses
+		leaseNames := make([]string, len(memberAddresses))
+		for i, memberAddress := range memberAddresses {
+			leaseNames[i] = GetMemberNameFromAddress(etcd, memberAddress)
+		}
+		return leaseNames
 	}
-	return leaseNames
 }
 
 // GetPodDisruptionBudgetName returns the name of the pod disruption budget for the Etcd.
@@ -177,7 +209,7 @@ func RemoveOperationAnnotation(etcdObjMeta metav1.ObjectMeta) {
 	delete(etcdObjMeta.Annotations, GardenerOperationAnnotation)
 }
 
-// IsEtcdRuntimeComponentCreationEnabled checks if the creation of runtime components is enabled for an Etcd resource.
-func IsEtcdRuntimeComponentCreationEnabled(etcdObjMeta metav1.ObjectMeta) bool {
-	return !metav1.HasAnnotation(etcdObjMeta, DisableEtcdRuntimeComponentCreationAnnotation)
+// ArePodsManagedByEtcdDruid checks if the management of pods is handled by etcd-druid for an Etcd resource.
+func ArePodsManagedByEtcdDruid(etcd *Etcd) bool {
+	return len(etcd.Spec.ExternallyManagedMemberAddresses) == 0
 }

--- a/api/core/v1alpha1/helper_test.go
+++ b/api/core/v1alpha1/helper_test.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -33,14 +34,45 @@ func TestGetPeerServiceName(t *testing.T) {
 	g := NewWithT(t)
 	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
 	peerServiceName := GetPeerServiceName(etcdObjMeta)
-	g.Expect(peerServiceName).To(Equal("etcd-test-peer"))
+	g.Expect(peerServiceName).To(Equal(etcdObjMeta.Name + "-peer"))
 }
 
 func TestGetClientServiceName(t *testing.T) {
 	g := NewWithT(t)
 	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
 	clientServiceName := GetClientServiceName(etcdObjMeta)
-	g.Expect(clientServiceName).To(Equal("etcd-test-client"))
+	g.Expect(clientServiceName).To(Equal(etcdObjMeta.Name + "-client"))
+}
+
+func TestGetClientHostnameWithDruidManagedMembers(t *testing.T) {
+	g := NewWithT(t)
+	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
+	etcd := &Etcd{
+		ObjectMeta: etcdObjMeta,
+		Spec: EtcdSpec{
+			Replicas: 3,
+		},
+	}
+	clientHostname := GetClientHostname(etcd)
+	g.Expect(clientHostname).To(Equal(fmt.Sprintf("%s.%s.svc", GetClientServiceName(etcd.ObjectMeta), etcd.Namespace)))
+}
+
+func TestGetClientHostnameWithExternallyManagedMembers(t *testing.T) {
+	g := NewWithT(t)
+	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
+	etcd := &Etcd{
+		ObjectMeta: etcdObjMeta,
+		Spec: EtcdSpec{
+			Replicas: 3,
+			ExternallyManagedMemberAddresses: []string{
+				"1.1.1.1",
+				"1.1.1.2",
+				"1.1.1.3",
+			},
+		},
+	}
+	clientHostname := GetClientHostname(etcd)
+	g.Expect(clientHostname).Should(BeElementOf([]string{"1.1.1.1", "1.1.1.2", "1.1.1.3"}))
 }
 
 func TestGetServiceAccountName(t *testing.T) {
@@ -62,38 +94,41 @@ func TestGetCompactionJobName(t *testing.T) {
 	g := NewWithT(t)
 	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
 	compactionJobName := GetCompactionJobName(etcdObjMeta)
-	g.Expect(compactionJobName).To(Equal("etcd-test-compactor"))
+	g.Expect(compactionJobName).To(Equal(etcdObjMeta.Name + "-compactor"))
 }
 
 func TestGetOrdinalPodName(t *testing.T) {
 	g := NewWithT(t)
 	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
 	ordinalPodName := GetOrdinalPodName(etcdObjMeta, 1)
-	g.Expect(ordinalPodName).To(Equal("etcd-test-1"))
+	g.Expect(ordinalPodName).To(Equal(etcdObjMeta.Name + "-1"))
 }
 
 func TestGetDeltaSnapshotLeaseName(t *testing.T) {
 	g := NewWithT(t)
 	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
 	deltaSnapshotLeaseName := GetDeltaSnapshotLeaseName(etcdObjMeta)
-	g.Expect(deltaSnapshotLeaseName).To(Equal("etcd-test-delta-snap"))
+	g.Expect(deltaSnapshotLeaseName).To(Equal(etcdObjMeta.Name + "-delta-snap"))
 }
 
 func TestGetFullSnapshotLeaseName(t *testing.T) {
 	g := NewWithT(t)
 	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
 	fullSnapshotLeaseName := GetFullSnapshotLeaseName(etcdObjMeta)
-	g.Expect(fullSnapshotLeaseName).To(Equal("etcd-test-full-snap"))
+	g.Expect(fullSnapshotLeaseName).To(Equal(etcdObjMeta.Name + "-full-snap"))
 }
 
 func TestGetMemberLeaseNames(t *testing.T) {
 	tests := []struct {
-		name                 string
-		memberNamePrefix     *string
-		expectedMemberLeases func(etcdName string) []string
+		name                     string
+		replicas                 int
+		memberNamePrefix         *string
+		expectedMemberLeases     func(etcdName string) []string
+		externallyManagedMembers []string
 	}{
 		{
 			name:             "no member name prefix",
+			replicas:         3,
 			memberNamePrefix: nil,
 			expectedMemberLeases: func(etcdName string) []string {
 				return []string{etcdName + "-0", etcdName + "-1", etcdName + "-2"}
@@ -101,9 +136,28 @@ func TestGetMemberLeaseNames(t *testing.T) {
 		},
 		{
 			name:             "with member name prefix",
+			replicas:         3,
 			memberNamePrefix: ptr.To("myprefix"),
 			expectedMemberLeases: func(etcdName string) []string {
 				return []string{"myprefix-" + etcdName + "-0", "myprefix-" + etcdName + "-1", "myprefix-" + etcdName + "-2"}
+			},
+		},
+		{
+			name:                     "externally managed with no member name prefix",
+			replicas:                 3,
+			memberNamePrefix:         nil,
+			externallyManagedMembers: []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+			expectedMemberLeases: func(etcdName string) []string {
+				return []string{etcdName + "-1.1.1.1", etcdName + "-1.1.1.2", etcdName + "-1.1.1.3"}
+			},
+		},
+		{
+			name:                     "externally managed with member name prefix",
+			replicas:                 3,
+			memberNamePrefix:         ptr.To("myprefix"),
+			externallyManagedMembers: []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+			expectedMemberLeases: func(etcdName string) []string {
+				return []string{"myprefix-" + etcdName + "-1.1.1.1", "myprefix-" + etcdName + "-1.1.1.2", "myprefix-" + etcdName + "-1.1.1.3"}
 			},
 		},
 	}
@@ -116,8 +170,9 @@ func TestGetMemberLeaseNames(t *testing.T) {
 			etcd := &Etcd{
 				ObjectMeta: etcdObjMeta,
 				Spec: EtcdSpec{
-					Replicas:         3,
-					MemberNamePrefix: test.memberNamePrefix,
+					Replicas:                         3,
+					MemberNamePrefix:                 test.memberNamePrefix,
+					ExternallyManagedMemberAddresses: test.externallyManagedMembers,
 				},
 			}
 			leaseNames := GetMemberLeaseNames(etcd)
@@ -126,25 +181,38 @@ func TestGetMemberLeaseNames(t *testing.T) {
 	}
 }
 
+func TestGetMemberNameFromAddress(t *testing.T) {
+	g := NewWithT(t)
+	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
+	etcd := &Etcd{
+		ObjectMeta: etcdObjMeta,
+		Spec: EtcdSpec{
+			Replicas: 3,
+		},
+	}
+	memberName := GetMemberNameFromAddress(etcd, "1.1.1.1")
+	g.Expect(memberName).To(Equal(etcdObjMeta.Name + "-1.1.1.1"))
+}
+
 func TestGetPodDisruptionBudgetName(t *testing.T) {
 	g := NewWithT(t)
 	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
 	podDisruptionBudgetName := GetPodDisruptionBudgetName(etcdObjMeta)
-	g.Expect(podDisruptionBudgetName).To(Equal("etcd-test"))
+	g.Expect(podDisruptionBudgetName).To(Equal(etcdObjMeta.Name))
 }
 
 func TestGetRoleName(t *testing.T) {
 	g := NewWithT(t)
 	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
 	roleName := GetRoleName(etcdObjMeta)
-	g.Expect(roleName).To(Equal("druid.gardener.cloud:etcd:etcd-test"))
+	g.Expect(roleName).To(Equal("druid.gardener.cloud:etcd:" + etcdObjMeta.Name))
 }
 
 func TestGetRoleBindingName(t *testing.T) {
 	g := NewWithT(t)
 	etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
 	roleBindingName := GetRoleBindingName(etcdObjMeta)
-	g.Expect(roleBindingName).To(Equal("druid.gardener.cloud:etcd:etcd-test"))
+	g.Expect(roleBindingName).To(Equal("druid.gardener.cloud:etcd:" + etcdObjMeta.Name))
 }
 
 func TestGetSuspendEtcdSpecReconcileAnnotationKey(t *testing.T) {
@@ -455,22 +523,21 @@ func TestGetReconcileOperationAnnotationKey(t *testing.T) {
 	}
 }
 
-func TestIsEtcdRuntimeComponentCreationEnabled(t *testing.T) {
+func TestIsPodManagementEnabled(t *testing.T) {
 	tests := []struct {
-		name        string
-		annotations map[string]string
-		expected    bool
+		name                        string
+		hasExternallyManagedMembers bool
+		expected                    bool
 	}{
 		{
-			name:     "Runtime component creation is enabled",
-			expected: true,
+			name:                        "Pod management is enabled",
+			hasExternallyManagedMembers: false,
+			expected:                    true,
 		},
 		{
-			name: "Runtime component creation is disabled",
-			annotations: map[string]string{
-				DisableEtcdRuntimeComponentCreationAnnotation: "",
-			},
-			expected: false,
+			name:                        "Pod management is disabled",
+			hasExternallyManagedMembers: true,
+			expected:                    false,
 		},
 	}
 
@@ -479,8 +546,20 @@ func TestIsEtcdRuntimeComponentCreationEnabled(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), test.annotations, nil, false)
-			actual := IsEtcdRuntimeComponentCreationEnabled(etcdObjMeta)
+			etcdObjMeta := createEtcdObjectMetadata(uuid.NewUUID(), nil, nil, false)
+			etcd := &Etcd{
+				ObjectMeta: etcdObjMeta,
+				Spec: EtcdSpec{
+					Replicas: 3,
+					ExternallyManagedMemberAddresses: func() []string {
+						if test.hasExternallyManagedMembers {
+							return []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"}
+						}
+						return nil
+					}(),
+				},
+			}
+			actual := ArePodsManagedByEtcdDruid(etcd)
 			g.Expect(actual).To(Equal(test.expected))
 		})
 	}

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -846,6 +846,11 @@ func (in *EtcdSpec) DeepCopyInto(out *EtcdSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ExternallyManagedMemberAddresses != nil {
+		in, out := &in.ExternallyManagedMemberAddresses, &out.ExternallyManagedMemberAddresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/charts/crds/druid.gardener.cloud_etcds.yaml
+++ b/charts/crds/druid.gardener.cloud_etcds.yaml
@@ -2159,8 +2159,8 @@ spec:
             - message: etcd.spec.volumeClaimTemplate field cannot be added or removed
                 dynamically.
               rule: has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)
-            - message: etcd.spec.replicas must be equal to length of etcd.spec.externallyManagedMemberAddresses
-                when etcd.spec.externallyManagedMemberAddresses is specified.
+            - message: etcd.spec.externallyManagedMemberAddresses length must equal
+                to etcd.spec.replicas.
               rule: 'has(self.externallyManagedMemberAddresses) ? self.replicas ==
                 self.externallyManagedMemberAddresses.size() : true'
             - message: etcd.spec.externallyManagedMemberAddresses field cannot be

--- a/charts/crds/druid.gardener.cloud_etcds.yaml
+++ b/charts/crds/druid.gardener.cloud_etcds.yaml
@@ -2163,8 +2163,8 @@ spec:
                 to etcd.spec.replicas.
               rule: 'has(self.externallyManagedMemberAddresses) ? self.replicas ==
                 self.externallyManagedMemberAddresses.size() : true'
-            - message: etcd.spec.externallyManagedMemberAddresses field cannot be
-                added or removed dynamically.
+            - message: etcd.spec.externallyManagedMemberAddresses field must only
+                be set during creation.
               rule: has(oldSelf.externallyManagedMemberAddresses) == has(self.externallyManagedMemberAddresses)
           status:
             description: EtcdStatus defines the observed state of Etcd.

--- a/charts/crds/druid.gardener.cloud_etcds.yaml
+++ b/charts/crds/druid.gardener.cloud_etcds.yaml
@@ -865,6 +865,15 @@ spec:
                 - message: etcd.spec.etcd.bootstrapWithExistingCluster cannot be added
                     after the Etcd resource has been created
                   rule: '!has(self.bootstrapWithExistingCluster) || has(oldSelf.bootstrapWithExistingCluster)'
+              externallyManagedMemberAddresses:
+                description: |-
+                  ExternallyManagedMemberAddresses defines the list of addresses of externally managed etcd members. Specifying this
+                  will disable components that are involved in management of etcd members like Pods, Services and PDBs.
+                  Allowed values include: IPv4/IPv6 addresses and hostnames. Protocol or port shall not be specified.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
               labels:
                 additionalProperties:
                   type: string
@@ -2143,12 +2152,20 @@ spec:
             - replicas
             type: object
             x-kubernetes-validations:
-            - message: etcd.spec.storageClass is an immutable field.
-              rule: has(oldSelf.storageClass) ==  has(self.storageClass)
-            - message: etcd.spec.volumeClaimTemplate is an immutable field.
-              rule: has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)
             - message: etcd.spec.memberNamePrefix is an immutable field.
               rule: has(oldSelf.memberNamePrefix) == has(self.memberNamePrefix)
+            - message: etcd.spec.storageClass field cannot be added or removed dynamically.
+              rule: has(oldSelf.storageClass) ==  has(self.storageClass)
+            - message: etcd.spec.volumeClaimTemplate field cannot be added or removed
+                dynamically.
+              rule: has(oldSelf.volumeClaimTemplate) == has(self.volumeClaimTemplate)
+            - message: etcd.spec.replicas must be equal to length of etcd.spec.externallyManagedMemberAddresses
+                when etcd.spec.externallyManagedMemberAddresses is specified.
+              rule: 'has(self.externallyManagedMemberAddresses) ? self.replicas ==
+                self.externallyManagedMemberAddresses.size() : true'
+            - message: etcd.spec.externallyManagedMemberAddresses field cannot be
+                added or removed dynamically.
+              rule: has(oldSelf.externallyManagedMemberAddresses) == has(self.externallyManagedMemberAddresses)
           status:
             description: EtcdStatus defines the observed state of Etcd.
             properties:

--- a/docs/api-reference/etcd-druid-api.md
+++ b/docs/api-reference/etcd-druid-api.md
@@ -1003,6 +1003,7 @@ _Appears in:_
 | `storageCapacity` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#quantity-resource-api)_ | StorageCapacity defines the size of persistent volume. |  | Optional: \{\} <br /> |
 | `volumeClaimTemplate` _string_ | VolumeClaimTemplate defines the volume claim template to be created |  | Optional: \{\} <br /> |
 | `runAsRoot` _boolean_ | RunAsRoot defines whether the securityContext of the pod specification should indicate that the containers shall<br />run as root. By default, they run as non-root with user 'nobody'. |  | Optional: \{\} <br /> |
+| `externallyManagedMemberAddresses` _string array_ | ExternallyManagedMemberAddresses defines the list of addresses of externally managed etcd members. Specifying this<br />will disable components that are involved in management of etcd members like Pods, Services and PDBs.<br />Allowed values include: IPv4/IPv6 addresses and hostnames. Protocol or port shall not be specified. |  | Optional: \{\} <br /> |
 
 
 #### EtcdStatus

--- a/docs/concepts/externally-managed-members.md
+++ b/docs/concepts/externally-managed-members.md
@@ -1,0 +1,42 @@
+# Externally Managed Members
+
+In certain scenarios, such as [self-hosted shoot clusters](https://github.com/gardener/enhancements/tree/main/geps/0028-self-hosted-shoot-clusters) in Gardener, the etcd members are managed by an external actor (such as static pods managed by the kubelet on the control plane nodes). In these cases, etcd-druid cannot manage the lifecycle of the etcd members directly through Kubernetes constructs like StatefulSets. To accommodate this use case, support for externally managed etcd members is introduced in etcd-druid.
+
+A new field called `spec.externallyManagedMemberAddresses` is introduced which will contain the IP addresses of the externally managed members. An example of this in action is as follows:
+```yaml
+apiVersion: druid.gardener.cloud/v1alpha1
+kind: Etcd
+metadata:
+  name: etcd-main
+spec:
+  externallyManagedMemberAddresses:
+    - 192.168.0.1
+    - 192.168.0.2
+    - 192.168.0.3
+```
+
+When a list of member IPs is provided to etcd-druid via the `spec.externallyManagedMemberAddresses` field of the Etcd resource, etcd-druid will:
+* Disable specific pod-related features:
+  * Pods (StatefulSet is created with 0 replicas)
+  * Peer/Client Services
+  * PodDisruptionBudget
+* Populate the etcd ConfigMap with peer/client URLs that use the member IPs from `spec.externallyManagedMemberAddresses` instead of DNS names.
+* Populate the Lease object used for sharing state with the sidecar with the member IPs from `spec.externallyManagedMemberAddresses` instead of DNS names.
+* Create and assume that the member identities will no longer rely on StatefulSet semantics (like etcd-main-0, etcd-main-1, etc.), instead the identity will be based on the member IPs from `spec.externallyManagedMemberAddresses`. (like etcd-main-192.168.0.1, etcd-main-192.168.0.2, etc.)
+* The `Status.Ready` field in the `Etcd` CR will be populated with the value of the `AllMembersReady` condition instead of the current logic that depends on the StatefulSet Ready status when members are being managed externally.
+* When the list of member IPs is changed, etcd-druid will update the ConfigMap and Lease objects accordingly (i.e getting rid of old leases), but it will be the external actor's responsibility to ensure that the old members are removed from the cluster and the new members are added correctly.
+
+The field is subject to the following validations:
+* The field is a list of valid IPv4 address strings.
+* If the field is specified, it's length must equal `spec.replicas`. This also applies during updates to the field.
+* The field can be only be specified during the creation of the `Etcd` CR. The transition from druid-managed to externally-managed members and vice-versa are not supported. i.e the field cannot be introduced when druid is already managing a cluster and the field cannot be removed when the members are being managed externally.
+* Removal of the field is not allowed once set.
+* The list of member IPs cannot contain duplicates.
+* The list of member IPs can be updated, but the updated list must still satisfy the above constraints.
+
+In the etcd-backup-restore sidecar,
+* If the "service-endpoints" field is not supplied, the endpoints used for creating the etcd client will be derived from the member IPs obtained from the config file as fallback (since the client service is not created in this scenario).
+
+Using externally managed members allows etcd-druid to support scenarios where etcd members are managed outside of its direct control, while still providing essential functionalities like backup/restore, maintenance, and monitoring. This allows for etcd-druid to be used for managing etcd clusters in use-cases like [self-hosted shoot clusters in Gardener](https://github.com/gardener/enhancements/tree/main/geps/0028-self-hosted-shoot-clusters), [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/), [k3s](https://k3s.io/), etc.
+
+Note that the changes introduced previously to disable runtime components for self-hosted shoot clusters (https://github.com/gardener/etcd-druid/pull/1117) will be subsumed by this new approach.

--- a/docs/concepts/externally-managed-members.md
+++ b/docs/concepts/externally-managed-members.md
@@ -37,6 +37,10 @@ The field is subject to the following validations:
 In the etcd-backup-restore sidecar,
 * If the "service-endpoints" field is not supplied, the endpoints used for creating the etcd client will be derived from the member IPs obtained from the config file as fallback (since the client service is not created in this scenario).
 
+
+> [!WARNING]
+> Currently, if member IPs are removed from the list, it would be the responsibility of the external actor to remove the etcd member from the cluster (using etcd's member remove API). This will be automated by etcd-druid after [DEP-08](https://github.com/gardener/etcd-druid/pull/1369) is implemented.
+
 Using externally managed members allows etcd-druid to support scenarios where etcd members are managed outside of its direct control, while still providing essential functionalities like backup/restore, maintenance, and monitoring. This allows for etcd-druid to be used for managing etcd clusters in use-cases like [self-hosted shoot clusters in Gardener](https://github.com/gardener/enhancements/tree/main/geps/0028-self-hosted-shoot-clusters), [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/), [k3s](https://k3s.io/), etc.
 
 Note that the changes introduced previously to disable runtime components for self-hosted shoot clusters (https://github.com/gardener/etcd-druid/pull/1117) will be subsumed by this new approach.

--- a/examples/etcd/druid_v1alpha1_etcd.yaml
+++ b/examples/etcd/druid_v1alpha1_etcd.yaml
@@ -87,6 +87,10 @@ spec:
     #   effect: NoSchedule
 
   replicas: 3
+  # externallyManagedMemberAddresses:
+  #   - 192.168.0.1
+  #   - 192.168.0.2
+  #   - 192.168.0.3
   # priorityClassName: priority-class-name
   # storageClass: default
   # storageCapacity: 10Gi

--- a/internal/common/constants.go
+++ b/internal/common/constants.go
@@ -64,6 +64,8 @@ const (
 	EnvPodName = "POD_NAME"
 	// EnvPodNamespace is the environment variable key for the pod namespace.
 	EnvPodNamespace = "POD_NAMESPACE"
+	// EnvPodIP is the environment variable key for the pod IP.
+	EnvPodIP = "POD_IP"
 	// EnvStorageContainer is the environment variable key for the storage container.
 	EnvStorageContainer = "STORAGE_CONTAINER"
 	// EnvSourceStorageContainer is the environment variable key for the source storage container.

--- a/internal/component/configmap/configmap_test.go
+++ b/internal/component/configmap/configmap_test.go
@@ -89,13 +89,14 @@ func TestGetExistingResourceNames(t *testing.T) {
 // ----------------------------------- Sync -----------------------------------
 func TestSyncWhenNoConfigMapExists(t *testing.T) {
 	testCases := []struct {
-		name             string
-		etcdReplicas     int32
-		createErr        *apierrors.StatusError
-		clientTLSEnabled bool
-		peerTLSEnabled   bool
-		memberNamePrefix *string
-		expectedErr      *druiderr.DruidError
+		name                             string
+		etcdReplicas                     int32
+		createErr                        *apierrors.StatusError
+		clientTLSEnabled                 bool
+		peerTLSEnabled                   bool
+		memberNamePrefix                 *string
+		externallyManagedMemberAddresses []string
+		expectedErr                      *druiderr.DruidError
 	}{
 		{
 			name:             "should create when no configmap exists for single node etcd cluster",
@@ -117,6 +118,13 @@ func TestSyncWhenNoConfigMapExists(t *testing.T) {
 			memberNamePrefix: ptr.To("test-prefix"),
 		},
 		{
+			name:                             "should create when no configmap exists for multi-node etcd cluster with externally managed members",
+			clientTLSEnabled:                 true,
+			peerTLSEnabled:                   true,
+			etcdReplicas:                     3,
+			externallyManagedMemberAddresses: []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+		},
+		{
 			name:             "return error when create client request fails",
 			etcdReplicas:     3,
 			clientTLSEnabled: true,
@@ -134,7 +142,7 @@ func TestSyncWhenNoConfigMapExists(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			etcd := buildEtcd(tc.etcdReplicas, tc.clientTLSEnabled, tc.peerTLSEnabled)
+			etcd := buildEtcd(tc.etcdReplicas, tc.clientTLSEnabled, tc.peerTLSEnabled, tc.externallyManagedMemberAddresses)
 			etcd.Spec.MemberNamePrefix = tc.memberNamePrefix
 			cl := testutils.CreateTestFakeClientForObjects(nil, tc.createErr, nil, nil, nil, getObjectKey(etcd.ObjectMeta))
 			operator := New(cl)
@@ -155,13 +163,14 @@ func TestSyncWhenNoConfigMapExists(t *testing.T) {
 
 func TestPrepareInitialCluster(t *testing.T) {
 	testCases := []struct {
-		name                        string
-		peerTLSEnabled              bool
-		etcdReplicas                int32
-		etcdSpecServerPort          *int32
-		additionalAdvertisePeerURLs []druidv1alpha1.MemberPeerURLs
-		memberNamePrefix            *string
-		expectedInitialCluster      string
+		name                             string
+		peerTLSEnabled                   bool
+		externallyManagedMemberAddresses []string
+		etcdReplicas                     int32
+		etcdSpecServerPort               *int32
+		additionalAdvertisePeerURLs      []druidv1alpha1.MemberPeerURLs
+		memberNamePrefix                 *string
+		expectedInitialCluster           string
 	}{
 		{
 			name:                   "should create initial cluster for single node etcd cluster when peer TLS is enabled",
@@ -184,6 +193,14 @@ func TestPrepareInitialCluster(t *testing.T) {
 			expectedInitialCluster: "etcd-test-0=https://etcd-test-0.etcd-test-peer.test-ns.svc:2333,etcd-test-1=https://etcd-test-1.etcd-test-peer.test-ns.svc:2333,etcd-test-2=https://etcd-test-2.etcd-test-peer.test-ns.svc:2333",
 		},
 		{
+			name:                             "should create initial cluster for multi node etcd cluster when externally managed members are present",
+			etcdReplicas:                     3,
+			peerTLSEnabled:                   true,
+			externallyManagedMemberAddresses: []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+			etcdSpecServerPort:               ptr.To[int32](2333),
+			expectedInitialCluster:           "etcd-test-1.1.1.1=https://1.1.1.1:2333,etcd-test-1.1.1.2=https://1.1.1.2:2333,etcd-test-1.1.1.3=https://1.1.1.3:2333",
+		},
+		{
 			name:           "should append additional peer URLs for matching member",
 			etcdReplicas:   2,
 			peerTLSEnabled: false,
@@ -193,7 +210,7 @@ func TestPrepareInitialCluster(t *testing.T) {
 					URLs:       []string{"http://10.0.0.1:2380"},
 				},
 			},
-			expectedInitialCluster: "etcd-test-0=http://etcd-test-0.etcd-test-peer.test-ns.svc:2380,etcd-test-0=http://10.0.0.1:2380,etcd-test-1=http://etcd-test-1.etcd-test-peer.test-ns.svc:2380",
+			expectedInitialCluster: "etcd-test-0=http://etcd-test-0.etcd-test-peer.test-ns.svc:2380,etcd-test-1=http://etcd-test-1.etcd-test-peer.test-ns.svc:2380,etcd-test-0=http://10.0.0.1:2380",
 		},
 		{
 			name:           "should append multiple additional peer URLs for single member",
@@ -221,7 +238,7 @@ func TestPrepareInitialCluster(t *testing.T) {
 					URLs:       []string{"http://10.0.0.3:2380"},
 				},
 			},
-			expectedInitialCluster: "etcd-test-0=http://etcd-test-0.etcd-test-peer.test-ns.svc:2380,etcd-test-0=http://10.0.0.1:2380,etcd-test-1=http://etcd-test-1.etcd-test-peer.test-ns.svc:2380,etcd-test-2=http://etcd-test-2.etcd-test-peer.test-ns.svc:2380,etcd-test-2=http://10.0.0.3:2380",
+			expectedInitialCluster: "etcd-test-0=http://etcd-test-0.etcd-test-peer.test-ns.svc:2380,etcd-test-1=http://etcd-test-1.etcd-test-peer.test-ns.svc:2380,etcd-test-2=http://etcd-test-2.etcd-test-peer.test-ns.svc:2380,etcd-test-0=http://10.0.0.1:2380,etcd-test-2=http://10.0.0.3:2380",
 		},
 		{
 			name:           "should ignore non-matching member names",
@@ -254,7 +271,7 @@ func TestPrepareInitialCluster(t *testing.T) {
 					URLs:       []string{"http://10.0.0.1:2380"},
 				},
 			},
-			expectedInitialCluster: "myprefix-etcd-test-0=http://etcd-test-0.etcd-test-peer.test-ns.svc:2380,myprefix-etcd-test-0=http://10.0.0.1:2380,myprefix-etcd-test-1=http://etcd-test-1.etcd-test-peer.test-ns.svc:2380",
+			expectedInitialCluster: "myprefix-etcd-test-0=http://etcd-test-0.etcd-test-peer.test-ns.svc:2380,myprefix-etcd-test-1=http://etcd-test-1.etcd-test-peer.test-ns.svc:2380,myprefix-etcd-test-0=http://10.0.0.1:2380",
 		},
 	}
 	t.Parallel()
@@ -262,7 +279,7 @@ func TestPrepareInitialCluster(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-			etcd := buildEtcd(tc.etcdReplicas, true, tc.peerTLSEnabled)
+			etcd := buildEtcd(tc.etcdReplicas, true, tc.peerTLSEnabled, tc.externallyManagedMemberAddresses)
 			etcd.Spec.Etcd.ServerPort = tc.etcdSpecServerPort
 			etcd.Spec.MemberNamePrefix = tc.memberNamePrefix
 			if tc.additionalAdvertisePeerURLs != nil {
@@ -421,7 +438,7 @@ func TestGetAdvertiseURLs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			etcd := buildEtcd(tc.etcdReplicas, true, tc.peerTLSEnabled)
+			etcd := buildEtcd(tc.etcdReplicas, true, tc.peerTLSEnabled, nil)
 			etcd.Spec.Etcd.ServerPort = tc.serverPort
 			etcd.Spec.Etcd.ClientPort = tc.clientPort
 			etcd.Spec.MemberNamePrefix = tc.memberNamePrefix
@@ -661,13 +678,16 @@ func TestTriggerDelete(t *testing.T) {
 }
 
 // ---------------------------- Helper Functions -----------------------------
-func buildEtcd(replicas int32, clientTLSEnabled, peerTLSEnabled bool) *druidv1alpha1.Etcd {
+func buildEtcd(replicas int32, clientTLSEnabled, peerTLSEnabled bool, externallyManagedMemberAddresses []string) *druidv1alpha1.Etcd {
 	etcdBuilder := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).WithReplicas(replicas)
 	if clientTLSEnabled {
 		etcdBuilder.WithClientTLS()
 	}
 	if peerTLSEnabled {
 		etcdBuilder.WithPeerTLS()
+	}
+	if len(externallyManagedMemberAddresses) > 0 {
+		etcdBuilder.WithExternallyManagedMembers(externallyManagedMemberAddresses)
 	}
 	return etcdBuilder.Build()
 }
@@ -756,10 +776,17 @@ func expectedAdvertiseURLs(etcd *druidv1alpha1.Etcd, advertiseURLType, scheme st
 		return nil
 	}
 	advUrlsMap := make(map[string][]string)
-	for i := 0; i < int(etcd.Spec.Replicas); i++ {
-		podName := druidv1alpha1.GetOrdinalPodName(etcd.ObjectMeta, i)
-		memberName := druidv1alpha1.GetMemberName(etcd.Spec.MemberNamePrefix, podName)
-		advUrlsMap[memberName] = []string{fmt.Sprintf("%s://%s.%s.%s.svc:%d", scheme, podName, druidv1alpha1.GetPeerServiceName(etcd.ObjectMeta), etcd.Namespace, port)}
+	if druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
+		for i := 0; i < int(etcd.Spec.Replicas); i++ {
+			podName := druidv1alpha1.GetOrdinalPodName(etcd.ObjectMeta, i)
+			memberName := druidv1alpha1.GetMemberName(etcd.Spec.MemberNamePrefix, podName)
+			advUrlsMap[memberName] = []string{fmt.Sprintf("%s://%s.%s.%s.svc:%d", scheme, podName, druidv1alpha1.GetPeerServiceName(etcd.ObjectMeta), etcd.Namespace, port)}
+		}
+	} else {
+		for _, memberAddress := range etcd.Spec.ExternallyManagedMemberAddresses {
+			memberName := druidv1alpha1.GetMemberNameFromAddress(etcd, memberAddress)
+			advUrlsMap[memberName] = []string{fmt.Sprintf("%s://%s:%d", scheme, memberAddress, port)}
+		}
 	}
 	return advUrlsMap
 }

--- a/internal/component/configmap/etcdconfig.go
+++ b/internal/component/configmap/etcdconfig.go
@@ -150,12 +150,23 @@ func prepareInitialCluster(etcd *druidv1alpha1.Etcd, peerScheme string) string {
 	domainName := fmt.Sprintf("%s.%s.%s", druidv1alpha1.GetPeerServiceName(etcd.ObjectMeta), etcd.Namespace, "svc")
 	serverPort := strconv.Itoa(int(ptr.Deref(etcd.Spec.Etcd.ServerPort, common.DefaultPortEtcdPeer)))
 	builder := strings.Builder{}
+
+	if druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
+		for i := range int(etcd.Spec.Replicas) {
+			podName := druidv1alpha1.GetOrdinalPodName(etcd.ObjectMeta, i)
+			memberName := druidv1alpha1.GetMemberName(etcd.Spec.MemberNamePrefix, podName)
+			fmt.Fprintf(&builder, "%s=%s://%s.%s:%s,", memberName, peerScheme, podName, domainName, serverPort)
+		}
+	} else {
+		for _, memberAddress := range etcd.Spec.ExternallyManagedMemberAddresses {
+			memberName := druidv1alpha1.GetMemberNameFromAddress(etcd, memberAddress)
+			fmt.Fprintf(&builder, "%s=%s://%s:%s,", memberName, peerScheme, memberAddress, serverPort)
+		}
+	}
+
 	for i := range int(etcd.Spec.Replicas) {
 		podName := druidv1alpha1.GetOrdinalPodName(etcd.ObjectMeta, i)
 		memberName := druidv1alpha1.GetMemberName(etcd.Spec.MemberNamePrefix, podName)
-
-		fmt.Fprintf(&builder, "%s=%s://%s.%s:%s,", memberName, peerScheme, podName, domainName, serverPort)
-
 		for _, memberURLs := range etcd.Spec.Etcd.AdditionalAdvertisePeerURLs {
 			if memberURLs.MemberName == podName {
 				for _, url := range memberURLs.URLs {
@@ -186,26 +197,34 @@ func getAdvertiseURLs(etcd *druidv1alpha1.Etcd, advertiseURLType, scheme, peerSv
 		return nil
 	}
 	advUrlsMap := make(map[string][]string)
-	// Headless service is created by etcd-druid, so we can use the DNS names of the pods.
-	domainName := fmt.Sprintf("%s.%s.%s", peerSvcName, etcd.Namespace, "svc")
-	for i := range int(etcd.Spec.Replicas) {
-		podName := druidv1alpha1.GetOrdinalPodName(etcd.ObjectMeta, i)
-		memberName := druidv1alpha1.GetMemberName(etcd.Spec.MemberNamePrefix, podName)
 
-		// Start with internal service DNS URL
-		urls := []string{fmt.Sprintf("%s://%s.%s:%d", scheme, podName, domainName, port)}
+	if druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
+		// Headless service is created by etcd-druid, so we can use the DNS names of the pods.
+		domainName := fmt.Sprintf("%s.%s.%s", peerSvcName, etcd.Namespace, "svc")
+		for i := range int(etcd.Spec.Replicas) {
+			podName := druidv1alpha1.GetOrdinalPodName(etcd.ObjectMeta, i)
+			memberName := druidv1alpha1.GetMemberName(etcd.Spec.MemberNamePrefix, podName)
+			advUrlsMap[memberName] = []string{fmt.Sprintf("%s://%s.%s:%d", scheme, podName, domainName, port)}
+		}
+	} else {
+		for _, memberAddress := range etcd.Spec.ExternallyManagedMemberAddresses {
+			memberName := druidv1alpha1.GetMemberNameFromAddress(etcd, memberAddress)
+			advUrlsMap[memberName] = []string{fmt.Sprintf("%s://%s:%d", scheme, memberAddress, port)}
+		}
+	}
 
-		// Append additional peer URLs only for peer advertise URLs
-		if advertiseURLType == advertiseURLTypePeer {
+	// Append additional peer URLs only for peer advertise URLs
+	if advertiseURLType == advertiseURLTypePeer {
+		for i := range int(etcd.Spec.Replicas) {
+			podName := druidv1alpha1.GetOrdinalPodName(etcd.ObjectMeta, i)
+			memberName := druidv1alpha1.GetMemberName(etcd.Spec.MemberNamePrefix, podName)
 			for _, memberURLs := range etcd.Spec.Etcd.AdditionalAdvertisePeerURLs {
 				if memberURLs.MemberName == podName {
-					urls = append(urls, memberURLs.URLs...)
+					advUrlsMap[memberName] = append(advUrlsMap[memberName], memberURLs.URLs...)
 					break
 				}
 			}
 		}
-
-		advUrlsMap[memberName] = urls
 	}
 	return advUrlsMap
 }

--- a/internal/component/memberlease/memberlease.go
+++ b/internal/component/memberlease/memberlease.go
@@ -6,6 +6,7 @@ package memberlease
 
 import (
 	"fmt"
+	"slices"
 
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -87,6 +89,33 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 			errs = multierror.Append(errs, err)
 		}
 	}
+
+	if !druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
+		// Delete any extra member leases that are not needed anymore.
+		// This can happen if a member is removed/replaced when configured with externally managed members.
+		if existingLeaseNames, err := r.GetExistingResourceNames(ctx, etcd.ObjectMeta); err == nil {
+			desiredLeaseNames := druidv1alpha1.GetMemberLeaseNames(etcd)
+			deleteTasks := make([]utils.OperatorTask, 0)
+			for _, existingLeaseName := range existingLeaseNames {
+				if !slices.Contains(desiredLeaseNames, existingLeaseName) {
+					leaseObjKey := client.ObjectKey{Name: existingLeaseName, Namespace: etcd.Namespace}
+					deleteTasks = append(deleteTasks, utils.OperatorTask{
+						Name: "Delete-" + leaseObjKey.String(),
+						Fn: func(ctx component.OperatorContext) error {
+							return r.doDelete(ctx, leaseObjKey)
+						},
+					})
+				}
+			}
+			if errorList := utils.RunConcurrently(ctx, deleteTasks); len(errorList) > 0 {
+				for _, err := range errorList {
+					errs = multierror.Append(errs, err)
+				}
+			}
+		} else {
+			errs = multierror.Append(errs, err)
+		}
+	}
 	return errs
 }
 
@@ -103,6 +132,21 @@ func (r _resource) doCreateOrUpdate(ctx component.OperatorContext, etcd *druidv1
 			fmt.Sprintf("Error syncing member lease: %v for etcd: %v", objKey, druidv1alpha1.GetNamespaceName(etcd.ObjectMeta)))
 	}
 	ctx.Logger.Info("triggered create or update of member lease", "objectKey", objKey, "operationResult", opResult)
+	return nil
+}
+
+func (r _resource) doDelete(ctx component.OperatorContext, objectKey client.ObjectKey) error {
+	if err := r.client.Delete(ctx, emptyMemberLease(objectKey)); err != nil {
+		if errors.IsNotFound(err) {
+			ctx.Logger.Info("No member lease found, Deletion is a No-Op", "objectKey", objectKey)
+			return nil
+		}
+		return druiderr.WrapError(err,
+			ErrDeleteMemberLease,
+			component.OperationTriggerDelete,
+			fmt.Sprintf("Failed to delete member lease: %v", objectKey))
+	}
+	ctx.Logger.Info("deleted", "component", "member-lease", "objectKey", objectKey)
 	return nil
 }
 

--- a/internal/component/memberlease/memberlease.go
+++ b/internal/component/memberlease/memberlease.go
@@ -91,28 +91,36 @@ func (r _resource) Sync(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd)
 	}
 
 	if !druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
-		// Delete any extra member leases that are not needed anymore.
-		// This can happen if a member is removed/replaced when configured with externally managed members.
-		if existingLeaseNames, err := r.GetExistingResourceNames(ctx, etcd.ObjectMeta); err == nil {
-			desiredLeaseNames := druidv1alpha1.GetMemberLeaseNames(etcd)
-			deleteTasks := make([]utils.OperatorTask, 0)
-			for _, existingLeaseName := range existingLeaseNames {
-				if !slices.Contains(desiredLeaseNames, existingLeaseName) {
-					leaseObjKey := client.ObjectKey{Name: existingLeaseName, Namespace: etcd.Namespace}
-					deleteTasks = append(deleteTasks, utils.OperatorTask{
-						Name: "Delete-" + leaseObjKey.String(),
-						Fn: func(ctx component.OperatorContext) error {
-							return r.doDelete(ctx, leaseObjKey)
-						},
-					})
-				}
-			}
-			if errorList := utils.RunConcurrently(ctx, deleteTasks); len(errorList) > 0 {
-				for _, err := range errorList {
-					errs = multierror.Append(errs, err)
-				}
-			}
-		} else {
+		if err := r.deleteStaleMemberLeases(ctx, etcd); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+	return errs
+}
+
+// deleteStaleMemberLeases deletes member leases that exist but are no longer required.
+// This can happen if a member is removed/replaced when configured with externally managed members.
+func (r _resource) deleteStaleMemberLeases(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) error {
+	existingLeaseNames, err := r.GetExistingResourceNames(ctx, etcd.ObjectMeta)
+	if err != nil {
+		return err
+	}
+	desiredLeaseNames := druidv1alpha1.GetMemberLeaseNames(etcd)
+	deleteTasks := make([]utils.OperatorTask, 0)
+	for _, existingLeaseName := range existingLeaseNames {
+		if !slices.Contains(desiredLeaseNames, existingLeaseName) {
+			leaseObjKey := client.ObjectKey{Name: existingLeaseName, Namespace: etcd.Namespace}
+			deleteTasks = append(deleteTasks, utils.OperatorTask{
+				Name: "Delete-" + leaseObjKey.String(),
+				Fn: func(ctx component.OperatorContext) error {
+					return r.doDelete(ctx, leaseObjKey)
+				},
+			})
+		}
+	}
+	var errs error
+	if errorList := utils.RunConcurrently(ctx, deleteTasks); len(errorList) > 0 {
+		for _, err := range errorList {
 			errs = multierror.Append(errs, err)
 		}
 	}

--- a/internal/component/memberlease/memberlease_test.go
+++ b/internal/component/memberlease/memberlease_test.go
@@ -7,7 +7,6 @@ package memberlease
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
@@ -108,13 +107,15 @@ func TestGetExistingResourceNames(t *testing.T) {
 // ----------------------------------- Sync -----------------------------------
 func TestSync(t *testing.T) {
 	testCases := []struct {
-		name              string
-		etcdReplicas      int32 // original replicas
-		deltaEtcdReplicas int32 // change in etcd replicas if any
-		numExistingLeases int
-		createErr         *apierrors.StatusError
-		getErr            *apierrors.StatusError
-		expectedErr       *druiderr.DruidError
+		name                    string
+		etcdReplicas            int32 // original replicas
+		deltaEtcdReplicas       int32 // change in etcd replicas if any
+		numExistingLeases       int
+		existingExternalMembers []string
+		newExternalMembers      []string
+		createErr               *apierrors.StatusError
+		getErr                  *apierrors.StatusError
+		expectedErr             *druiderr.DruidError
 	}{
 		{
 			name:              "create member leases for a single node etcd cluster",
@@ -126,6 +127,35 @@ func TestSync(t *testing.T) {
 			etcdReplicas:      1,
 			numExistingLeases: 1,
 			deltaEtcdReplicas: 2,
+		},
+		{
+			name:                    "creates member leases when new externally managed members are added",
+			etcdReplicas:            2,
+			deltaEtcdReplicas:       1,
+			numExistingLeases:       2,
+			existingExternalMembers: []string{"1.1.1.1", "1.1.1.2"},
+			newExternalMembers:      []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+		},
+		{
+			name:                    "deletes excess member leases when externally managed member is removed",
+			etcdReplicas:            3,
+			deltaEtcdReplicas:       -1,
+			existingExternalMembers: []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+			newExternalMembers:      []string{"1.1.1.1", "1.1.1.2"},
+			numExistingLeases:       3,
+		},
+		{
+			name:                    "deletes excess member leases when externally managed member is replaced",
+			etcdReplicas:            3,
+			existingExternalMembers: []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+			newExternalMembers:      []string{"1.1.1.1", "1.1.1.2", "1.1.1.4"},
+			numExistingLeases:       3,
+		},
+		{
+			name:              "should not delete excess member leases when hibernating druid-managed members",
+			etcdReplicas:      3,
+			deltaEtcdReplicas: -3,
+			numExistingLeases: 3,
 		},
 		{
 			name:              "should return error when client create fails",
@@ -158,35 +188,40 @@ func TestSync(t *testing.T) {
 			t.Parallel()
 			// *************** set up existing environment *****************
 			etcdBuilder := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace)
-			etcd := etcdBuilder.WithReplicas(tc.etcdReplicas).Build()
+			if len(tc.existingExternalMembers) > 0 {
+				etcdBuilder = etcdBuilder.WithExternallyManagedMembers(tc.existingExternalMembers)
+			}
+			etcd := *etcdBuilder.WithReplicas(tc.etcdReplicas).Build()
 			var existingObjects []client.Object
 			if tc.numExistingLeases > 0 {
-				leases, err := newMemberLeases(etcd, tc.numExistingLeases)
+				leases, err := newMemberLeases(&etcd, tc.numExistingLeases)
 				g.Expect(err).ToNot(HaveOccurred())
 				for _, lease := range leases {
 					existingObjects = append(existingObjects, lease)
 				}
 			}
-			cl := testutils.CreateTestFakeClientForObjects(tc.getErr, tc.createErr, nil, nil, existingObjects, getObjectKeys(etcd)...)
+			cl := testutils.CreateTestFakeClientForObjects(tc.getErr, tc.createErr, nil, nil, existingObjects, getObjectKeys(&etcd)...)
 
 			// ***************** Setup updated etcd to be passed to the Sync method *****************
-			var updatedEtcd *druidv1alpha1.Etcd
-			// Currently we only support up-scaling. If and when down-scaling is supported, this condition will have to change.
-			if tc.deltaEtcdReplicas > 0 {
-				updatedEtcd = etcdBuilder.WithReplicas(tc.etcdReplicas + tc.deltaEtcdReplicas).Build()
-			} else {
-				updatedEtcd = etcd
+			etcdBuilder = etcdBuilder.WithReplicas(tc.etcdReplicas + tc.deltaEtcdReplicas)
+			if len(tc.newExternalMembers) > 0 {
+				etcdBuilder = etcdBuilder.WithExternallyManagedMembers(tc.newExternalMembers)
 			}
+			updatedEtcd := *etcdBuilder.Build()
 			// ***************** Setup component operator and test *****************
 			operator := New(cl)
 			opCtx := component.NewOperatorContext(context.Background(), logr.Discard(), uuid.NewString())
-			err := operator.Sync(opCtx, updatedEtcd)
-			memberLeasesPostSync := getLatestMemberLeases(g, cl, updatedEtcd)
+			err := operator.Sync(opCtx, &updatedEtcd)
+			memberLeasesPostSync := getLatestMemberLeases(g, cl, &updatedEtcd)
 			if tc.expectedErr != nil {
 				testutils.CheckDruidError(g, tc.expectedErr, err)
 				g.Expect(memberLeasesPostSync).Should(HaveLen(tc.numExistingLeases))
 			} else {
-				g.Expect(memberLeasesPostSync).To(ConsistOf(memberLeases(updatedEtcd.Name, updatedEtcd.UID, updatedEtcd.Spec.Replicas)))
+				if updatedEtcd.Spec.Replicas == 0 { // hibernation
+					g.Expect(memberLeasesPostSync).To(ConsistOf(memberLeases(&etcd, etcd.UID, etcd.Spec.Replicas)))
+				} else {
+					g.Expect(memberLeasesPostSync).To(ConsistOf(memberLeases(&updatedEtcd, updatedEtcd.UID, updatedEtcd.Spec.Replicas)))
+				}
 			}
 		})
 	}
@@ -236,7 +271,7 @@ func TestTriggerDelete(t *testing.T) {
 
 	g := NewWithT(t)
 	t.Parallel()
-	nonTargetEtcd := testutils.EtcdBuilderWithDefaults(nonTargetEtcdName, testutils.TestNamespace).Build()
+	nonTargetEtcd := testutils.EtcdBuilderWithDefaults(nonTargetEtcdName, testutils.TestNamespace).WithReplicas(2).Build()
 	nonTargetLeaseNames := []string{"another-etcd-0", "another-etcd-1"}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -267,7 +302,8 @@ func TestTriggerDelete(t *testing.T) {
 				g.Expect(memberLeasesPostDelete).Should(HaveLen(0))
 				nonTargetMemberLeases := getLatestMemberLeases(g, cl, nonTargetEtcd)
 				g.Expect(nonTargetMemberLeases).To(HaveLen(len(nonTargetLeaseNames)))
-				g.Expect(nonTargetMemberLeases).To(ConsistOf(memberLeases(nonTargetEtcd.Name, nonTargetEtcd.UID, int32(len(nonTargetLeaseNames)))))
+				g.Expect(nonTargetMemberLeases).To(ConsistOf(memberLeases(nonTargetEtcd, nonTargetEtcd.UID, int32(len(nonTargetLeaseNames)))))
+
 			}
 		})
 	}
@@ -292,11 +328,10 @@ func doGetLatestLeases(g *WithT, cl client.Client, etcd *druidv1alpha1.Etcd, mat
 	return leases.Items
 }
 
-func memberLeases(etcdName string, etcdUID types.UID, numLeases int32) []any {
+func memberLeases(etcd *druidv1alpha1.Etcd, etcdUID types.UID, numLeases int32) []interface{} {
 	var elements []any
-	for i := 0; i < int(numLeases); i++ {
-		leaseName := fmt.Sprintf("%s-%d", etcdName, i)
-		elements = append(elements, matchLeaseElement(leaseName, etcdName, etcdUID))
+	for _, leaseName := range druidv1alpha1.GetMemberLeaseNames(etcd)[:numLeases] {
+		elements = append(elements, matchLeaseElement(leaseName, etcd.Name, etcdUID))
 	}
 	return elements
 }

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -138,18 +138,18 @@ func (b *stsBuilder) getStatefulSetLabels() map[string]string {
 
 func (b *stsBuilder) createStatefulSetSpec(ctx component.OperatorContext) error {
 	err := b.createPodTemplateSpec(ctx)
-	b.sts.Spec.Replicas = ptr.To(utils.IfConditionOr(druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta), b.replicas, 0))
-	b.logger.Info("Creating StatefulSet spec", "replicas", b.sts.Spec.Replicas, "name", b.sts.Name, "namespace", b.sts.Namespace)
-	b.sts.Spec.UpdateStrategy = defaultUpdateStrategy
 	if err != nil {
 		return err
 	}
+	b.sts.Spec.Replicas = ptr.To(utils.IfConditionOr(druidv1alpha1.ArePodsManagedByEtcdDruid(b.etcd), b.replicas, 0))
+	b.logger.Info("Creating StatefulSet spec", "replicas", b.sts.Spec.Replicas, "name", b.sts.Name, "namespace", b.sts.Namespace)
+	b.sts.Spec.UpdateStrategy = defaultUpdateStrategy
 	if !b.skipSetOrUpdateForbiddenFields {
 		b.sts.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: druidv1alpha1.GetDefaultLabels(b.etcd.ObjectMeta),
 		}
 		b.sts.Spec.PodManagementPolicy = defaultPodManagementPolicy
-		if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta) {
+		if druidv1alpha1.ArePodsManagedByEtcdDruid(b.etcd) {
 			b.sts.Spec.ServiceName = druidv1alpha1.GetPeerServiceName(b.etcd.ObjectMeta)
 		}
 		b.sts.Spec.VolumeClaimTemplates = b.getVolumeClaimTemplates()
@@ -183,9 +183,8 @@ func (b *stsBuilder) createPodTemplateSpec(ctx component.OperatorContext) error 
 			PriorityClassName:         ptr.Deref(b.etcd.Spec.PriorityClassName, ""),
 		},
 	}
-	if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta) {
-		podTemplateSpec.Spec.ServiceAccountName = druidv1alpha1.GetServiceAccountName(b.etcd.ObjectMeta)
-	}
+	podTemplateSpec.Spec.ServiceAccountName = druidv1alpha1.GetServiceAccountName(b.etcd.ObjectMeta)
+
 	podTemplateLabels := b.getStatefulSetPodLabels()
 	selectorMatchesLabels, err := kubernetes.DoesLabelSelectorMatchLabels(b.sts.Spec.Selector, podTemplateLabels)
 	if err != nil {
@@ -393,7 +392,7 @@ func (b *stsBuilder) getEtcdContainer() corev1.Container {
 }
 
 func (b *stsBuilder) getBackupRestoreContainer() (corev1.Container, error) {
-	env, err := utils.GetBackupRestoreContainerEnvVars(b.etcd.Spec.Backup.Store)
+	env, err := utils.GetBackupRestoreContainerEnvVars(b.etcd, b.etcd.Spec.Backup.Store)
 	if err != nil {
 		return corev1.Container{}, err
 	}
@@ -469,14 +468,14 @@ func (b *stsBuilder) getBackupRestoreContainerCommandArgs() []string {
 		commandArgs = append(commandArgs, "--insecure-transport=false")
 		commandArgs = append(commandArgs, "--insecure-skip-tls-verify=false")
 		commandArgs = append(commandArgs, fmt.Sprintf("--endpoints=https://%s-local:%d", b.etcd.Name, b.clientPort))
-		if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta) {
+		if druidv1alpha1.ArePodsManagedByEtcdDruid(b.etcd) {
 			commandArgs = append(commandArgs, fmt.Sprintf("--service-endpoints=%s", b.getServiceEndpoints("https")))
 		}
 	} else {
 		commandArgs = append(commandArgs, "--insecure-transport=true")
 		commandArgs = append(commandArgs, "--insecure-skip-tls-verify=true")
 		commandArgs = append(commandArgs, fmt.Sprintf("--endpoints=http://%s-local:%d", b.etcd.Name, b.clientPort))
-		if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta) {
+		if druidv1alpha1.ArePodsManagedByEtcdDruid(b.etcd) {
 			commandArgs = append(commandArgs, fmt.Sprintf("--service-endpoints=%s", b.getServiceEndpoints("http")))
 		}
 	}
@@ -492,14 +491,12 @@ func (b *stsBuilder) getBackupRestoreContainerCommandArgs() []string {
 	commandArgs = append(commandArgs, fmt.Sprintf("--snapstore-temp-directory=%s/temp", common.VolumeMountPathEtcdData))
 	commandArgs = append(commandArgs, fmt.Sprintf("--etcd-connection-timeout=%s", defaultEtcdConnectionTimeout))
 	commandArgs = append(commandArgs, "--use-etcd-wrapper=true")
-	if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta) {
-		commandArgs = append(commandArgs, "--enable-member-lease-renewal=true")
-		heartbeatDuration := defaultHeartbeatDuration
-		if b.etcd.Spec.Etcd.HeartbeatDuration != nil {
-			heartbeatDuration = b.etcd.Spec.Etcd.HeartbeatDuration.Duration.String()
-		}
-		commandArgs = append(commandArgs, fmt.Sprintf("--k8s-heartbeat-duration=%s", heartbeatDuration))
+	commandArgs = append(commandArgs, "--enable-member-lease-renewal=true")
+	heartbeatDuration := defaultHeartbeatDuration
+	if b.etcd.Spec.Etcd.HeartbeatDuration != nil {
+		heartbeatDuration = b.etcd.Spec.Etcd.HeartbeatDuration.Duration.String()
 	}
+	commandArgs = append(commandArgs, fmt.Sprintf("--k8s-heartbeat-duration=%s", heartbeatDuration))
 
 	var quota = defaultQuota
 	if b.etcd.Spec.Etcd.Quota != nil {
@@ -536,11 +533,9 @@ func (b *stsBuilder) getServiceEndpoints(scheme string) string {
 func (b *stsBuilder) getBackupStoreCommandArgs() []string {
 	var commandArgs []string
 
-	if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(b.etcd.ObjectMeta) {
-		commandArgs = append(commandArgs, "--enable-snapshot-lease-renewal=true")
-		commandArgs = append(commandArgs, fmt.Sprintf("--full-snapshot-lease-name=%s", druidv1alpha1.GetFullSnapshotLeaseName(b.etcd.ObjectMeta)))
-		commandArgs = append(commandArgs, fmt.Sprintf("--delta-snapshot-lease-name=%s", druidv1alpha1.GetDeltaSnapshotLeaseName(b.etcd.ObjectMeta)))
-	}
+	commandArgs = append(commandArgs, "--enable-snapshot-lease-renewal=true")
+	commandArgs = append(commandArgs, fmt.Sprintf("--full-snapshot-lease-name=%s", druidv1alpha1.GetFullSnapshotLeaseName(b.etcd.ObjectMeta)))
+	commandArgs = append(commandArgs, fmt.Sprintf("--delta-snapshot-lease-name=%s", druidv1alpha1.GetDeltaSnapshotLeaseName(b.etcd.ObjectMeta)))
 	commandArgs = append(commandArgs, fmt.Sprintf("--storage-provider=%s", *b.provider))
 	commandArgs = append(commandArgs, fmt.Sprintf("--store-prefix=%s", b.etcd.Spec.Backup.Store.Prefix))
 	if b.etcd.Spec.Backup.Store.EndpointOverride != nil {

--- a/internal/component/statefulset/builder.go
+++ b/internal/component/statefulset/builder.go
@@ -392,7 +392,7 @@ func (b *stsBuilder) getEtcdContainer() corev1.Container {
 }
 
 func (b *stsBuilder) getBackupRestoreContainer() (corev1.Container, error) {
-	env, err := utils.GetBackupRestoreContainerEnvVars(b.etcd, b.etcd.Spec.Backup.Store)
+	env, err := utils.GetBackupRestoreContainerEnvVars(b.etcd)
 	if err != nil {
 		return corev1.Container{}, err
 	}

--- a/internal/component/statefulset/statefulset_test.go
+++ b/internal/component/statefulset/statefulset_test.go
@@ -308,15 +308,14 @@ func TestPreSync(t *testing.T) {
 // ----------------------------------- Sync -----------------------------------
 func TestSyncWhenNoSTSExists(t *testing.T) {
 	testCases := []struct {
-		name                   string
-		replicas               int32
-		annotations            map[string]string
-		tolerations            []corev1.Toleration
-		createErr              *apierrors.StatusError
-		expectedErr            *druiderr.DruidError
-		expectedReplicas       *int32
-		expectNoServiceAccount bool
-		expectNoService        bool
+		name                        string
+		replicas                    int32
+		tolerations                 []corev1.Toleration
+		hasExternallyManagedMembers bool
+		createErr                   *apierrors.StatusError
+		expectedErr                 *druiderr.DruidError
+		expectedReplicas            *int32
+		expectNoService             bool
 	}{
 		{
 			name:             "creates a single replica sts for a single node etcd cluster",
@@ -353,14 +352,11 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 			},
 		},
 		{
-			name:     "creates sts with 0 replicas, with no serviceAccount and service defined, with lease renewal and client-service-endpoint CLI flags disabled on backup-restore container when runtime component creation is disabled",
-			replicas: 3,
-			annotations: map[string]string{
-				druidv1alpha1.DisableEtcdRuntimeComponentCreationAnnotation: "",
-			},
-			expectedReplicas:       ptr.To[int32](0),
-			expectNoServiceAccount: true,
-			expectNoService:        true,
+			name:                        "creates sts with 0 replicas, with no service defined and client-service-endpoint CLI flags disabled on backup-restore container when members are managed externally",
+			replicas:                    3,
+			hasExternallyManagedMembers: true,
+			expectedReplicas:            ptr.To[int32](0),
+			expectNoService:             true,
 		},
 	}
 
@@ -371,17 +367,19 @@ func TestSyncWhenNoSTSExists(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			// *************** Build test environment ***************
-			etcd := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).
+			etcdBuilder := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).
 				WithReplicas(tc.replicas).
-				WithAnnotations(tc.annotations).
-				WithTolerations(tc.tolerations).
-				Build()
+				WithTolerations(tc.tolerations)
+			if tc.hasExternallyManagedMembers {
+				etcdBuilder = etcdBuilder.WithExternallyManagedMembers([]string{"1.1.1.1", "1.1.1.2", "1.1.1.3"})
+			}
+			etcd := etcdBuilder.Build()
 
 			cl := testutils.CreateTestFakeClientForObjects(nil, tc.createErr, nil, nil, []client.Object{buildBackupSecret()}, getObjectKey(etcd.ObjectMeta))
 			etcdImage, etcdBRImage, initContainerImage, err := utils.GetEtcdImages(etcd, iv)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(tc.expectedReplicas).ToNot(BeNil())
-			stsMatcher := NewStatefulSetMatcher(g, cl, etcd, *tc.expectedReplicas, initContainerImage, etcdImage, etcdBRImage, ptr.To(druidstore.Local), tc.expectNoServiceAccount, tc.expectNoService)
+			stsMatcher := NewStatefulSetMatcher(g, cl, etcd, *tc.expectedReplicas, initContainerImage, etcdImage, etcdBRImage, ptr.To(druidstore.Local), tc.expectNoService)
 			operator := New(cl, iv)
 			// *************** Test and assert ***************
 			opCtx := component.NewOperatorContext(context.Background(), logr.Discard(), uuid.NewString())

--- a/internal/component/statefulset/stsmatcher.go
+++ b/internal/component/statefulset/stsmatcher.go
@@ -38,20 +38,19 @@ var (
 
 // StatefulSetMatcher is the type used for matching StatefulSets. It holds relevant information required for matching.
 type StatefulSetMatcher struct {
-	g                      *WithT
-	cl                     client.Client
-	etcd                   *druidv1alpha1.Etcd
-	initContainerImage     string
-	etcdImage              string
-	etcdBRImage            string
-	provider               *string
-	clientPort             int32
-	serverPort             int32
-	backupPort             int32
-	wrapperPort            int32
-	expectedReplicas       int32
-	expectNoServiceAccount bool
-	expectNoService        bool
+	g                  *WithT
+	cl                 client.Client
+	etcd               *druidv1alpha1.Etcd
+	initContainerImage string
+	etcdImage          string
+	etcdBRImage        string
+	provider           *string
+	clientPort         int32
+	serverPort         int32
+	backupPort         int32
+	wrapperPort        int32
+	expectedReplicas   int32
+	expectNoService    bool
 }
 
 // NewStatefulSetMatcher constructs a new instance of StatefulSetMatcher.
@@ -61,22 +60,21 @@ func NewStatefulSetMatcher(g *WithT,
 	replicas int32,
 	initContainerImage, etcdImage, etcdBRImage string,
 	provider *string,
-	expectNoServiceAccount, expectNoService bool) StatefulSetMatcher {
+	expectNoService bool) StatefulSetMatcher {
 	return StatefulSetMatcher{
-		g:                      g,
-		cl:                     cl,
-		etcd:                   etcd,
-		initContainerImage:     initContainerImage,
-		etcdImage:              etcdImage,
-		etcdBRImage:            etcdBRImage,
-		provider:               provider,
-		clientPort:             ptr.Deref(etcd.Spec.Etcd.ClientPort, 2379),
-		serverPort:             ptr.Deref(etcd.Spec.Etcd.ServerPort, 2380),
-		backupPort:             ptr.Deref(etcd.Spec.Backup.Port, 8080),
-		wrapperPort:            ptr.Deref(etcd.Spec.Etcd.WrapperPort, 9095),
-		expectedReplicas:       replicas,
-		expectNoServiceAccount: expectNoServiceAccount,
-		expectNoService:        expectNoService,
+		g:                  g,
+		cl:                 cl,
+		etcd:               etcd,
+		initContainerImage: initContainerImage,
+		etcdImage:          etcdImage,
+		etcdBRImage:        etcdBRImage,
+		provider:           provider,
+		clientPort:         ptr.Deref(etcd.Spec.Etcd.ClientPort, 2379),
+		serverPort:         ptr.Deref(etcd.Spec.Etcd.ServerPort, 2380),
+		backupPort:         ptr.Deref(etcd.Spec.Backup.Port, 8080),
+		wrapperPort:        ptr.Deref(etcd.Spec.Etcd.WrapperPort, 9095),
+		expectedReplicas:   replicas,
+		expectNoService:    expectNoService,
 	}
 }
 
@@ -160,9 +158,7 @@ func (s StatefulSetMatcher) matchPodSpec() gomegatypes.GomegaMatcher {
 		"PriorityClassName":     Equal(ptr.Deref(s.etcd.Spec.PriorityClassName, "")),
 		"Tolerations":           Equal(s.etcd.Spec.SchedulingConstraints.Tolerations),
 	}
-	if !s.expectNoServiceAccount {
-		fields["ServiceAccountName"] = Equal(druidv1alpha1.GetServiceAccountName(s.etcd.ObjectMeta))
-	}
+	fields["ServiceAccountName"] = Equal(druidv1alpha1.GetServiceAccountName(s.etcd.ObjectMeta))
 	return MatchFields(IgnoreExtras, fields)
 }
 

--- a/internal/controller/compaction/reconciler.go
+++ b/internal/controller/compaction/reconciler.go
@@ -532,7 +532,7 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 		job.Spec.Template.Spec.Containers[0].VolumeMounts = vms
 	}
 
-	env, err := utils.GetBackupRestoreContainerEnvVars(etcd.Spec.Backup.Store)
+	env, err := utils.GetBackupRestoreContainerEnvVars(etcd, etcd.Spec.Backup.Store)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating compaction job in %v for %v : unable to get backup-restore container environment variables : %w",
 			etcd.Namespace,

--- a/internal/controller/compaction/reconciler.go
+++ b/internal/controller/compaction/reconciler.go
@@ -532,7 +532,7 @@ func (r *Reconciler) createCompactionJob(ctx context.Context, logger logr.Logger
 		job.Spec.Template.Spec.Containers[0].VolumeMounts = vms
 	}
 
-	env, err := utils.GetBackupRestoreContainerEnvVars(etcd, etcd.Spec.Backup.Store)
+	env, err := utils.GetBackupRestoreContainerEnvVars(etcd)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating compaction job in %v for %v : unable to get backup-restore container environment variables : %w",
 			etcd.Namespace,

--- a/internal/controller/compaction/snapshot.go
+++ b/internal/controller/compaction/snapshot.go
@@ -117,10 +117,9 @@ func newHTTPClient(ctx context.Context, cl client.Client, etcd *druidv1alpha1.Et
 // fullSnapshot makes an HTTP GET request to the etcd client service for a full snapshot.
 func fullSnapshot(ctx context.Context, etcd *druidv1alpha1.Etcd, httpClient httpClientInterface, httpScheme string) error {
 	fullSnapshotURL := fmt.Sprintf(
-		"%s://%s.%s.svc.cluster.local:%d/snapshot/full",
+		"%s://%s:%d/snapshot/full",
 		httpScheme,
-		druidv1alpha1.GetClientServiceName(etcd.ObjectMeta),
-		etcd.Namespace,
+		druidv1alpha1.GetClientHostname(etcd),
 		ptr.Deref(etcd.Spec.Backup.Port, common.DefaultPortEtcdBackupRestore),
 	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullSnapshotURL, nil)

--- a/internal/controller/compaction/snapshot_test.go
+++ b/internal/controller/compaction/snapshot_test.go
@@ -46,7 +46,7 @@ func TestFullSnapshot(t *testing.T) {
 			httpClient: &mockHTTPClient{
 				DoFunc: func(req *http.Request) (*http.Response, error) {
 					if req.URL.String() != fmt.Sprintf(
-						"http://%s.%s.svc.cluster.local:%d/snapshot/full",
+						"http://%s.%s.svc:%d/snapshot/full",
 						druidv1alpha1.GetClientServiceName(eb.Build().ObjectMeta),
 						testutils.TestNamespace,
 						backupPort,
@@ -68,11 +68,35 @@ func TestFullSnapshot(t *testing.T) {
 			httpClient: &mockHTTPClient{
 				DoFunc: func(req *http.Request) (*http.Response, error) {
 					if req.URL.String() != fmt.Sprintf(
-						"https://%s.%s.svc.cluster.local:%d/snapshot/full",
+						"https://%s.%s.svc:%d/snapshot/full",
 						druidv1alpha1.GetClientServiceName(eb.Build().ObjectMeta),
 						testutils.TestNamespace,
 						backupPort,
 					) {
+						return nil, fmt.Errorf("unexpected URL: %s", req.URL.String())
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       http.NoBody,
+					}, nil
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:       "should trigger full snapshot with externally managed member addresses (success)",
+			httpScheme: "http",
+			etcd: testutils.EtcdBuilderWithoutDefaults(testutils.TestEtcdName, testutils.TestNamespace).
+				WithExternallyManagedMembers([]string{"1.1.1.1"}).
+				WithBackupPort(&backupPort).
+				Build(),
+			httpClient: &mockHTTPClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					expectedURL := fmt.Sprintf(
+						"http://1.1.1.1:%d/snapshot/full",
+						backupPort,
+					)
+					if req.URL.String() != expectedURL {
 						return nil, fmt.Errorf("unexpected URL: %s", req.URL.String())
 					}
 					return &http.Response{
@@ -90,7 +114,7 @@ func TestFullSnapshot(t *testing.T) {
 			httpClient: &mockHTTPClient{
 				DoFunc: func(req *http.Request) (*http.Response, error) {
 					if req.URL.String() != fmt.Sprintf(
-						"http://%s.%s.svc.cluster.local:%d/snapshot/full",
+						"http://%s.%s.svc:%d/snapshot/full",
 						druidv1alpha1.GetClientServiceName(eb.Build().ObjectMeta),
 						testutils.TestNamespace,
 						backupPort,
@@ -112,7 +136,7 @@ func TestFullSnapshot(t *testing.T) {
 			httpClient: &mockHTTPClient{
 				DoFunc: func(req *http.Request) (*http.Response, error) {
 					if req.URL.String() != fmt.Sprintf(
-						"http://%s.%s.svc.cluster.local:%d/snapshot/full",
+						"http://%s.%s.svc:%d/snapshot/full",
 						druidv1alpha1.GetClientServiceName(eb.Build().ObjectMeta),
 						testutils.TestNamespace,
 						backupPort,

--- a/internal/controller/etcd/reconcile_spec.go
+++ b/internal/controller/etcd/reconcile_spec.go
@@ -13,11 +13,9 @@ import (
 	"github.com/gardener/etcd-druid/internal/component"
 	ctrlutils "github.com/gardener/etcd-druid/internal/controller/utils"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
-	"github.com/gardener/etcd-druid/internal/utils"
 	"github.com/gardener/etcd-druid/internal/utils/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -34,7 +32,6 @@ func (r *Reconciler) reconcileSpec(ctx component.OperatorContext, etcd *druidv1a
 		r.ensureFinalizer,
 		r.preSyncEtcdResources,
 		r.syncEtcdResources,
-		r.cleanupEtcdResources,
 		r.recordReconcileSuccessOperation,
 	}
 
@@ -75,7 +72,7 @@ func (r *Reconciler) preSyncEtcdResources(ctx component.OperatorContext, etcd *d
 }
 
 func (r *Reconciler) syncEtcdResources(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) ctrlutils.ReconcileStepResult {
-	resourceOperators := r.getOrderedOperatorsForSync(etcd.ObjectMeta)
+	resourceOperators := r.getOrderedOperatorsForSync(etcd)
 	for _, kind := range resourceOperators {
 		op := r.operatorRegistry.GetOperator(kind)
 		if err := op.Sync(ctx, etcd); err != nil {
@@ -86,29 +83,6 @@ func (r *Reconciler) syncEtcdResources(ctx component.OperatorContext, etcd *drui
 			ctx.Logger.Error(err, "failed to sync etcd resource", "kind", kind)
 			return ctrlutils.ReconcileWithError(err)
 		}
-	}
-	return ctrlutils.ContinueReconcile()
-}
-
-// cleanupEtcdResources cleans up the resources that are no longer required for the Etcd cluster.
-// This is required when runtime components are disabled for an Etcd cluster after it was created with runtime components enabled,
-// so druid needs to ensure that the previously created runtime components are now cleaned up to avoid leaked resources in the cluster.
-func (r *Reconciler) cleanupEtcdResources(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) ctrlutils.ReconcileStepResult {
-	resourceOperators := r.getOperatorsForCleanup(etcd.ObjectMeta)
-	deleteTasks := make([]utils.OperatorTask, 0, len(resourceOperators))
-	for _, kind := range resourceOperators {
-		operator := r.operatorRegistry.GetOperator(kind)
-		deleteTasks = append(deleteTasks, utils.OperatorTask{
-			Name: fmt.Sprintf("cleanup-%s-component", kind),
-			Fn: func(ctx component.OperatorContext) error {
-				return operator.TriggerDelete(ctx, etcd.ObjectMeta)
-			},
-		})
-	}
-
-	ctx.Logger.Info("triggering cleanup for druid-managed resources that are no longer required")
-	if errs := utils.RunConcurrently(ctx, deleteTasks); len(errs) > 0 {
-		return ctrlutils.ReconcileWithError(errs...)
 	}
 	return ctrlutils.ContinueReconcile()
 }
@@ -188,43 +162,25 @@ func (r *Reconciler) getOrderedOperatorsForPreSync() []component.Kind {
 	}
 }
 
-func (r *Reconciler) getOrderedOperatorsForSync(etcdObjMeta metav1.ObjectMeta) []component.Kind {
-	var operators []component.Kind
-
-	if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(etcdObjMeta) {
-		operators = []component.Kind{
-			component.ServiceAccountKind,
-			component.RoleKind,
-			component.RoleBindingKind,
-			component.MemberLeaseKind,
-			component.SnapshotLeaseKind,
+func (r *Reconciler) getOrderedOperatorsForSync(etcd *druidv1alpha1.Etcd) []component.Kind {
+	var operators = []component.Kind{
+		component.ServiceAccountKind,
+		component.RoleKind,
+		component.RoleBindingKind,
+		component.MemberLeaseKind,
+		component.SnapshotLeaseKind,
+	}
+	if druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
+		operators = append(operators,
 			component.PodDisruptionBudgetKind,
 			component.ClientServiceKind,
 			component.PeerServiceKind,
-		}
+		)
 	}
-
-	// add the rest of the operators that are always needed for the etcd cluster
 	operators = append(operators,
 		component.ConfigMapKind,
 		component.StatefulSetKind,
 	)
 
 	return operators
-}
-
-func (r *Reconciler) getOperatorsForCleanup(etcdObjMeta metav1.ObjectMeta) []component.Kind {
-	if druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(etcdObjMeta) {
-		return nil
-	}
-	return []component.Kind{
-		component.ServiceAccountKind,
-		component.RoleKind,
-		component.RoleBindingKind,
-		component.MemberLeaseKind,
-		component.SnapshotLeaseKind,
-		component.PodDisruptionBudgetKind,
-		component.ClientServiceKind,
-		component.PeerServiceKind,
-	}
 }

--- a/internal/controller/etcd/reconcile_status.go
+++ b/internal/controller/etcd/reconcile_status.go
@@ -24,10 +24,6 @@ type mutateEtcdStatusFn func(ctx component.OperatorContext, etcd *druidv1alpha1.
 
 func (r *Reconciler) reconcileStatus(ctx component.OperatorContext, etcd *druidv1alpha1.Etcd) ctrlutils.ReconcileStepResult {
 	sLog := r.logger.WithValues("etcd", client.ObjectKeyFromObject(etcd), "operation", "reconcileStatus").WithValues("runID", ctx.RunID)
-	if !druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(etcd.ObjectMeta) {
-		sLog.Info("Skipping status checks since etcd runtime component creation is disabled")
-		return ctrlutils.ContinueReconcile()
-	}
 	originalEtcd := etcd.DeepCopy()
 
 	var mutateETCDStatusStepFns = []mutateEtcdStatusFn{
@@ -74,11 +70,22 @@ func (r *Reconciler) inspectStatefulSetAndMutateETCDStatus(ctx component.Operato
 		if etcd.Status.ObservedGeneration == nil || *etcd.Status.ObservedGeneration != etcd.Generation {
 			expectedReplicas = *sts.Spec.Replicas
 		}
-		ready, _ := kubernetes.IsStatefulSetReady(expectedReplicas, sts)
 		etcd.Status.CurrentReplicas = sts.Status.CurrentReplicas
 		etcd.Status.ReadyReplicas = sts.Status.ReadyReplicas
 		etcd.Status.Replicas = sts.Status.CurrentReplicas
-		etcd.Status.Ready = &ready
+		if druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
+			ready, _ := kubernetes.IsStatefulSetReady(expectedReplicas, sts)
+			etcd.Status.Ready = &ready
+		} else {
+			allMembersReady := false
+			for _, condition := range etcd.Status.Conditions {
+				if condition.Type == druidv1alpha1.ConditionTypeAllMembersReady {
+					allMembersReady = condition.Status == druidv1alpha1.ConditionTrue
+					break
+				}
+			}
+			etcd.Status.Ready = &allMembersReady
+		}
 	} else {
 		etcd.Status.CurrentReplicas = 0
 		etcd.Status.ReadyReplicas = 0

--- a/internal/controller/etcdopstask/handler/ondemandsnapshot/ondemandsnapshot.go
+++ b/internal/controller/etcdopstask/handler/ondemandsnapshot/ondemandsnapshot.go
@@ -100,7 +100,7 @@ func (h *handler) Execute(ctx context.Context) taskhandler.Result {
 	}
 	h.httpClient = httpClient
 
-	url := fmt.Sprintf("%s://%s.%s:%d/snapshot/%s", httpScheme, druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), etcd.Namespace, ptr.Deref(etcd.Spec.Backup.Port, common.DefaultPortEtcdBackupRestore), h.config.Type)
+	url := fmt.Sprintf("%s://%s:%d/snapshot/%s", httpScheme, druidv1alpha1.GetClientHostname(etcd), ptr.Deref(etcd.Spec.Backup.Port, common.DefaultPortEtcdBackupRestore), h.config.Type)
 	if ptr.Deref(h.config.IsFinal, false) {
 		url += "?final=true"
 	}

--- a/internal/utils/envvar.go
+++ b/internal/utils/envvar.go
@@ -5,6 +5,8 @@
 package utils
 
 import (
+	"fmt"
+
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/common"
 
@@ -49,10 +51,16 @@ func GetEnvVarFromSecret(name, secretName, secretKey string, optional bool) core
 }
 
 // GetBackupRestoreContainerEnvVars returns non-provider-specific environment variables for the backup-restore container.
-func GetBackupRestoreContainerEnvVars(store *druidv1alpha1.StoreSpec) ([]corev1.EnvVar, error) {
+func GetBackupRestoreContainerEnvVars(etcd *druidv1alpha1.Etcd, store *druidv1alpha1.StoreSpec) ([]corev1.EnvVar, error) {
 	var envVars []corev1.EnvVar
 
-	envVars = append(envVars, getEnvVarFromFieldPath(common.EnvPodName, "metadata.name"))
+	if druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
+		envVars = append(envVars, getEnvVarFromFieldPath(common.EnvPodName, "metadata.name"))
+	} else {
+		// Populate the POD_NAME as <etcd-name>-<pod-ip> in case of externally managed members.
+		envVars = append(envVars, getEnvVarFromFieldPath(common.EnvPodIP, "status.podIP"))
+		envVars = append(envVars, GetEnvVarFromValue(common.EnvPodName, fmt.Sprintf("%s-$(%s)", etcd.Name, common.EnvPodIP)))
+	}
 	envVars = append(envVars, getEnvVarFromFieldPath(common.EnvPodNamespace, "metadata.namespace"))
 
 	if store == nil {

--- a/internal/utils/envvar.go
+++ b/internal/utils/envvar.go
@@ -51,7 +51,7 @@ func GetEnvVarFromSecret(name, secretName, secretKey string, optional bool) core
 }
 
 // GetBackupRestoreContainerEnvVars returns non-provider-specific environment variables for the backup-restore container.
-func GetBackupRestoreContainerEnvVars(etcd *druidv1alpha1.Etcd, store *druidv1alpha1.StoreSpec) ([]corev1.EnvVar, error) {
+func GetBackupRestoreContainerEnvVars(etcd *druidv1alpha1.Etcd) ([]corev1.EnvVar, error) {
 	var envVars []corev1.EnvVar
 
 	if druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
@@ -63,11 +63,11 @@ func GetBackupRestoreContainerEnvVars(etcd *druidv1alpha1.Etcd, store *druidv1al
 	}
 	envVars = append(envVars, getEnvVarFromFieldPath(common.EnvPodNamespace, "metadata.namespace"))
 
-	if store == nil {
+	if etcd.Spec.Backup.Store == nil {
 		return envVars, nil
 	}
 
-	storageContainer := ptr.Deref(store.Container, "")
+	storageContainer := ptr.Deref(etcd.Spec.Backup.Store.Container, "")
 	envVars = append(envVars, GetEnvVarFromValue(common.EnvStorageContainer, storageContainer))
 
 	return envVars, nil

--- a/internal/webhook/etcdcomponentprotection/handler.go
+++ b/internal/webhook/etcdcomponentprotection/handler.go
@@ -19,7 +19,6 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -92,9 +91,9 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Allowed(fmt.Sprintf("changes allowed, since Etcd %s has annotation %s", etcd.Name, druidv1alpha1.DisableEtcdComponentProtectionAnnotation))
 	}
 
-	if isRuntimeComponent(requestGK) {
-		if !druidv1alpha1.IsEtcdRuntimeComponentCreationEnabled(etcd.ObjectMeta) {
-			return admission.Allowed(fmt.Sprintf("Etcd %s has runtime component creation disabled, skipping validations for resource %v", etcd.Name, utils.CreateObjectKey(partialObjMeta)))
+	if isComponentInvolvedInPodManagement(requestGK) {
+		if !druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
+			return admission.Allowed(fmt.Sprintf("Etcd %s has pod management disabled, skipping validations for resource %v", etcd.Name, utils.CreateObjectKey(partialObjMeta)))
 		}
 	}
 
@@ -174,13 +173,9 @@ func isObjManagedByDruid(objMeta metav1.ObjectMeta) bool {
 	return hasLabel && managedBy == druidv1alpha1.LabelManagedByValue
 }
 
-// isRuntimeComponent checks if the request is for a runtime component for the etcd cluster, such as lease, RBAC, etc.
-func isRuntimeComponent(requestGK schema.GroupKind) bool {
-	return requestGK == corev1.SchemeGroupVersion.WithKind("ServiceAccount").GroupKind() ||
-		requestGK == rbacv1.SchemeGroupVersion.WithKind("Role").GroupKind() ||
-		requestGK == rbacv1.SchemeGroupVersion.WithKind("RoleBinding").GroupKind() ||
-		requestGK == coordinationv1.SchemeGroupVersion.WithKind("Lease").GroupKind() ||
-		requestGK == policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget").GroupKind() ||
+// isComponentInvolvedInPodManagement checks if the request is for a component that is involved in pod management like PodDisruptionBudgets and Services.
+func isComponentInvolvedInPodManagement(requestGK schema.GroupKind) bool {
+	return requestGK == policyv1.SchemeGroupVersion.WithKind("PodDisruptionBudget").GroupKind() ||
 		requestGK == corev1.SchemeGroupVersion.WithKind("Service").GroupKind()
 }
 

--- a/test/it/controller/etcd/assertions.go
+++ b/test/it/controller/etcd/assertions.go
@@ -141,10 +141,7 @@ func assertResourceCreation(ctx component.OperatorContext, t *testing.T, opRegis
 }
 
 func assertMemberLeasesCreated(ctx component.OperatorContext, t *testing.T, opRegistry component.Registry, etcd *druidv1alpha1.Etcd, timeout, pollInterval time.Duration) {
-	expectedMemberLeaseNames := make([]string, 0, etcd.Spec.Replicas)
-	for i := 0; i < int(etcd.Spec.Replicas); i++ {
-		expectedMemberLeaseNames = append(expectedMemberLeaseNames, fmt.Sprintf("%s-%d", etcd.Name, i))
-	}
+	expectedMemberLeaseNames := druidv1alpha1.GetMemberLeaseNames(etcd)
 	assertResourceCreation(ctx, t, opRegistry, component.MemberLeaseKind, etcd, expectedMemberLeaseNames, timeout, pollInterval)
 }
 

--- a/test/it/controller/etcd/reconciler_test.go
+++ b/test/it/controller/etcd/reconciler_test.go
@@ -83,8 +83,7 @@ func TestEtcdReconcileSpecWithNoAutoReconcile(t *testing.T) {
 	}{
 		{"should add finalizer to etcd when etcd resource is created", testAddFinalizerToEtcd},
 		{"should create all managed resources when etcd resource is created", testAllManagedResourcesAreCreated},
-		{"should create necessary managed resources when `disable-etcd-runtime-component-creation` annotation is set", testNecessaryManagedResourcesAreCorrectlyCreatedWhenDisableEtcdRuntimeComponentCreationAnnotationIsSet},
-		{"should clean up unnecessary managed resources when `disable-etcd-runtime-component-creation` annotation is set", testUnnecessaryManagedResourcesAreCleanedUpWhenDisableEtcdRuntimeComponentCreationAnnotationIsSet},
+		{"should create necessary managed resources when externally managed members are present", testNecessaryManagedResourcesAreCorrectlyCreatedWhenExternallyManagedMembersArePresent},
 		{"should succeed only in creation of some resources and not all and should record error in lastErrors and lastOperation", testFailureToCreateAllResources},
 		{"should not reconcile spec when reconciliation is suspended", testWhenReconciliationIsSuspended},
 		{"should not reconcile upon etcd spec update when no reconcile operation annotation is set", testEtcdSpecUpdateWhenNoReconcileOperationAnnotationIsSet},
@@ -153,7 +152,7 @@ func testAllManagedResourcesAreCreated(t *testing.T, testNs string, reconcilerTe
 	assertETCDOperationAnnotation(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), false, 5*time.Second, 1*time.Second)
 }
 
-func testNecessaryManagedResourcesAreCorrectlyCreatedWhenDisableEtcdRuntimeComponentCreationAnnotationIsSet(t *testing.T, testNs string, reconcilerTestEnv ReconcilerTestEnv) {
+func testNecessaryManagedResourcesAreCorrectlyCreatedWhenExternallyManagedMembersArePresent(t *testing.T, testNs string, reconcilerTestEnv ReconcilerTestEnv) {
 	const (
 		timeout         = time.Minute * 2
 		pollingInterval = time.Second * 2
@@ -164,9 +163,7 @@ func testNecessaryManagedResourcesAreCorrectlyCreatedWhenDisableEtcdRuntimeCompo
 		WithClientTLS().
 		WithPeerTLS().
 		WithReplicas(3).
-		WithAnnotations(map[string]string{
-			druidv1alpha1.DisableEtcdRuntimeComponentCreationAnnotation: "",
-		}).
+		WithExternallyManagedMembers([]string{"1.1.1.1", "1.1.1.2", "1.1.1.3"}).
 		Build()
 	g.Expect(etcdInstance.Spec.Backup.Store).ToNot(BeNil())
 	g.Expect(etcdInstance.Spec.Backup.Store.SecretRef).ToNot(BeNil())
@@ -180,92 +177,20 @@ func testNecessaryManagedResourcesAreCorrectlyCreatedWhenDisableEtcdRuntimeCompo
 	componentKindCreated := []component.Kind{
 		component.ConfigMapKind,
 		component.StatefulSetKind,
-	}
-	assertSelectedComponentsExists(ctx, t, reconcilerTestEnv, etcdInstance, componentKindCreated, timeout, pollingInterval)
-	assertStatefulSetReplicas(ctx, t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), 0, 30*time.Second, 2*time.Second)
-	componentKindNotCreated := []component.Kind{
 		component.ServiceAccountKind,
 		component.RoleKind,
 		component.RoleBindingKind,
 		component.MemberLeaseKind,
 		component.SnapshotLeaseKind,
+	}
+	assertSelectedComponentsExists(ctx, t, reconcilerTestEnv, etcdInstance, componentKindCreated, timeout, pollingInterval)
+	assertStatefulSetReplicas(ctx, t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), 0, 30*time.Second, 2*time.Second)
+	componentKindNotCreated := []component.Kind{
 		component.PodDisruptionBudgetKind,
 		component.ClientServiceKind,
 		component.PeerServiceKind,
 	}
 	assertComponentsDoNotExist(ctx, t, reconcilerTestEnv, etcdInstance, componentKindNotCreated, timeout, pollingInterval)
-	expectedLastOperation := &druidapicommon.LastOperation{
-		Type:  druidv1alpha1.LastOperationTypeReconcile,
-		State: druidv1alpha1.LastOperationStateSucceeded,
-	}
-	assertETCDLastOperationAndLastErrorsUpdatedSuccessfully(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), expectedLastOperation, nil, 5*time.Second, 1*time.Second)
-	assertETCDObservedGeneration(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), ptr.To[int64](1), 30*time.Second, 1*time.Second)
-	assertETCDOperationAnnotation(t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), false, 5*time.Second, 1*time.Second)
-}
-
-func testUnnecessaryManagedResourcesAreCleanedUpWhenDisableEtcdRuntimeComponentCreationAnnotationIsSet(t *testing.T, testNs string, reconcilerTestEnv ReconcilerTestEnv) {
-	const (
-		timeout         = time.Minute * 2
-		pollingInterval = time.Second * 2
-	)
-	// ***************** setup *****************
-	g := NewWithT(t)
-	etcdInstance := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testNs).
-		WithClientTLS().
-		WithPeerTLS().
-		WithReplicas(3).
-		Build()
-	g.Expect(etcdInstance.Spec.Backup.Store).ToNot(BeNil())
-	g.Expect(etcdInstance.Spec.Backup.Store.SecretRef).ToNot(BeNil())
-	cl := reconcilerTestEnv.itTestEnv.GetClient()
-	ctx := context.Background()
-	// create backup secrets
-	g.Expect(testutils.CreateSecrets(ctx, cl, testNs, etcdInstance.Spec.Backup.Store.SecretRef.Name)).To(Succeed())
-	// create etcdInstance resource and assert successful reconciliation, and ensure that sts generation is 1
-	createAndAssertEtcdReconciliation(ctx, t, reconcilerTestEnv, etcdInstance)
-	assertStatefulSetReplicas(ctx, t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), 3, 30*time.Second, 2*time.Second)
-	// update member leases with peer-tls-enabled annotation set to true
-	memberLeaseNames := druidv1alpha1.GetMemberLeaseNames(etcdInstance)
-	t.Log("updating member leases with peer-tls-enabled annotation set to true")
-	mlcs := []etcdMemberLeaseConfig{
-		{name: memberLeaseNames[0], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
-		{name: memberLeaseNames[1], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
-		{name: memberLeaseNames[2], annotations: map[string]string{common.LeaseAnnotationKeyPeerURLTLSEnabled: "true"}},
-	}
-	updateMemberLeases(context.Background(), t, reconcilerTestEnv.itTestEnv.GetClient(), testNs, mlcs)
-	// update etcd with annotations, retrying on conflict since reconciler may be updating status concurrently
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// get latest version of etcdInstance
-		if err := cl.Get(ctx, druidv1alpha1.GetNamespaceName(etcdInstance.ObjectMeta), etcdInstance); err != nil {
-			return err
-		}
-		// add `disable-etcd-runtime-component-creation` annotation and operation reconcile annotation to etcdInstance
-		etcdInstance.Annotations = map[string]string{
-			druidv1alpha1.DisableEtcdRuntimeComponentCreationAnnotation: "",
-			druidv1alpha1.DruidOperationAnnotation:                      druidv1alpha1.DruidOperationReconcile,
-		}
-		return cl.Update(ctx, etcdInstance)
-	})
-	g.Expect(err).To(Succeed())
-
-	// ***************** test etcd spec reconciliation  *****************
-	componentKindAbsent := []component.Kind{
-		component.ServiceAccountKind,
-		component.RoleKind,
-		component.RoleBindingKind,
-		component.MemberLeaseKind,
-		component.SnapshotLeaseKind,
-		component.PodDisruptionBudgetKind,
-		component.ClientServiceKind,
-		component.PeerServiceKind,
-	}
-	assertComponentsDoNotExist(ctx, t, reconcilerTestEnv, etcdInstance, componentKindAbsent, timeout, pollingInterval)
-	componentKindPresent := []component.Kind{
-		component.ConfigMapKind,
-		component.StatefulSetKind,
-	}
-	assertSelectedComponentsExists(ctx, t, reconcilerTestEnv, etcdInstance, componentKindPresent, timeout, pollingInterval)
-	assertStatefulSetReplicas(ctx, t, reconcilerTestEnv.itTestEnv.GetClient(), client.ObjectKeyFromObject(etcdInstance), 0, 30*time.Second, 2*time.Second)
 	expectedLastOperation := &druidapicommon.LastOperation{
 		Type:  druidv1alpha1.LastOperationTypeReconcile,
 		State: druidv1alpha1.LastOperationStateSucceeded,

--- a/test/it/crdvalidation/etcd/spec_test.go
+++ b/test/it/crdvalidation/etcd/spec_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Testing validations of etcd.spec fields.
+
+package etcd
+
+import (
+	"testing"
+
+	"github.com/gardener/etcd-druid/test/utils"
+)
+
+// TestSpecExternallyManagedMemberAddresses tests the validation of the Spec.ExternallyManagedMemberAddresses field.
+func TestSpecExternallyManagedMemberAddresses(t *testing.T) {
+	tests := []struct {
+		name                           string
+		etcdName                       string
+		replicas                       int32
+		externallyManagedMemberAddress []string
+		expectErr                      bool
+	}{
+		{
+			name:                           "Valid externallyManagedMemberAddresses #1: druid-managed setup - no addresses with non-zero replicas",
+			etcdName:                       "etcd-valid-1",
+			replicas:                       3,
+			externallyManagedMemberAddress: []string{},
+			expectErr:                      false,
+		},
+		{
+			name:                           "Valid externallyManagedMemberAddresses #2: valid addresses",
+			etcdName:                       "etcd-valid-2",
+			replicas:                       3,
+			externallyManagedMemberAddress: []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"},
+			expectErr:                      false,
+		},
+		{
+			name:                           "Invalid externallyManagedMemberAddresses #1: mismatched number of addresses and replicas",
+			etcdName:                       "etcd-invalid-1",
+			replicas:                       3,
+			externallyManagedMemberAddress: []string{"1.1.1.1", "1.1.1.2"},
+			expectErr:                      true,
+		},
+		{
+			name:                           "Invalid externallyManagedMemberAddresses #2: non-unique addresses",
+			etcdName:                       "etcd-invalid-2",
+			replicas:                       3,
+			externallyManagedMemberAddress: []string{"1.1.1.1", "1.1.1.1", "1.1.1.1"},
+			expectErr:                      true,
+		},
+	}
+
+	testNs, g := setupTestEnvironment(t)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			etcd := utils.EtcdBuilderWithoutDefaults(test.etcdName, testNs).
+				WithReplicas(test.replicas).
+				WithExternallyManagedMembers(test.externallyManagedMemberAddress).
+				Build()
+
+			validateEtcdCreation(g, etcd, test.expectErr)
+		})
+	}
+}

--- a/test/utils/etcd.go
+++ b/test/utils/etcd.go
@@ -541,6 +541,12 @@ func (eb *EtcdBuilder) WithGRPCGatewayEnabled() *EtcdBuilder {
 	return eb
 }
 
+// WithExternallyManagedMembers sets the externally managed member addresses in the etcd spec.
+func (eb *EtcdBuilder) WithExternallyManagedMembers(addresses []string) *EtcdBuilder {
+	eb.etcd.Spec.ExternallyManagedMemberAddresses = addresses
+	return eb
+}
+
 // WithDefaultBackup creates a default backup spec and initializes etcd with it.
 func (eb *EtcdBuilder) WithDefaultBackup() *EtcdBuilder {
 	eb.etcd.Spec.Backup = getBackupSpec()


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/area high-availability
/kind enhancement
/kind api-change

**What this PR does / why we need it**:
This pull request introduces a new mode of operation in `etcd-druid` to support etcd clusters whose members are managed by an external actor, rather than by `etcd-druid` via the `StatefulSet` controller. This is primarily to enable use cases like Gardener's [self-hosted shoot clusters (GEP-28)](https://github.com/gardener/gardener/blob/master/docs/proposals/28-self-hosted-shoot-clusters.md), where a tool like `gardenadm` is responsible for deploying and managing etcd members as static pods on the control plane nodes.

To enable this, a new field, `spec.externallyManagedMemberAddresses`, is introduced in the `Etcd` API. When this field is populated with a list of member IP addresses, `etcd-druid`'s behavior changes as follows:

*   **Decoupled Pod Management**: `etcd-druid` no longer manages the lifecycle of etcd pods. It creates the `StatefulSet` with `replicas=0` to serve as a template but does not create any pods itself.
    * The template now sets the `POD_NAME` to be `<etcd-name>-<ip-address>` for the external tool to spin up `etcd` pods with the `etcd-backup-restore` sidecar using the template.
*   **IP-based Communication**: All etcd configuration is generated to use the provided IP addresses for peer communication. This removes the dependency on Kubernetes DNS and headless services.
    *   The `initial-cluster` and `advertised-<peer|client>-urls` configuration in the `ConfigMap` is populated using the IPs from `spec.externallyManagedMemberAddresses`.
    *   Member identities are based on their IP addresses (e.g., `etcd-main-192.168.0.1`) instead of StatefulSet ordinals.
*   **Disabled Component Creation**: The creation of several components that are tied to pod lifecycle management is disabled:
    *   Client and Peer `Service`s.
    *   `PodDisruptionBudget`.
*   **Continued Management Role**: While pod management is delegated, `etcd-druid` continues to provide value by:
    *   Generating and reconciling the etcd `ConfigMap`.
    *   Providing status reporting and facilitating maintenance operations for the externally managed cluster (enabling all functionality of `etcd-backup-restore` full/delta snapshots, compaction, de-fragmentation, etc.).

This approach provides a generic mechanism to integrate `etcd-druid` with diverse deployment strategies beyond the default `StatefulSet`-based model, making it more flexible.

This work supersedes the previous approach in PR #1117, opting for a more explicit API field (`spec.externallyManagedMemberAddresses`) over an annotation, along with design changes that overcome the limitations of the previous approach.

**Which issue(s) this PR fixes**:
Part of #1071
Supersedes #1117

**Special notes for your reviewer**:

This is just https://github.com/gardener/etcd-druid/pull/1214 reopened after rebasing on upstream master.

The core logic is triggered by the presence of the `spec.externallyManagedMemberAddresses` field. Please pay close attention to the validation rules for this new field, as they are crucial for preventing unsupported transitions:

*   The field must contain a list of valid IPv4 address strings.
*   If specified, its length must be equal to `spec.replicas`.
*   The field can be specified during the creation of a new `Etcd` resource.
*   **Mode Conversion is Not Supported**:
    *   The field **cannot** be added to an existing, running cluster or a hibernating cluster that is currently managed by `etcd-druid`
    *   The field **cannot** be removed from a running, externally managed cluster to convert it back to a `etcd-druid`-managed one.
    *   Externally managed clusters cannot be hibernated, i.e it cannot be scaled-in to zero replicas.

When `externallyManagedMemberAddresses` is set, `etcd-druid` effectively transitions from a pod lifecycle manager to a configuration and maintenance provider for an externally managed cluster.

**Release note**:
```feature operator
A new field `spec.externallyManagedMemberAddresses` has been added to the `Etcd` API. When this field is specified with a list of IP addresses, `etcd-druid` enters a new operational mode where it does not manage the etcd member pods directly. In this mode, `etcd-druid` will not create pods, services, or `PodDisruptionBudget`s. Instead, it will generate the etcd `ConfigMap` with a configuration tailored for the provided member IP addresses, enabling peer communication without relying on Kubernetes services.

This feature allows external actors, such as `gardenadm`, to manage the lifecycle of etcd members (e.g., as static pods) while still leveraging `etcd-druid` for configuration generation, status reporting, and other management tasks.
```