### PR TITLE
fix PDB selector not being specific enough

### DIFF
--- a/internal/component/poddistruptionbudget/poddisruptionbudget.go
+++ b/internal/component/poddistruptionbudget/poddisruptionbudget.go
@@ -114,7 +114,9 @@ func buildResource(etcd *druidv1alpha1.Etcd, pdb *policyv1.PodDisruptionBudget) 
 		Type:   intstr.Int,
 	}
 	pdb.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta),
+		MatchLabels: utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{
+			druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet,
+		}),
 	}
 	if metav1.HasAnnotation(etcd.ObjectMeta, annotationAllowUnhealthyPodEviction) {
 		pdb.Spec.UnhealthyPodEvictionPolicy = ptr.To(policyv1.AlwaysAllow)

--- a/internal/component/poddistruptionbudget/poddisruptionbudget_test.go
+++ b/internal/component/poddistruptionbudget/poddisruptionbudget_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	"github.com/gardener/etcd-druid/internal/common"
 	"github.com/gardener/etcd-druid/internal/component"
 	druiderr "github.com/gardener/etcd-druid/internal/errors"
+	"github.com/gardener/etcd-druid/internal/utils"
 	testutils "github.com/gardener/etcd-druid/test/utils"
 
 	"github.com/go-logr/logr"
@@ -267,7 +269,9 @@ func matchPodDisruptionBudget(g *WithT, etcd *druidv1alpha1.Etcd, actualPDB poli
 			"OwnerReferences": testutils.MatchEtcdOwnerReference(etcd.Name, etcd.UID),
 		}),
 		"Spec": MatchFields(IgnoreExtras, Fields{
-			"Selector": testutils.MatchSpecLabelSelector(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta)),
+			"Selector": testutils.MatchSpecLabelSelector(utils.MergeMaps(druidv1alpha1.GetDefaultLabels(etcd.ObjectMeta), map[string]string{
+				druidv1alpha1.LabelComponentKey: common.ComponentNameStatefulSet,
+			})),
 			"MinAvailable": PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(intstr.Int),
 				"IntVal": Equal(expectedPDBMinAvailable),


### PR DESCRIPTION
Fixes https://github.com/gardener/etcd-druid/issues/1412.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area high-availability
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1412

**Checklist**:
- [ ] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [ ] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [x] Add tests that cover your changes (if applicable)
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
