### PR TITLE
chore: bump distroless base from debian11 to debian12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN make build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static-debian11:nonroot AS druid
+FROM gcr.io/distroless/static-debian12:nonroot AS druid
 WORKDIR /
 COPY --from=builder /go/src/github.com/gardener/etcd-druid/bin/etcd-druid /etcd-druid
 COPY charts charts


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the runtime base image from `gcr.io/distroless/static-debian11:nonroot` to `gcr.io/distroless/static-debian12:nonroot`. Debian 11 reached EOL on 2024-08-14 — flagged by PCI DSS 12.3.4 / ISP-013 scans during gardener SAP landscape crypto-inventory.

Drop-in for static Go binaries: contents consumed from the base are limited to `ca-certificates`, `tzdata`, `base-files` — all available in the debian-12 variant.

**Issue**: resolves the `ISP-013 / PCI-12.3.4` EOL violation detected in Gardener @ SAP landscape-live-garden 0.638.0 crypto-inventory.

**Release note**:

```noteworthy operator
Runtime base image bumped from `distroless/static-debian11` to `distroless/static-debian12` to address Debian 11 EOL (PCI/ISP-013 finding).
```
