### PR TITLE
Change maturity level of UpgradeEtcdVersion featuregate from Alpha to Beta

### DIFF
--- a/api/config/v1alpha1/features.go
+++ b/api/config/v1alpha1/features.go
@@ -84,7 +84,7 @@ var DefaultFeatureGates = newFeatureGate()
 // If and when a new feature is introduced then it should be ensured that it is added to the featureGate using this function.
 func init() {
 	DefaultFeatureGates.knownFeatures[UseEtcdWrapper] = maturityLevelSpecGA
-	DefaultFeatureGates.knownFeatures[UpgradeEtcdVersion] = maturityLevelSpecAlpha
+	DefaultFeatureGates.knownFeatures[UpgradeEtcdVersion] = maturityLevelSpecBeta
 }
 
 // IsEnabled checks if a feature is enabled.

--- a/api/config/v1alpha1/features_test.go
+++ b/api/config/v1alpha1/features_test.go
@@ -50,7 +50,7 @@ func TestDefaultFeatureGate(t *testing.T) {
 			},
 		},
 		{
-			name: "UpgradeEtcdVersion can be disabled (alpha feature)",
+			name: "UpgradeEtcdVersion can be disabled",
 			enabledFeatures: map[string]bool{
 				UpgradeEtcdVersion: false,
 			},

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -19,8 +19,8 @@ tolerations: [ ]
 
 topologySpreadConstraints: [ ]
 
-featureGates: { 
-  UpgradeEtcdVersion: false
+featureGates: {
+  UpgradeEtcdVersion: true
 }
 
 webhookPKI:
@@ -84,8 +84,8 @@ operatorConfig:
       enabled: false
       exemptServiceAccounts:
         - system:serviceaccount:kube-system:generic-garbage-collector
-  featureGates: { 
-    UpgradeEtcdVersion: false
+  featureGates: {
+    UpgradeEtcdVersion: true
   }
   logConfiguration:
     logLevel: info

--- a/docs/deployment/feature-gates.md
+++ b/docs/deployment/feature-gates.md
@@ -22,7 +22,8 @@ The following tables are a summary of the feature gates that you can set on etcd
 
 | Feature | Default | Stage | Since | Until |
 |---------|---------|-------|-------|-------|
-| `UpgradeEtcdVersion` | `false` | `Alpha` | `0.36` |       |
+| `UpgradeEtcdVersion` | `false` | `Alpha` | `0.36` | `0.38` |
+| `UpgradeEtcdVersion` | `true`  | `Beta`  | `0.39` |       |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/docs/usage/bootstrapping-with-existing-cluster.md
+++ b/docs/usage/bootstrapping-with-existing-cluster.md
@@ -16,8 +16,8 @@ Before creating the target `Etcd` resource, ensure:
 4. **The source and target use compatible TLS trust roots.** The target's peer/client TLS configuration is used when dialing source peer/client endpoints. See the [TLS trust model](../concepts/bootstrap-with-existing-cluster.md#tls-trust-model).
 5. **The target `Etcd` resource does not already exist.** `bootstrapWithExistingCluster` is create-only and cannot be added to an existing `Etcd` resource.
 6. **Source and target run the same etcd minor version.** The etcd version `etcd-druid` deploys on the target depends on the [`UpgradeEtcdVersion`](../deployment/feature-gates.md#feature-gates-for-alpha-or-beta-features) feature gate:
-    - With `UpgradeEtcdVersion` enabled, `etcd-druid` deploys etcd `3.5.x` on the target; the source must also be on `3.5.x`.
-    - With `UpgradeEtcdVersion` disabled (current default), `etcd-druid` deploys etcd `3.4.x` on the target; the source must also be on `3.4.x`.
+    - With `UpgradeEtcdVersion` enabled (current default), `etcd-druid` deploys etcd `3.5.x` on the target; the source must also be on `3.5.x`.
+    - With `UpgradeEtcdVersion` disabled, `etcd-druid` deploys etcd `3.4.x` on the target; the source must also be on `3.4.x`.
 
 ## Step 1: Inspect the source cluster
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Druid Enhancement Proposals (DEPs), please ensure that the proposal is written in the following [format](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/00-template.md) before submitting this pull request.
-->
/area usability
/kind task

**What this PR does / why we need it**:
The PR https://github.com/gardener/etcd-druid/pull/1300 introduced a featuregate to be set in order to upgrade the etcd version managed etcd resource to 3.5.27. Following the lifecycle of a featuregate based on releases, this PR sets it to Beta which means it's default value is true while still being mutable.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**:
- [x] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [ ] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [ ] Add tests that cover your changes (if applicable)
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Upgrade the maturity level of `UpgradeEtcdVersion` featuregate to `Beta`, it will upgrade etcd cluster to `v3.5.x`. Please set the featuregate: `UpgradeEtcdVersion` to `false` if don't want to upgrade etcd cluster.
```
