### PR TITLE
Remove access to the StatefulSet object

### DIFF
--- a/internal/component/role/role.go
+++ b/internal/component/role/role.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	druidapicommon "github.com/gardener/etcd-druid/api/common"
+	druidconfigv1alpha1 "github.com/gardener/etcd-druid/api/config/v1alpha1"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/common"
 	"github.com/gardener/etcd-druid/internal/component"
@@ -131,6 +132,17 @@ func buildResource(etcd *druidv1alpha1.Etcd, role *rbacv1.Role) {
 			Resources: []string{"pods"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
+	}
+	// The etcd-backup-restore versions used before the UpgradeEtcdVersion feature gate was enabled still
+	// require access to the STS resource. Once the feature gate is enabled, the newer
+	// etcd-backup-restore image is used, so this permission can be dropped.
+	// See https://github.com/gardener/etcd-backup-restore/pull/1040 for details
+	if !druidconfigv1alpha1.DefaultFeatureGates.IsEnabled(druidconfigv1alpha1.UpgradeEtcdVersion) {
+		role.Rules = append(role.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{"apps"},
+			Resources: []string{"statefulsets"},
+			Verbs:     []string{"get", "list", "patch", "update", "watch"},
+		})
 	}
 }
 

--- a/internal/component/role/role.go
+++ b/internal/component/role/role.go
@@ -127,11 +127,6 @@ func buildResource(etcd *druidv1alpha1.Etcd, role *rbacv1.Role) {
 			Verbs:     []string{"get", "list", "patch", "update", "watch"},
 		},
 		{
-			APIGroups: []string{"apps"},
-			Resources: []string{"statefulsets"},
-			Verbs:     []string{"get", "list", "patch", "update", "watch"},
-		},
-		{
 			APIGroups: []string{""},
 			Resources: []string{"pods"},
 			Verbs:     []string{"get", "list", "watch"},

--- a/internal/component/role/role.go
+++ b/internal/component/role/role.go
@@ -133,9 +133,11 @@ func buildResource(etcd *druidv1alpha1.Etcd, role *rbacv1.Role) {
 			Verbs:     []string{"get", "list", "watch"},
 		},
 	}
