### PR TITLE
Upgrade the alpine image version to 3.23.4

### DIFF
--- a/internal/images/images.yaml
+++ b/internal/images/images.yaml
@@ -25,4 +25,4 @@ images:
   tag: "v0.44.2"
 - name: alpine
   repository: europe-docker.pkg.dev/gardener-project/public/3rd/alpine
-  tag: "3.21.3"
+  tag: "3.23.4"


### PR DESCRIPTION
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR upgrades the `alpine` image version to the `3.23.4` to fix the CVEs: `CVE-2025-46394`, `CVE-2024-58251` and `CVE-2026-6042`.


**Which issue(s) this PR fixes**:
Fixes #

**Checklist**:
- [ ] Update documentation in the `/docs` folder (if applicable)
    - If new files added to docs, or docs structure modified:
        - [ ] Update [mkdocs.yml](https://github.com/gardener/etcd-druid/blob/master/mkdocs.yml). Follow [Updating Documentation](https://github.com/gardener/etcd-druid/blob/master/docs/development/updating-documentation.md) guide to test the changes locally.
        - [ ] Update [Table of Contents](https://github.com/gardener/etcd-druid/blob/master/docs/README.md) for the docs.
- [ ] Add tests that cover your changes (if applicable)
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] E2E tests

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrade the `alpine` image version to `3.23.4`
```
