### PR TITLE
Add e2e tests for externally managed members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ go.work.sum
 test/e2e/pki-resources/*
 test/e2e/controller/pki-resources/*
 test/e2e/controller/etcdopstask/pki-resources/*
+test/e2e/controller/ext-members-resources/*
 
 # AI coding agents
 # Claude Code

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,12 @@ ci-e2e-kind: $(GINKGO) $(YQ) $(KIND)
 clean-e2e-test-resources: $(KUBECTL)
 	@rm -rf $(REPO_ROOT)/test/e2e/controller/pki-resources/*
 	@rm -rf $(REPO_ROOT)/test/e2e/controller/etcdopstask/pki-resources/*
+	@rm -rf $(REPO_ROOT)/test/e2e/controller/ext-members-resources/*
+	@KIND_CLUSTER_NAME=$${KIND_CLUSTER_NAME:-etcd-druid-e2e}; \
+	for node in $$(docker ps --filter "name=$${KIND_CLUSTER_NAME}-worker" --format '{{.Names}}' 2>/dev/null); do \
+		docker exec $$node bash -c 'rm -f /etc/kubernetes/manifests/etcd-e2e-*.yaml' 2>/dev/null || true; \
+		docker exec $$node bash -c 'rm -rf /var/lib/etcd-e2e-*' 2>/dev/null || true; \
+	done
 	@kubectl get ns -o custom-columns=":metadata.name" --no-headers | grep -E '^(etcd-e2e|eot-e2e)-' |  xargs --no-run-if-empty kubectl delete ns
 # Rules related to binary build, Docker image build and release
 # -------------------------------------------------------------------------

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -97,6 +97,30 @@ nodes:
   - containerPort: 4443
     hostPort: 4443
     protocol: TCP
+- role: worker
+  image: kindest/node:v1.32.0
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        register-with-taints: "node.gardener.cloud/etcd-machine=true:NoSchedule"
+- role: worker
+  image: kindest/node:v1.32.0
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        register-with-taints: "node.gardener.cloud/etcd-machine=true:NoSchedule"
+- role: worker
+  image: kindest/node:v1.32.0
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        register-with-taints: "node.gardener.cloud/etcd-machine=true:NoSchedule"
 EOF
   if [ "${DEPLOY_REGISTRY}" = true ]; then
     printf -v reg '[plugins."io.containerd.grpc.v1.cri".registry]
@@ -177,6 +201,9 @@ function main() {
   fi
   generate_kind_config
   create_kind_cluster
+  # Remove control-plane taint so workloads (etcd-druid, localstack, etc.) can
+  # schedule on the control-plane node alongside the tainted worker nodes.
+  kubectl taint nodes "${CLUSTER_NAME}-control-plane" node-role.kubernetes.io/control-plane:NoSchedule- 2>/dev/null || true
   if [ "${DEPLOY_REGISTRY}" = true ]; then
     initialize_registry
     create_local_container_reg_configmap

--- a/test/e2e/controller/externally_managed_members_test.go
+++ b/test/e2e/controller/externally_managed_members_test.go
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	e2eutils "github.com/gardener/etcd-druid/test/e2e/utils"
+	testutils "github.com/gardener/etcd-druid/test/utils"
+
+	"github.com/go-logr/logr/testr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestExternallyManagedMembersScaleOut(t *testing.T) {
+	t.Parallel()
+	log := testr.NewWithOptions(t, testr.Options{LogTimestamp: true})
+
+	testCases := []struct {
+		name       string
+		purpose    string
+		tlsEnabled bool
+	}{
+		{
+			name:    "no-tls",
+			purpose: "test sequential 1->2->3 scale-out with externally managed members",
+		},
+		{
+			name:       "tls",
+			purpose:    "test sequential 1->2->3 scale-out with TLS and externally managed members",
+			tlsEnabled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tcName := fmt.Sprintf("ext-members-scaleout-%s", tc.name)
+		t.Run(tcName, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			var testSucceeded bool
+
+			ctx := testEnv.Context()
+			cl := testEnv.Client()
+			testNamespace := testutils.GenerateTestNamespaceNameWithTestCaseName(t, testNamespacePrefix, tcName, 4)
+			logger := log.WithName(tcName).WithValues("etcdName", e2eutils.DefaultEtcdName, "namespace", testNamespace)
+			defer func() {
+				e2eutils.CleanupTestArtifacts(retainTestArtifacts, testSucceeded, testEnv, logger, g, testNamespace)
+			}()
+
+			// Set up 3 worker nodes and record their IPs
+			workerIPs := make([]string, 3)
+			for i := range 3 {
+				logger.Info("setting up worker node", "ordinal", i)
+				workerIPs[i] = setupWorker(g, ctx, cl, e2eutils.DefaultEtcdName, testNamespace, i)
+				logger.Info("worker node ready", "ordinal", i, "ip", workerIPs[i])
+			}
+			defer func() {
+				if e2eutils.ShouldCleanup(retainTestArtifacts, testSucceeded) {
+					logger.Info("cleaning up workers")
+					cleanupWorkers(e2eutils.DefaultEtcdName, testNamespace, 3)
+				} else {
+					logger.Info("retaining worker artifacts")
+				}
+			}()
+
+			var etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir string
+			if tc.tlsEnabled {
+				memberIPs := make([]net.IP, len(workerIPs))
+				for i, ip := range workerIPs {
+					memberIPs[i] = net.ParseIP(ip)
+					g.Expect(memberIPs[i]).ToNot(BeNil(), "failed to parse worker IP %s", ip)
+				}
+				logger.Info("initializing TLS PKI resources")
+				etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir = e2eutils.InitializeExternalMembersTestCaseWithTLS(g, testEnv, logger, testNamespace, e2eutils.DefaultEtcdName, memberIPs)
+			} else {
+				e2eutils.InitializeExternalMembersTestCase(g, testEnv, logger, testNamespace)
+			}
+
+			// --- Scale step 1: replicas=1, addresses=[ip0] ---
+			ports := allocatePorts(tcName)
+			logger.Info("step 1: creating Etcd CR with 1 replica", "ports", ports)
+			etcdBuilder := testutils.EtcdBuilderWithoutDefaults(e2eutils.DefaultEtcdName, testNamespace).
+				WithReplicas(1).
+				WithEtcdClientPort(ptr.To(ports.ClientPort)).
+				WithEtcdServerPort(ptr.To(ports.PeerPort)).
+				WithBackupPort(ptr.To(ports.BackupPort)).
+				WithEtcdWrapperPort(ptr.To(ports.WrapperPort)).
+				WithBackupRestoreContainerImage("europe-docker.pkg.dev/gardener-project/snapshots/gardener/etcdbrctl:v0.44.0-debd95bd77352280dada2a9a94efa9d1d20bbb78").
+				WithExternallyManagedMembers(workerIPs[:1])
+			if tc.tlsEnabled {
+				etcdBuilder = etcdBuilder.WithClientTLS().WithPeerTLS().WithBackupRestoreTLS()
+			}
+			etcd := etcdBuilder.Build()
+
+			etcd.SetAnnotations(map[string]string{druidv1alpha1.DruidOperationAnnotation: druidv1alpha1.DruidOperationReconcile})
+			g.Expect(cl.Create(ctx, etcd)).To(Succeed())
+
+			logger.Info("waiting for druid reconciliation")
+			testEnv.WaitForReconciliation(g, etcd, timeoutReconciliation)
+
+			logger.Info("preparing service account token")
+			saTokenFile, caCertFile := prepareServiceAccount(g, ctx, cl, e2eutils.DefaultEtcdName, testNamespace)
+
+			// Deploy static pod on worker-0
+			logger.Info("deploying static pod on worker-0")
+			if tc.tlsEnabled {
+				copyTLSToWorker(g, e2eutils.DefaultEtcdName, testNamespace, 0, etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir)
+			}
+			deployStaticPod(g, ctx, cl, e2eutils.DefaultEtcdName, testNamespace, 0, saTokenFile, caCertFile)
+
+			logger.Info("waiting for 1 member to be ready")
+			testEnv.CheckEtcdReady(g, etcd, timeoutExtMembersReady)
+			logger.Info("step 1: 1 member ready")
+
+			testEnv.VerifyMemberLeases(g, etcd, workerIPs[:1], timeoutMemberLeases)
+			testEnv.VerifyStatefulSetZeroReplicas(g, etcd)
+			testEnv.VerifyNoServicesOrPDB(g, etcd)
+
+			// --- Scale step 2: replicas=2, addresses=[ip0, ip1] ---
+			logger.Info("step 2: scaling to 2 replicas")
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+			etcd.Spec.Replicas = 2
+			etcd.Spec.ExternallyManagedMemberAddresses = workerIPs[:2]
+			etcd.SetAnnotations(map[string]string{druidv1alpha1.DruidOperationAnnotation: druidv1alpha1.DruidOperationReconcile})
+			g.Expect(cl.Update(ctx, etcd)).To(Succeed())
+
+			logger.Info("waiting for druid reconciliation after scale to 2")
+			testEnv.WaitForReconciliation(g, etcd, timeoutReconciliation)
+
+			logger.Info("updating config on worker-0")
+			updateWorkerConfig(g, ctx, cl, e2eutils.DefaultEtcdName, testNamespace, 0)
+
+			// Deploy static pod on worker-1
+			logger.Info("deploying static pod on worker-1")
+			if tc.tlsEnabled {
+				copyTLSToWorker(g, e2eutils.DefaultEtcdName, testNamespace, 1, etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir)
+			}
+			deployStaticPod(g, ctx, cl, e2eutils.DefaultEtcdName, testNamespace, 1, saTokenFile, caCertFile)
+
+			logger.Info("waiting for 2 members to be ready")
+			testEnv.CheckEtcdReady(g, etcd, timeoutExtMembersReady)
+			logger.Info("step 2: 2 members ready")
+
+			testEnv.VerifyMemberLeases(g, etcd, workerIPs[:2], timeoutMemberLeases)
+			testEnv.VerifyStatefulSetZeroReplicas(g, etcd)
+
+			// --- Scale step 3: replicas=3, addresses=[ip0, ip1, ip2] ---
+			logger.Info("step 3: scaling to 3 replicas")
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+			etcd.Spec.Replicas = 3
+			etcd.Spec.ExternallyManagedMemberAddresses = workerIPs[:3]
+			etcd.SetAnnotations(map[string]string{druidv1alpha1.DruidOperationAnnotation: druidv1alpha1.DruidOperationReconcile})
+			g.Expect(cl.Update(ctx, etcd)).To(Succeed())
+
+			logger.Info("waiting for druid reconciliation after scale to 3")
+			testEnv.WaitForReconciliation(g, etcd, timeoutReconciliation)
+
+			logger.Info("updating config on worker-0 and worker-1")
+			updateWorkerConfig(g, ctx, cl, e2eutils.DefaultEtcdName, testNamespace, 0)
+			updateWorkerConfig(g, ctx, cl, e2eutils.DefaultEtcdName, testNamespace, 1)
+
+			// Deploy static pod on worker-2
+			logger.Info("deploying static pod on worker-2")
+			if tc.tlsEnabled {
+				copyTLSToWorker(g, e2eutils.DefaultEtcdName, testNamespace, 2, etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir)
+			}
+			deployStaticPod(g, ctx, cl, e2eutils.DefaultEtcdName, testNamespace, 2, saTokenFile, caCertFile)
+
+			logger.Info("waiting for 3 members to be ready")
+			testEnv.CheckEtcdReady(g, etcd, timeoutExtMembersReady)
+			logger.Info("step 3: all 3 members ready")
+
+			testEnv.VerifyMemberLeases(g, etcd, workerIPs[:3], timeoutMemberLeases)
+			testEnv.VerifyStatefulSetZeroReplicas(g, etcd)
+			testEnv.VerifyNoServicesOrPDB(g, etcd)
+
+			// Verify final Etcd status
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(etcd), etcd)).To(Succeed())
+			g.Expect(etcd.Status.Ready).ToNot(BeNil())
+			g.Expect(*etcd.Status.Ready).To(BeTrue())
+
+			logger.Info("test passed", "purpose", tc.purpose)
+			testSucceeded = true
+		})
+	}
+}

--- a/test/e2e/controller/secret_test.go
+++ b/test/e2e/controller/secret_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 var (
-	timeout         = time.Minute * 2
-	pollingInterval = time.Second * 2
+	timeout = time.Minute * 2
 )
 
 // TestSecretFinalizers tests addition and removal of finalizer on referred secrets in Etcd resources.

--- a/test/e2e/controller/utils.go
+++ b/test/e2e/controller/utils.go
@@ -5,7 +5,12 @@
 package controller
 
 import (
+	"context"
 	"fmt"
+	"hash/fnv"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"time"
 
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
@@ -14,9 +19,16 @@ import (
 	e2eutils "github.com/gardener/etcd-druid/test/e2e/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
+
+	. "github.com/onsi/gomega"
 )
 
 const (
@@ -32,6 +44,11 @@ const (
 	timeoutEtcdDisruptionStart = 30 * time.Second
 	timeoutEtcdRecovery        = 5 * time.Minute
 	timeoutDeployJob           = 2 * time.Minute
+	timeoutReconciliation      = 3 * time.Minute
+	timeoutMemberLeases        = 5 * time.Minute
+	timeoutExtMembersReady     = 10 * time.Minute
+
+	pollingInterval = 2 * time.Second
 )
 
 var (
@@ -81,4 +98,305 @@ func updateEtcdTLSAndLabels(etcd *druidv1alpha1.Etcd, clientTLSEnabled, peerTLSE
 	}
 
 	etcd.Spec.Labels = testutils.MergeMaps(etcd.Spec.Labels, additionalLabels)
+}
+
+// --- Externally managed members helpers ---
+
+// portSet holds the port numbers for an etcd cluster, allowing parallel tests
+// on the same hostNetwork worker nodes without port conflicts.
+type portSet struct {
+	ClientPort  int32
+	PeerPort    int32
+	BackupPort  int32
+	WrapperPort int32
+}
+
+// allocatePorts returns a unique portSet for a given test case name.
+// Ports are deterministically derived from the name so that re-runs are reproducible.
+func allocatePorts(testCaseName string) portSet {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(testCaseName))
+	base := int32(10000 + (h.Sum32()%4000)*10) // #nosec G115 -- result is bounded to [10000, 49990], fits int32
+	return portSet{
+		ClientPort:  base,
+		PeerPort:    base + 1,
+		BackupPort:  base + 2,
+		WrapperPort: base + 3,
+	}
+}
+
+// workerName returns the KIND node name for the given ordinal.
+// KIND naming: ordinal 0 → {cluster}-worker, ordinal N → {cluster}-worker{N+1}
+func workerName(ordinal int) string {
+	clusterName := os.Getenv(e2eutils.EnvKindClusterName)
+	if clusterName == "" {
+		clusterName = e2eutils.DefaultKindClusterName
+	}
+	if ordinal == 0 {
+		return clusterName + "-worker"
+	}
+	return fmt.Sprintf("%s-worker%d", clusterName, ordinal+1)
+}
+
+// workerBaseDir returns the base directory on the worker node for the given namespace and etcd name.
+func workerBaseDir(namespace, etcdName string) string {
+	return fmt.Sprintf("/var/lib/%s/%s", namespace, etcdName)
+}
+
+// manifestName returns a unique static pod manifest filename for the given namespace and etcd name.
+func manifestName(namespace, etcdName string) string {
+	return fmt.Sprintf("%s-%s", namespace, etcdName)
+}
+
+// setupWorker prepares a KIND worker node by creating required directories and returns its IP.
+func setupWorker(g *WithT, ctx context.Context, cl client.Client, etcdName, namespace string, ordinal int) string {
+	worker := workerName(ordinal)
+
+	node := &corev1.Node{}
+	g.Expect(cl.Get(ctx, types.NamespacedName{Name: worker}, node)).To(Succeed())
+
+	var workerIP string
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			workerIP = addr.Address
+			break
+		}
+	}
+	g.Expect(workerIP).ToNot(BeEmpty(), "could not determine InternalIP for worker %s", worker)
+
+	base := workerBaseDir(namespace, etcdName)
+	script := fmt.Sprintf(`set -e
+mkdir -p %[1]s/etcd-config-file %[1]s/data %[1]s/serviceaccount \
+  %[1]s/etcd-ca %[1]s/etcd-server-tls %[1]s/etcd-client-tls \
+  %[1]s/etcd-peer-ca %[1]s/etcd-peer-server-tls \
+  %[1]s/backup-restore-ca %[1]s/backup-restore-server-tls %[1]s/backup-restore-client-tls`, base)
+	g.Expect(dockerExec(worker, script)).To(Succeed())
+	chownNonroot(g, worker, base)
+
+	return workerIP
+}
+
+// cleanupWorkers removes static pod manifests and data directories from all workers.
+func cleanupWorkers(etcdName, namespace string, numWorkers int) {
+	manifest := manifestName(namespace, etcdName)
+	base := workerBaseDir(namespace, etcdName)
+	for i := range numWorkers {
+		worker := workerName(i)
+		_ = dockerExec(worker, fmt.Sprintf("rm -rf /etc/kubernetes/manifests/%s.yaml %s", manifest, base))
+	}
+}
+
+// prepareServiceAccount creates a SA token secret, waits for the token controller
+// to populate it, and writes the token and CA cert to local files.
+func prepareServiceAccount(g *WithT, ctx context.Context, cl client.Client, etcdName, namespace string) (tokenFile, caCertFile string) {
+	secretName := etcdName + "-sa-token"
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"kubernetes.io/service-account.name": etcdName,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+	g.Expect(cl.Create(ctx, secret)).To(Succeed())
+
+	var token, caCert []byte
+	g.Eventually(func() error {
+		if err := cl.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+			return err
+		}
+		token = secret.Data["token"]
+		caCert = secret.Data["ca.crt"]
+		if len(token) == 0 || len(caCert) == 0 {
+			return fmt.Errorf("token or ca.crt not yet populated")
+		}
+		return nil
+	}, 60*time.Second, 2*time.Second).Should(Succeed())
+
+	saDir := filepath.Join(e2eutils.ExtMembersResourcesDir, namespace, "serviceaccount")
+	g.Expect(os.MkdirAll(saDir, 0755)).To(Succeed()) // #nosec G301 -- test directory
+
+	tokenFile = filepath.Join(saDir, "token")
+	caCertFile = filepath.Join(saDir, "ca.crt")
+	g.Expect(os.WriteFile(tokenFile, token, 0600)).To(Succeed())   // #nosec G306 -- test file
+	g.Expect(os.WriteFile(caCertFile, caCert, 0600)).To(Succeed()) // #nosec G306 -- test file
+
+	return tokenFile, caCertFile
+}
+
+// writeConfigToWorker reads the ConfigMap for the etcd and writes all config
+// files to the worker node in a single docker exec call.
+func writeConfigToWorker(g *WithT, ctx context.Context, cl client.Client, etcdName, namespace string, ordinal int) {
+	worker := workerName(ordinal)
+	base := workerBaseDir(namespace, etcdName)
+
+	cm := &corev1.ConfigMap{}
+	g.Expect(cl.Get(ctx, types.NamespacedName{Name: etcdName + "-config", Namespace: namespace}, cm)).To(Succeed())
+
+	script := "set -e\n"
+	for key, data := range cm.Data {
+		script += fmt.Sprintf("cat > '%s/etcd-config-file/%s' << 'CONFIG_EOF'\n%s\nCONFIG_EOF\n", base, key, data)
+	}
+	g.Expect(dockerExec(worker, script)).To(Succeed())
+}
+
+// deployStaticPod deploys an etcd static pod to a worker node.
+func deployStaticPod(g *WithT, ctx context.Context, cl client.Client, etcdName, namespace string, ordinal int, saTokenFile, caCertFile string) {
+	worker := workerName(ordinal)
+	base := workerBaseDir(namespace, etcdName)
+
+	writeConfigToWorker(g, ctx, cl, etcdName, namespace, ordinal)
+
+	saDir := base + "/serviceaccount"
+	g.Expect(dockerCp(saTokenFile, worker, saDir+"/token")).To(Succeed())
+	g.Expect(dockerCp(caCertFile, worker, saDir+"/ca.crt")).To(Succeed())
+	chownNonroot(g, worker, saDir)
+
+	podYAML, err := translateStatefulSetToPod(ctx, cl, etcdName, namespace)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	writeManifest(g, worker, namespace, etcdName, podYAML)
+}
+
+// updateWorkerConfig updates config files on a worker without restarting the pod.
+func updateWorkerConfig(g *WithT, ctx context.Context, cl client.Client, etcdName, namespace string, ordinal int) {
+	writeConfigToWorker(g, ctx, cl, etcdName, namespace, ordinal)
+}
+
+// translateStatefulSetToPod fetches the StatefulSet created by druid and converts
+// its pod template into a static Pod manifest suitable for KIND worker nodes.
+func translateStatefulSetToPod(ctx context.Context, cl client.Client, etcdName, namespace string) ([]byte, error) {
+	sts := &appsv1.StatefulSet{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: etcdName, Namespace: namespace}, sts); err != nil {
+		return nil, fmt.Errorf("failed to get StatefulSet %s/%s: %w", namespace, etcdName, err)
+	}
+
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      etcdName,
+			Namespace: namespace,
+			Labels:    sts.Spec.Template.Labels,
+		},
+		Spec: *sts.Spec.Template.Spec.DeepCopy(),
+	}
+
+	pod.Spec.HostNetwork = true
+	pod.Spec.EnableServiceLinks = ptr.To(false)
+	pod.Spec.ServiceAccountName = ""
+	pod.Spec.DeprecatedServiceAccount = ""
+	pod.Spec.AutomountServiceAccountToken = ptr.To(false)
+
+	base := workerBaseDir(namespace, etcdName)
+
+	dirType := corev1.HostPathDirectoryOrCreate
+	var volumes []corev1.Volume
+	for _, v := range pod.Spec.Volumes {
+		if v.ConfigMap != nil || v.Name == etcdName {
+			continue
+		}
+		if v.Secret != nil {
+			volumes = append(volumes, corev1.Volume{
+				Name: v.Name,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{Path: fmt.Sprintf("%s/%s", base, v.Name), Type: &dirType},
+				},
+			})
+			continue
+		}
+		volumes = append(volumes, v)
+	}
+	volumes = append(volumes,
+		corev1.Volume{
+			Name: "etcd-config-file",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{Path: base + "/etcd-config-file", Type: &dirType},
+			},
+		},
+		corev1.Volume{
+			Name: etcdName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{Path: base + "/data", Type: &dirType},
+			},
+		},
+		corev1.Volume{
+			Name: "serviceaccount",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{Path: base + "/serviceaccount", Type: &dirType},
+			},
+		},
+	)
+	pod.Spec.Volumes = volumes
+
+	if len(pod.Spec.Containers) > 1 {
+		pod.Spec.Containers[1].VolumeMounts = append(pod.Spec.Containers[1].VolumeMounts, corev1.VolumeMount{
+			Name:      "serviceaccount",
+			MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+			ReadOnly:  true,
+		})
+	}
+
+	return yaml.Marshal(pod)
+}
+
+// writeManifest writes a static pod YAML to /etc/kubernetes/manifests/ on the worker.
+func writeManifest(g *WithT, worker, namespace, etcdName string, podYAML []byte) {
+	manifest := manifestName(namespace, etcdName)
+	localPath := filepath.Join(e2eutils.ExtMembersResourcesDir, namespace, manifest+".yaml")
+	g.Expect(os.WriteFile(localPath, podYAML, 0600)).To(Succeed()) // #nosec G306 -- test file
+	g.Expect(dockerCp(localPath, worker, fmt.Sprintf("/etc/kubernetes/manifests/%s.yaml", manifest))).To(Succeed())
+}
+
+// chownNonroot sets ownership of a directory on a worker node to UID/GID 65532,
+// the nonroot user that etcd and backup-restore containers run as.
+func chownNonroot(g *WithT, worker, path string) {
+	g.Expect(dockerExec(worker, fmt.Sprintf("chown -R 65532:65532 %s", path))).To(Succeed())
+}
+
+// dockerExec runs a bash script on a KIND worker node via docker exec.
+func dockerExec(worker, script string) error {
+	cmd := exec.Command("docker", "exec", worker, "bash", "-c", script) // #nosec G204 -- e2e test utility
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// dockerCp copies a local file to a path inside a KIND worker node.
+func dockerCp(localPath, worker, remotePath string) error {
+	cmd := exec.Command("docker", "cp", localPath, fmt.Sprintf("%s:%s", worker, remotePath)) // #nosec G204 -- e2e test utility
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// copyTLSToWorker copies TLS cert files from local directories to the worker node
+// and fixes ownership so the non-root etcd/backup-restore processes can read them.
+func copyTLSToWorker(g *WithT, etcdName, namespace string, ordinal int, etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir string) {
+	worker := workerName(ordinal)
+	base := workerBaseDir(namespace, etcdName)
+
+	type copyEntry struct {
+		localDir  string
+		remoteDir string
+		files     [][2]string // [localName, remoteName]
+	}
+	entries := []copyEntry{
+		{etcdCertsDir, base + "/etcd-ca", [][2]string{{"ca.crt", "ca.crt"}, {"ca.key", "ca.key"}}},
+		{etcdCertsDir, base + "/etcd-server-tls", [][2]string{{"server.crt", "tls.crt"}, {"server.key", "tls.key"}}},
+		{etcdCertsDir, base + "/etcd-client-tls", [][2]string{{"client.crt", "tls.crt"}, {"client.key", "tls.key"}}},
+		{etcdPeerCertsDir, base + "/etcd-peer-ca", [][2]string{{"ca.crt", "ca.crt"}, {"ca.key", "ca.key"}}},
+		{etcdPeerCertsDir, base + "/etcd-peer-server-tls", [][2]string{{"server.crt", "tls.crt"}, {"server.key", "tls.key"}}},
+		{etcdbrCertsDir, base + "/backup-restore-ca", [][2]string{{"ca.crt", "ca.crt"}, {"ca.key", "ca.key"}}},
+		{etcdbrCertsDir, base + "/backup-restore-server-tls", [][2]string{{"server.crt", "tls.crt"}, {"server.key", "tls.key"}}},
+		{etcdbrCertsDir, base + "/backup-restore-client-tls", [][2]string{{"client.crt", "tls.crt"}, {"client.key", "tls.key"}}},
+	}
+
+	for _, e := range entries {
+		for _, f := range e.files {
+			g.Expect(dockerCp(filepath.Join(e.localDir, f[0]), worker, e.remoteDir+"/"+f[1])).To(Succeed())
+		}
+	}
+
+	chownNonroot(g, worker, base)
 }

--- a/test/e2e/testenv/testenv.go
+++ b/test/e2e/testenv/testenv.go
@@ -29,9 +29,11 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -160,8 +162,25 @@ func (t *TestEnvironment) UpdateAndCheckEtcd(g *WithT, etcd *druidv1alpha1.Etcd,
 	t.CheckEtcdReady(g, etcd, timeout)
 }
 
+// WaitForReconciliation waits until the etcd object's observed generation matches its generation.
+func (t *TestEnvironment) WaitForReconciliation(g *WithT, etcd *druidv1alpha1.Etcd, timeout time.Duration) {
+	g.Eventually(func() error {
+		if err := t.cl.Get(t.ctx, client.ObjectKeyFromObject(etcd), etcd); err != nil {
+			return err
+		}
+		if etcd.Status.ObservedGeneration == nil {
+			return fmt.Errorf("etcd %s status observed generation is nil", etcd.Name)
+		}
+		if *etcd.Status.ObservedGeneration != etcd.Generation {
+			return fmt.Errorf("etcd '%s' is not at the expected generation (observed: %d, expected: %d)", etcd.Name, *etcd.Status.ObservedGeneration, etcd.Generation)
+		}
+		return nil
+	}, timeout, defaultPollingInterval).Should(Succeed())
+}
+
 // CheckEtcdReady checks if the Etcd object is ready.
 func (t *TestEnvironment) CheckEtcdReady(g *WithT, etcd *druidv1alpha1.Etcd, timeout time.Duration) {
+	t.WaitForReconciliation(g, etcd, timeout)
 	g.Eventually(func() error {
 		ctx, cancelFunc := context.WithTimeout(t.ctx, timeout)
 		defer cancelFunc()
@@ -170,34 +189,28 @@ func (t *TestEnvironment) CheckEtcdReady(g *WithT, etcd *druidv1alpha1.Etcd, tim
 			return err
 		}
 
-		// Ensure the etcd cluster's current generation matches the observed generation
-		if etcd.Status.ObservedGeneration == nil {
-			return fmt.Errorf("etcd %s status observed generation is nil", etcd.Name)
-		}
-		if *etcd.Status.ObservedGeneration != etcd.Generation {
-			return fmt.Errorf("etcd '%s' is not at the expected generation (observed: %d, expected: %d)", etcd.Name, *etcd.Status.ObservedGeneration, etcd.Generation)
-		}
-
-		etcdPods, err := t.getEtcdPods(etcd)
-		if err != nil {
-			return fmt.Errorf("failed to get etcd pods: %w", err)
-		}
-		if len(etcdPods) != int(etcd.Spec.Replicas) {
-			return fmt.Errorf("etcd %s has %d pods, expected %d", etcd.Name, len(etcdPods), etcd.Spec.Replicas)
-		}
-
-		// if replicas is 0, the subsequent checks do not apply
-		if etcd.Spec.Replicas == 0 {
-			return nil
-		}
-
-		for _, pod := range etcdPods {
-			if pod.Status.Phase != corev1.PodRunning {
-				return fmt.Errorf("etcd %s pod %s is not running", etcd.Name, pod.Name)
+		if druidv1alpha1.ArePodsManagedByEtcdDruid(etcd) {
+			etcdPods, err := t.getEtcdPods(etcd)
+			if err != nil {
+				return fmt.Errorf("failed to get etcd pods: %w", err)
 			}
-			for _, containerStatus := range pod.Status.ContainerStatuses {
-				if !containerStatus.Ready {
-					return fmt.Errorf("etcd %s pod %s container %s is not ready", etcd.Name, pod.Name, containerStatus.Name)
+			if len(etcdPods) != int(etcd.Spec.Replicas) {
+				return fmt.Errorf("etcd %s has %d pods, expected %d", etcd.Name, len(etcdPods), etcd.Spec.Replicas)
+			}
+
+			// if replicas is 0, the subsequent checks do not apply
+			if etcd.Spec.Replicas == 0 {
+				return nil
+			}
+
+			for _, pod := range etcdPods {
+				if pod.Status.Phase != corev1.PodRunning {
+					return fmt.Errorf("etcd %s pod %s is not running", etcd.Name, pod.Name)
+				}
+				for _, containerStatus := range pod.Status.ContainerStatuses {
+					if !containerStatus.Ready {
+						return fmt.Errorf("etcd %s pod %s container %s is not ready", etcd.Name, pod.Name, containerStatus.Name)
+					}
 				}
 			}
 		}
@@ -772,4 +785,52 @@ func (t *TestEnvironment) GetSnapshotRevisions(etcdObjectMeta metav1.ObjectMeta)
 	}
 
 	return fullSnapshotRevision, deltaSnapshotRevision, nil
+}
+
+// VerifyMemberLeases checks that member leases exist and are being renewed.
+func (t *TestEnvironment) VerifyMemberLeases(g *WithT, etcd *druidv1alpha1.Etcd, expectedAddresses []string, timeout time.Duration) {
+	g.Eventually(func() error {
+		for _, addr := range expectedAddresses {
+			leaseName := druidv1alpha1.GetMemberNameFromAddress(etcd, addr)
+			lease := &coordinationv1.Lease{}
+			if err := t.cl.Get(t.ctx, types.NamespacedName{Name: leaseName, Namespace: etcd.Namespace}, lease); err != nil {
+				return fmt.Errorf("member lease %s not found: %w", leaseName, err)
+			}
+
+			if lease.Spec.RenewTime == nil {
+				return fmt.Errorf("member lease %s has nil RenewTime", leaseName)
+			}
+
+			if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+				return fmt.Errorf("member lease %s has empty HolderIdentity", leaseName)
+			}
+		}
+		return nil
+	}, timeout, defaultPollingInterval).Should(Succeed())
+}
+
+// VerifyStatefulSetZeroReplicas confirms the StatefulSet exists with 0 replicas.
+func (t *TestEnvironment) VerifyStatefulSetZeroReplicas(g *WithT, etcd *druidv1alpha1.Etcd) {
+	stsName := druidv1alpha1.GetStatefulSetName(etcd.ObjectMeta)
+	sts := &appsv1.StatefulSet{}
+	g.Expect(t.cl.Get(t.ctx, types.NamespacedName{Name: stsName, Namespace: etcd.Namespace}, sts)).To(Succeed())
+	g.Expect(sts.Spec.Replicas).ToNot(BeNil())
+	g.Expect(*sts.Spec.Replicas).To(Equal(int32(0)))
+	g.Expect(sts.Status.Replicas).To(Equal(int32(0)))
+}
+
+// VerifyNoServicesOrPDB confirms that ClientService, PeerService, and PodDisruptionBudget
+// do not exist for an Etcd cluster with externally managed members.
+func (t *TestEnvironment) VerifyNoServicesOrPDB(g *WithT, etcd *druidv1alpha1.Etcd) {
+	clientSvc := &corev1.Service{}
+	err := t.cl.Get(t.ctx, types.NamespacedName{Name: druidv1alpha1.GetClientServiceName(etcd.ObjectMeta), Namespace: etcd.Namespace}, clientSvc)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "client service should not exist for externally managed members")
+
+	peerSvc := &corev1.Service{}
+	err = t.cl.Get(t.ctx, types.NamespacedName{Name: druidv1alpha1.GetPeerServiceName(etcd.ObjectMeta), Namespace: etcd.Namespace}, peerSvc)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "peer service should not exist for externally managed members")
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err = t.cl.Get(t.ctx, types.NamespacedName{Name: druidv1alpha1.GetPodDisruptionBudgetName(etcd.ObjectMeta), Namespace: etcd.Namespace}, pdb)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "PDB should not exist for externally managed members")
 }

--- a/test/e2e/utils/setup.go
+++ b/test/e2e/utils/setup.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
@@ -22,6 +23,7 @@ import (
 
 const (
 	PKIResourcesDir              = "pki-resources"
+	ExtMembersResourcesDir       = "ext-members-resources"
 	DefaultBackupStoreSecretName = "etcd-backup"
 	DefaultEtcdName              = "test"
 
@@ -29,6 +31,9 @@ const (
 	EnvKubeconfigPath      = "KUBECONFIG"
 	EnvRetainTestArtifacts = "RETAIN_TEST_ARTIFACTS"
 	EnvBackupProviders     = "PROVIDERS"
+	EnvKindClusterName     = "KIND_CLUSTER_NAME"
+
+	DefaultKindClusterName = "etcd-druid-e2e"
 )
 
 // RetainTestArtifactsMode controls whether test artifacts are retained after test execution.
@@ -121,4 +126,51 @@ func CleanupTestArtifacts(retainTestArtifacts RetainTestArtifactsMode, testSucce
 	logger.Info(fmt.Sprintf("deleting namespace %s", ns))
 	g.Expect(testEnv.DeleteTestNamespace(ns)).To(Succeed())
 	logger.Info("successfully deleted namespace")
+}
+
+// ShouldCleanup returns true if test artifacts should be cleaned up based on the retain mode and test result.
+func ShouldCleanup(retainTestArtifacts RetainTestArtifactsMode, testSucceeded bool) bool {
+	switch retainTestArtifacts {
+	case RetainTestArtifactsAll:
+		return false
+	case RetainTestArtifactsFailed:
+		return testSucceeded
+	default:
+		return true
+	}
+}
+
+// InitializeExternalMembersTestCase sets up the test namespace for externally managed members tests.
+func InitializeExternalMembersTestCase(g *WithT, testEnv *testenv.TestEnvironment, logger logr.Logger, testNamespace string) {
+	CreateNamespace(g, testEnv, logger, testNamespace)
+}
+
+// InitializeExternalMembersTestCaseWithTLS sets up the test namespace and generates PKI resources
+// with IP SANs for the given member IPs, then creates the corresponding TLS secrets.
+func InitializeExternalMembersTestCaseWithTLS(g *WithT, testEnv *testenv.TestEnvironment, logger logr.Logger, testNamespace, etcdName string, memberIPs []net.IP) (etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir string) {
+	CreateNamespace(g, testEnv, logger, testNamespace)
+	etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir = GeneratePKIResourcesWithIPSANs(g, logger, testNamespace, etcdName, memberIPs)
+	CreateTLSSecrets(g, testEnv, logger, testNamespace, etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir)
+	return etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir
+}
+
+// GeneratePKIResourcesWithIPSANs generates PKI resources with IP SANs for externally managed member certs.
+func GeneratePKIResourcesWithIPSANs(g *WithT, logger logr.Logger, testNamespace, etcdName string, memberIPs []net.IP) (string, string, string) {
+	logger.Info("generating PKI resources with IP SANs", "memberIPs", memberIPs)
+	certDir := fmt.Sprintf("%s/%s", ExtMembersResourcesDir, testNamespace)
+
+	etcdCertsDir := fmt.Sprintf("%s/etcd", certDir)
+	g.Expect(os.MkdirAll(etcdCertsDir, 0755)).To(Succeed()) // #nosec G301 -- local directory creation for test purposes.
+	g.Expect(testutils.GeneratePKIResourcesWithIPSANs(logger, etcdCertsDir, etcdName, testNamespace, memberIPs)).To(Succeed())
+
+	etcdPeerCertsDir := fmt.Sprintf("%s/etcd-peer", certDir)
+	g.Expect(os.MkdirAll(etcdPeerCertsDir, 0755)).To(Succeed()) // #nosec G301 -- local directory creation for test purposes.
+	g.Expect(testutils.GeneratePKIResourcesWithIPSANs(logger, etcdPeerCertsDir, etcdName, testNamespace, memberIPs)).To(Succeed())
+
+	etcdbrCertsDir := fmt.Sprintf("%s/etcd-backup-restore", certDir)
+	g.Expect(os.MkdirAll(etcdbrCertsDir, 0755)).To(Succeed()) // #nosec G301 -- local directory creation for test purposes.
+	g.Expect(testutils.GeneratePKIResourcesWithIPSANs(logger, etcdbrCertsDir, etcdName, testNamespace, memberIPs)).To(Succeed())
+
+	logger.Info("successfully generated PKI resources with IP SANs")
+	return etcdCertsDir, etcdPeerCertsDir, etcdbrCertsDir
 }

--- a/test/utils/pki.go
+++ b/test/utils/pki.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -203,7 +204,7 @@ const (
 
 // generateTLSKeyCertToDirectory generates TLS key and certificate for either server or client, specified by certType parameter
 // using the given CA directory, and writes them to the specified output directory.
-func generateTLSKeyCertToDirectory(logger logr.Logger, certType certificateType, caDir, outputDir, name, namespace string) (err error) {
+func generateTLSKeyCertToDirectory(logger logr.Logger, certType certificateType, caDir, outputDir, name, namespace string, ipAddresses []net.IP) (err error) {
 	logger.Info("generating TLS key", "type", certType, "name", name, "caDir", caDir, "outputDir", outputDir)
 
 	key, err := rsa.GenerateKey(rand.Reader, 4096)
@@ -253,6 +254,7 @@ func generateTLSKeyCertToDirectory(logger logr.Logger, certType certificateType,
 		certTemplate.SerialNumber = big.NewInt(2)
 		certTemplate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
 		certTemplate.DNSNames = getDNSNames(name, namespace)
+		certTemplate.IPAddresses = ipAddresses
 	case certTypeClient:
 		certTemplate.SerialNumber = big.NewInt(3)
 		certTemplate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
@@ -308,11 +310,29 @@ func GeneratePKIResourcesToDirectory(logger logr.Logger, tlsDir, name, namespace
 		return err
 	}
 
-	if err := generateTLSKeyCertToDirectory(logger, certTypeServer, tlsDir, tlsDir, name, namespace); err != nil {
+	if err := generateTLSKeyCertToDirectory(logger, certTypeServer, tlsDir, tlsDir, name, namespace, nil); err != nil {
 		return err
 	}
 
-	if err := generateTLSKeyCertToDirectory(logger, certTypeClient, tlsDir, tlsDir, name, namespace); err != nil {
+	if err := generateTLSKeyCertToDirectory(logger, certTypeClient, tlsDir, tlsDir, name, namespace, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GeneratePKIResourcesWithIPSANs generates CA, server, and client TLS key and certificate files
+// like GeneratePKIResourcesToDirectory but includes the given IPs as SANs on server certificates.
+func GeneratePKIResourcesWithIPSANs(logger logr.Logger, tlsDir, name, namespace string, ipAddresses []net.IP) error {
+	if err := GenerateCAKeyCertToDirectory(logger, tlsDir, name); err != nil {
+		return err
+	}
+
+	if err := generateTLSKeyCertToDirectory(logger, certTypeServer, tlsDir, tlsDir, name, namespace, ipAddresses); err != nil {
+		return err
+	}
+
+	if err := generateTLSKeyCertToDirectory(logger, certTypeClient, tlsDir, tlsDir, name, namespace, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:

Adds e2e tests for the externally managed members feature introduced in https://github.com/gardener/etcd-druid/pull/1397.

**Checklist**:
- [x] Add tests that cover your changes (if applicable)
    - [x] E2E tests

**Special notes for your reviewer**:

If you have an existing kind cluster, it has to be brought down (`make kind-down`) and brought up again with this PR branch (`make kind-up`) for this to work.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```