### PR TITLE
fix: Deflake e2e and API unit tests

### DIFF
--- a/api/config/v1alpha1/features_test.go
+++ b/api/config/v1alpha1/features_test.go
@@ -63,7 +63,6 @@ func TestDefaultFeatureGate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
-			t.Parallel()
 			err := DefaultFeatureGates.SetEnabledFeaturesFromMap(test.enabledFeatures)
 			if test.expectedError {
 				g.Expect(err).ToNot(BeNil())

--- a/test/e2e/controller/etcdopstask/ondemandsnapshot_test.go
+++ b/test/e2e/controller/etcdopstask/ondemandsnapshot_test.go
@@ -231,7 +231,7 @@ func TestOnDemandSnapshotLifecycle(t *testing.T) {
 							return fullRevAfter > fullRevBefore
 						}
 						return deltaRevAfter > deltaRevBefore
-					}, 30*time.Second, 2*time.Second).Should(BeTrue(), "snapshot lease revision did not advance after task completion")
+					}, 60*time.Second, 2*time.Second).Should(BeTrue(), "snapshot lease revision did not advance after task completion")
 					logger.Info("snapshot lease revision advanced as expected")
 				}
 

--- a/test/e2e/controller/utils.go
+++ b/test/e2e/controller/utils.go
@@ -29,7 +29,7 @@ const (
 	timeoutEtcdHibernation     = 2 * time.Minute
 	timeoutEtcdUnhibernation   = 5 * time.Minute
 	timeoutEtcdUpdation        = 10 * time.Minute
-	timeoutEtcdDisruptionStart = 30 * time.Second
+	timeoutEtcdDisruptionStart = 60 * time.Second
 	timeoutEtcdRecovery        = 5 * time.Minute
 	timeoutDeployJob           = 2 * time.Minute
 )


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

Fixes flaky e2e and API unit tests:
- Increase timeout for disrupting etcd pod (to avoid flakes in recovery tests)
- Increase timeout for checking snapshot lease (to avoid flakes in ops-task tests)
- Disable parallelism in API unit tests for feature gate as concurrent updates to the global feature gate map can cause tests to fail

**Special notes for your reviewer**:

/cc @Shreyas-s14 @shreyas-s-rao 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```