-	// The etcd-backup-restore versions used before the UpgradeEtcdVersion feature gate was enabled still
-	// require access to the STS resource. Once the feature gate is enabled, the newer
-	// etcd-backup-restore image is used, so this permission can be dropped.
+
+	// TODO - The condition check will be removed once the feature gate is GAed.
+	// When the UpgradeEtcdVersion feature-gate is disabled, the older version of etcd-backup-restore
+	// version is used, which requires access to the StatefulSet resource. When enabled,
+	// the updated etcd-backup-restore version is used which no longer requires this StatefulSet access.
 	// See https://github.com/gardener/etcd-backup-restore/pull/1040 for details
 	if !druidconfigv1alpha1.DefaultFeatureGates.IsEnabled(druidconfigv1alpha1.UpgradeEtcdVersion) {
 		role.Rules = append(role.Rules, rbacv1.PolicyRule{

--- a/internal/component/role/role_test.go
+++ b/internal/component/role/role_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"testing"
 
+	druidconfigv1alpha1 "github.com/gardener/etcd-druid/api/config/v1alpha1"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/etcd-druid/internal/component"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
@@ -85,12 +86,17 @@ func TestGetExistingResourceNames(t *testing.T) {
 func TestSync(t *testing.T) {
 	etcd := testutils.EtcdBuilderWithDefaults(testutils.TestEtcdName, testutils.TestNamespace).Build()
 	testCases := []struct {
-		name        string
-		createErr   *apierrors.StatusError
-		expectedErr *druiderr.DruidError
+		name               string
+		featureGateEnabled bool
+		createErr          *apierrors.StatusError
+		expectedErr        *druiderr.DruidError
 	}{
 		{
-			name: "create role when none exists",
+			name: "create role with statefulset access when UpgradeEtcdVersion feature gate is disabled",
+		},
+		{
+			name:               "create role without statefulset access when UpgradeEtcdVersion feature gate is enabled",
+			featureGateEnabled: true,
 		},
 		{
 			name:      "create role fails when client create fails",
@@ -104,11 +110,19 @@ func TestSync(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	t.Parallel()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+			err := druidconfigv1alpha1.DefaultFeatureGates.SetEnabledFeaturesFromMap(
+				map[string]bool{druidconfigv1alpha1.UpgradeEtcdVersion: tc.featureGateEnabled},
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			t.Cleanup(func() {
+				_ = druidconfigv1alpha1.DefaultFeatureGates.SetEnabledFeaturesFromMap(
+					map[string]bool{druidconfigv1alpha1.UpgradeEtcdVersion: false},
+				)
+			})
+
 			cl := testutils.CreateTestFakeClientForObjects(nil, tc.createErr, nil, nil, nil, getObjectKey(etcd.ObjectMeta))
 			operator := New(cl)
 			opCtx := component.NewOperatorContext(context.Background(), logr.Discard(), uuid.NewString())
@@ -121,7 +135,7 @@ func TestSync(t *testing.T) {
 				g.Expect(syncErr).ToNot(HaveOccurred())
 				g.Expect(getErr).ToNot(HaveOccurred())
 				g.Expect(latestRole).ToNot(BeNil())
-				matchRole(g, etcd, *latestRole)
+				matchRole(g, etcd, *latestRole, tc.featureGateEnabled)
 			}
 		})
 	}
@@ -197,7 +211,28 @@ func getLatestRole(cl client.Client, etcd *druidv1alpha1.Etcd) (*rbacv1.Role, er
 	return role, err
 }
 
-func matchRole(g *WithT, etcd *druidv1alpha1.Etcd, actualRole rbacv1.Role) {
+func matchRole(g *WithT, etcd *druidv1alpha1.Etcd, actualRole rbacv1.Role, upgradeEtcdVersionEnabled bool) {
+	expectedRules := []interface{}{
+		rbacv1.PolicyRule{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+			Verbs:     []string{"get", "list", "patch", "update", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+	// When the UpgradeEtcdVersion feature gate is disabled, the older etcd-backup-restore image is used,
+	// which still requires access to the StatefulSet object.
+	if !upgradeEtcdVersionEnabled {
+		expectedRules = append(expectedRules, rbacv1.PolicyRule{
+			APIGroups: []string{"apps"},
+			Resources: []string{"statefulsets"},
+			Verbs:     []string{"get", "list", "patch", "update", "watch"},
+		})
+	}
 	g.Expect(actualRole).To(MatchFields(IgnoreExtras, Fields{
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{
 			"Name":            Equal(druidv1alpha1.GetRoleName(etcd.ObjectMeta)),
@@ -205,17 +240,6 @@ func matchRole(g *WithT, etcd *druidv1alpha1.Etcd, actualRole rbacv1.Role) {
 			"Labels":          testutils.MatchResourceLabels(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta)),
 			"OwnerReferences": testutils.MatchEtcdOwnerReference(etcd.Name, etcd.UID),
 		}),
-		"Rules": ConsistOf(
-			rbacv1.PolicyRule{
-				APIGroups: []string{"coordination.k8s.io"},
-				Resources: []string{"leases"},
-				Verbs:     []string{"get", "list", "patch", "update", "watch"},
-			},
-			rbacv1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-		),
+		"Rules": ConsistOf(expectedRules...),
 	}))
 }

--- a/internal/component/role/role_test.go
+++ b/internal/component/role/role_test.go
@@ -212,11 +212,6 @@ func matchRole(g *WithT, etcd *druidv1alpha1.Etcd, actualRole rbacv1.Role) {
 				Verbs:     []string{"get", "list", "patch", "update", "watch"},
 			},
 			rbacv1.PolicyRule{
-				APIGroups: []string{"apps"},
-				Resources: []string{"statefulsets"},
-				Verbs:     []string{"get", "list", "patch", "update", "watch"},
-			},
-			rbacv1.PolicyRule{
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
 				Verbs:     []string{"get", "list", "watch"},


### PR DESCRIPTION

**How to categorize this PR?**

/area security
/kind cleanup

**What this PR does / why we need it**:
Following the changes in [etcd-backup-restore#1040](https://github.com/gardener/etcd-backup-restore/pull/1040), the etcd-backup-restore container no longer requires access to StatefulSet objects. This PR removes the now-unwanted statefulsets policy rule from the Role created for the etcd pod's ServiceAccount, following the principle of least privilege.

**Which issue(s) this PR fixes**:
Fixes #1387

**Checklist**:

- [x] Add tests that cover your changes (if applicable)
    - [x] Unit tests

**Special notes for your reviewer**:

**Release note**:
```other operator
Removed StatefulSet access from the etcd pod's ServiceAccount Role as it is no longer needed by etcd-backup-restore.
```
